### PR TITLE
compute time once when evaluating LRU policy

### DIFF
--- a/BitFaster.Caching.Benchmarks/Program.cs
+++ b/BitFaster.Caching.Benchmarks/Program.cs
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.Benchmarks
         static void Main(string[] args)
         {
             var summary = BenchmarkRunner
-                .Run<MissHitHitRemove>(ManualConfig.Create(DefaultConfig.Instance)
+                .Run<LruCycle2>(ManualConfig.Create(DefaultConfig.Instance)
                 .AddJob(Job.RyuJitX64));
         }
     }

--- a/BitFaster.Caching.UnitTests/Lru/LruPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/LruPolicyTests.cs
@@ -10,6 +10,7 @@ namespace BitFaster.Caching.UnitTests.Lru
     public class LruPolicyTests
     {
         private readonly LruPolicy<int, int> policy = new LruPolicy<int, int>();
+        private DateTime now = default;
 
         [Fact]
         public void CreateItemInitializesKeyAndValue()
@@ -44,7 +45,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item, ref now).Should().BeFalse();
         }
 
         [Fact]
@@ -53,7 +54,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.WasAccessed = true;
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item, ref now).Should().BeFalse();
         }
 
         [Theory]
@@ -63,7 +64,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item, ref now).Should().Be(expectedDestination);
         }
 
         [Theory]
@@ -73,7 +74,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item, ref now).Should().Be(expectedDestination);
         }
 
         [Theory]
@@ -83,7 +84,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item, ref now).Should().Be(expectedDestination);
         }
 
         private LruItem<int, int> CreateItem(bool wasAccessed)

--- a/BitFaster.Caching.UnitTests/Lru/TlruPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruPolicyTests.cs
@@ -45,19 +45,21 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenItemIsExpiredShouldDiscardIsTrue()
         {
+            var now = DateTime.UtcNow;
             var item = this.policy.CreateItem(1, 2);
             item.TimeStamp = DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(11));
 
-            this.policy.ShouldDiscard(item).Should().BeTrue();
+            this.policy.ShouldDiscard(item, ref now).Should().BeTrue();
         }
 
         [Fact]
         public void WhenItemIsNotExpiredShouldDiscardIsFalse()
         {
+            var now = DateTime.UtcNow;
             var item = this.policy.CreateItem(1, 2);
             item.TimeStamp = DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(9));
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item, ref now).Should().BeFalse();
         }
 
         [Theory]
@@ -67,9 +69,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         [InlineData(false, false, ItemDestination.Cold)]
         public void RouteHot(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
         {
+            var now = DateTime.UtcNow;
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item, ref now).Should().Be(expectedDestination);
         }
 
         [Theory]
@@ -79,9 +82,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         [InlineData(false, false, ItemDestination.Cold)]
         public void RouteWarm(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
         {
+            var now = DateTime.UtcNow;
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item, ref now).Should().Be(expectedDestination);
         }
 
         [Theory]
@@ -91,9 +95,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         [InlineData(false, false, ItemDestination.Remove)]
         public void RouteCold(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
         {
+            var now = DateTime.UtcNow;
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item, ref now).Should().Be(expectedDestination);
         }
 
         private TimeStampedLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)

--- a/BitFaster.Caching/Lru/IPolicy.cs
+++ b/BitFaster.Caching/Lru/IPolicy.cs
@@ -8,16 +8,18 @@ namespace BitFaster.Caching.Lru
 {
 	public interface IPolicy<in K, in V, I> where I : LruItem<K, V>
 	{
+        DateTime UtcNow();
+
 		I CreateItem(K key, V value);
 
 		void Touch(I item);
 
-		bool ShouldDiscard(I item);
+		bool ShouldDiscard(I item, ref DateTime now);
 
-		ItemDestination RouteHot(I item);
+		ItemDestination RouteHot(I item, ref DateTime now);
 
-		ItemDestination RouteWarm(I item);
+		ItemDestination RouteWarm(I item, ref DateTime now);
 
-		ItemDestination RouteCold(I item);
+		ItemDestination RouteCold(I item, ref DateTime now);
 	}
 }

--- a/BitFaster.Caching/Lru/LruPolicy.cs
+++ b/BitFaster.Caching/Lru/LruPolicy.cs
@@ -7,12 +7,14 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Lru
 {
-	/// <summary>
-	/// Discards the least recently used items first. 
-	/// </summary>
-	public readonly struct LruPolicy<K, V> : IPolicy<K, V, LruItem<K, V>>
-	{
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+    /// <summary>
+    /// Discards the least recently used items first. 
+    /// </summary>
+    public readonly struct LruPolicy<K, V> : IPolicy<K, V, LruItem<K, V>>
+    {
+        public DateTime UtcNow() { return default; }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public LruItem<K, V> CreateItem(K key, V value)
 		{
 			return new LruItem<K, V>(key, value);
@@ -25,13 +27,13 @@ namespace BitFaster.Caching.Lru
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public bool ShouldDiscard(LruItem<K, V> item)
+		public bool ShouldDiscard(LruItem<K, V> item, ref DateTime now)
 		{
 			return false;
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public ItemDestination RouteHot(LruItem<K, V> item)
+		public ItemDestination RouteHot(LruItem<K, V> item, ref DateTime now)
 		{
 			if (item.WasAccessed)
 			{
@@ -42,7 +44,7 @@ namespace BitFaster.Caching.Lru
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public ItemDestination RouteWarm(LruItem<K, V> item)
+		public ItemDestination RouteWarm(LruItem<K, V> item, ref DateTime now)
 		{
 			if (item.WasAccessed)
 			{
@@ -53,7 +55,7 @@ namespace BitFaster.Caching.Lru
 		}
 
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		public ItemDestination RouteCold(LruItem<K, V> item)
+		public ItemDestination RouteCold(LruItem<K, V> item, ref DateTime now)
 		{
 			if (item.WasAccessed)
 			{

--- a/BitFaster.Caching/Lru/TlruPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruPolicy.cs
@@ -15,6 +15,8 @@ namespace BitFaster.Caching.Lru
     {
         private readonly TimeSpan timeToLive;
 
+        public DateTime UtcNow() { return DateTime.UtcNow; }
+
         public TLruPolicy(TimeSpan timeToLive)
         {
             this.timeToLive = timeToLive;
@@ -33,7 +35,7 @@ namespace BitFaster.Caching.Lru
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ShouldDiscard(TimeStampedLruItem<K, V> item)
+        public bool ShouldDiscard(TimeStampedLruItem<K, V> item, ref DateTime now)
         {
             if (DateTime.UtcNow - item.TimeStamp > this.timeToLive)
             {
@@ -44,9 +46,9 @@ namespace BitFaster.Caching.Lru
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ItemDestination RouteHot(TimeStampedLruItem<K, V> item)
+        public ItemDestination RouteHot(TimeStampedLruItem<K, V> item, ref DateTime now)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item, ref now))
             {
                 return ItemDestination.Remove;
             }
@@ -60,9 +62,9 @@ namespace BitFaster.Caching.Lru
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ItemDestination RouteWarm(TimeStampedLruItem<K, V> item)
+        public ItemDestination RouteWarm(TimeStampedLruItem<K, V> item, ref DateTime now)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item, ref now))
             {
                 return ItemDestination.Remove;
             }
@@ -76,9 +78,9 @@ namespace BitFaster.Caching.Lru
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ItemDestination RouteCold(TimeStampedLruItem<K, V> item)
+        public ItemDestination RouteCold(TimeStampedLruItem<K, V> item, ref DateTime now)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item, ref now))
             {
                 return ItemDestination.Remove;
             }

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ After
 
 ### LruCycle2
 
+Before
 |               Method |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
 |--------------------- |-----------:|---------:|---------:|------:|-------:|----------:|
 | ConcurrentDictionary |   111.0 ns |  1.60 ns |  1.33 ns |  1.00 | 0.0079 |      17 B |
@@ -149,6 +150,17 @@ After
 |       ConcurrentTLru | 2,419.7 ns | 46.90 ns | 52.13 ns | 21.82 | 0.1577 |     333 B |
 |           ClassicLru |   834.3 ns | 10.84 ns |  9.61 ns |  7.52 | 0.2225 |     467 B |
 |          MemoryCache | 1,572.9 ns | 30.94 ns | 44.37 ns | 14.14 | 0.1424 |     313 B |
+
+After
+|               Method |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
+|--------------------- |-----------:|---------:|---------:|------:|-------:|----------:|
+| ConcurrentDictionary |   104.6 ns |  0.63 ns |  0.56 ns |  1.00 | 0.0079 |      17 B |
+|    FastConcurrentLru | 1,014.6 ns | 19.10 ns | 17.86 ns |  9.71 | 0.1424 |     300 B |
+|        ConcurrentLru | 1,014.3 ns |  8.66 ns |  8.10 ns |  9.70 | 0.1424 |     300 B |
+|   FastConcurrentTLru | 2,581.1 ns | 12.95 ns | 10.81 ns | 24.68 | 0.1577 |     333 B |
+|       ConcurrentTLru | 2,642.3 ns | 34.09 ns | 51.02 ns | 25.48 | 0.1577 |     333 B |
+|           ClassicLru |   810.2 ns | 15.91 ns | 19.53 ns |  7.77 | 0.2708 |     567 B |
+|          MemoryCache | 1,422.9 ns | 18.50 ns | 15.44 ns | 13.60 | 0.1475 |     313 B |
 
 ## Meta-programming using structs for JIT dead code removal and inlining
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Cache contains 6 items which are fetched repeatedly, no items are evicted. Repre
 
 FastConcurrentLru does not allocate and is approximately 10x faster than MemoryCache.
 
+Before
 |               Method |      Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
 |--------------------- |----------:|---------:|---------:|------:|-------:|----------:|
 | ConcurrentDictionary |  15.83 ns | 0.242 ns | 0.215 ns |  1.00 |      - |         - |
@@ -97,12 +98,24 @@ FastConcurrentLru does not allocate and is approximately 10x faster than MemoryC
 |           ClassicLru |  69.01 ns | 0.503 ns | 0.446 ns |  4.36 |      - |         - |
 |          MemoryCache | 257.83 ns | 4.786 ns | 4.700 ns | 16.30 | 0.0153 |      32 B |
 
+After
+|               Method |      Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
+|--------------------- |----------:|---------:|---------:|------:|-------:|----------:|
+| ConcurrentDictionary |  15.32 ns | 0.275 ns | 0.257 ns |  1.00 |      - |         - |
+|    FastConcurrentLru |  20.14 ns | 0.157 ns | 0.147 ns |  1.32 |      - |         - |
+|        ConcurrentLru |  24.97 ns | 0.473 ns | 0.419 ns |  1.63 |      - |         - |
+|   FastConcurrentTLru | 201.49 ns | 1.107 ns | 0.924 ns | 13.16 |      - |         - |
+|       ConcurrentTLru | 205.35 ns | 2.602 ns | 2.307 ns | 13.42 |      - |         - |
+|           ClassicLru |  70.72 ns | 0.265 ns | 0.207 ns |  4.61 |      - |         - |
+|          MemoryCache | 260.50 ns | 5.188 ns | 5.327 ns | 17.03 | 0.0153 |      32 B |
+
 ### Mixed workload
 
 Tests 4 operations, 1 miss (adding the item), 2 hits then remove.
 
 This test needs to be improved to provoke queue cycling.
 
+Before
 |               Method |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
 |--------------------- |-----------:|---------:|---------:|------:|-------:|----------:|
 | ConcurrentDictionary |   151.7 ns |  2.34 ns |  1.96 ns |  1.00 | 0.0381 |      80 B |
@@ -112,6 +125,17 @@ This test needs to be improved to provoke queue cycling.
 |       ConcurrentTlru |   852.7 ns | 16.12 ns | 13.46 ns |  5.62 | 0.0572 |     120 B |
 |           ClassicLru |   347.3 ns |  2.67 ns |  2.08 ns |  2.29 | 0.0763 |     160 B |
 |          MemoryCache | 1,987.5 ns | 38.29 ns | 57.31 ns | 13.15 | 2.3460 |    4912 B |
+
+After
+|               Method |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
+|--------------------- |-----------:|---------:|---------:|------:|-------:|----------:|
+| ConcurrentDictionary |   151.0 ns |  2.04 ns |  1.91 ns |  1.00 | 0.0381 |      80 B |
+|    FastConcurrentLru |   375.3 ns |  5.57 ns |  5.21 ns |  2.49 | 0.0534 |     112 B |
+|        ConcurrentLru |   383.5 ns |  3.68 ns |  2.87 ns |  2.54 | 0.0534 |     112 B |
+|   FastConcurrentTlru | 1,106.7 ns | 13.47 ns | 11.25 ns |  7.33 | 0.0572 |     120 B |
+|       ConcurrentTlru | 1,120.3 ns | 11.53 ns | 10.78 ns |  7.42 | 0.0572 |     120 B |
+|           ClassicLru |   347.8 ns |  2.48 ns |  2.07 ns |  2.30 | 0.0763 |     160 B |
+|          MemoryCache | 1,979.0 ns | 13.60 ns | 12.06 ns | 13.11 | 2.3460 |    4912 B |
 
 
 ### LruCycle2


### PR DESCRIPTION
Experiment to try to call DateTime.UtcNow only once, instead of multiple times during cycle.

This shows that the JIT can largely eliminate the extra method arg overhead for LruPolicy. But TLruPolicy got much slower, even in the second cycle tests which presumably will compute the time multiple times per cycle.