### PR TITLE
Implement scopes for Lazy<T> and AsyncLazy<T> (master)

### DIFF
--- a/BitFaster.Caching/LazyExperiments/AsyncLazy.cs
+++ b/BitFaster.Caching/LazyExperiments/AsyncLazy.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.LazyExperiments
+{
+    public class AsyncLazy<T>
+    {
+        private readonly object mutex;
+        private Lazy<Task<T>> lazy;
+        private readonly Func<Task<T>> valueFactory;
+
+        public AsyncLazy(Func<Task<T>> valueFactory)
+        {
+            this.mutex = new object();
+            this.valueFactory = RetryOnFailure(valueFactory);
+            this.lazy = new Lazy<Task<T>>(this.valueFactory);
+        }
+
+        private Func<Task<T>> RetryOnFailure(Func<Task<T>> valueFactory)
+        {
+            return async () =>
+            {
+                try
+                {
+                    return await valueFactory().ConfigureAwait(false);
+                }
+                catch
+                {
+                    // lock exists only because lazy is replaced on error
+                    // better approach might be either:
+                    // - value factory is responsible for retry, not lazy (single responsibility)
+                    // - use TLRU, expire invalid items
+                    lock (mutex)
+                    {
+                        this.lazy = new Lazy<Task<T>>(this.valueFactory);
+                    }
+                    throw;
+                }
+            };
+        }
+
+        public Task<T> Task
+        {
+            get { lock (this.mutex) { return this.lazy.Value; } }
+        }
+
+        public TaskAwaiter<T> GetAwaiter()
+        {
+            return Task.GetAwaiter();
+        }
+    }
+}

--- a/BitFaster.Caching/LazyExperiments/DesiredApi.cs
+++ b/BitFaster.Caching/LazyExperiments/DesiredApi.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using BitFaster.Caching.Lru;
+
+namespace BitFaster.Caching.LazyExperiments
+{
+    class DesiredApi
+    {
+        public static void HowToCacheALazy()
+        {
+            var lru = new ConcurrentLru<int, ScopedLazy<SomeDisposable>>(4);
+            var factory = new ScopedLazyFactory();
+
+            using (var lifetime = lru.GetOrAdd(1, factory.Create).CreateLifetime())
+            {
+                var y = lifetime.Value;
+            }
+        }
+
+        // Requirements:
+        // 1. lifetime/value create is async end to end (if async delegate is used to create value)
+        // 2. value is created lazily, guarantee single instance of object, single invocation of lazy
+        // 3. lazy value is disposed by scope
+        // 4. lifetime keeps scope alive
+        public static async Task HowToCacheAnAsyncLazy()
+        {
+            var lru = new ConcurrentLru<int, ScopedAsyncLazy<SomeDisposable>>(4);
+            var factory = new ScopedAsyncLazyFactory();
+
+            using (var lifetime = await lru.GetOrAdd(1, factory.Create).CreateLifetimeAsync())
+            {
+                var y = lifetime.Value;
+            }
+        }
+    }
+
+    public class ScopedLazyFactory
+    {
+        public Task<SomeDisposable> CreateAsync(int key)
+        {
+            return Task.FromResult(new SomeDisposable());
+        }
+
+        public ScopedLazy<SomeDisposable> Create(int key)
+        {
+            return new ScopedLazy<SomeDisposable>(() => new SomeDisposable());
+        }
+    }
+
+    public class ScopedAsyncLazyFactory
+    {
+        public Task<SomeDisposable> CreateAsync(int key)
+        {
+            return Task.FromResult(new SomeDisposable());
+        }
+
+        public ScopedAsyncLazy<SomeDisposable> Create(int key)
+        {
+            return new ScopedAsyncLazy<SomeDisposable>(() => Task.FromResult(new SomeDisposable()));
+        }
+    }
+
+    public class SomeDisposable : IDisposable
+    {
+        public void Dispose()
+        {
+
+        }
+    }
+}

--- a/BitFaster.Caching/LazyExperiments/ScopedAsyncLazy.cs
+++ b/BitFaster.Caching/LazyExperiments/ScopedAsyncLazy.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.LazyExperiments
+{
+    // Enable caching an AsyncLazy disposable object - guarantee single instance, safe disposal
+    public class ScopedAsyncLazy<TValue> : IDisposable 
+        where TValue : IDisposable
+    {
+        private ReferenceCount<Lazy<TValue>> refCount;
+        private bool isDisposed;
+
+        private readonly Func<Task<TValue>> valueFactory;
+
+        private readonly AsyncLazy<TValue> lazy;
+
+        // should this even be allowed?
+        public ScopedAsyncLazy(Func<TValue> valueFactory)
+        {
+            this.lazy = new AsyncLazy<TValue>(() => Task.FromResult(valueFactory()));
+        }
+
+        public ScopedAsyncLazy(Func<Task<TValue>> valueFactory)
+        {
+            this.lazy = new AsyncLazy<TValue>(valueFactory);
+        }
+
+        public async Task<Lifetime<TValue>> CreateLifetimeAsync()
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException($"{nameof(TValue)} is disposed.");
+            }
+
+            while (true)
+            {
+                // IncrementCopy will throw ObjectDisposedException if the referenced object has no references.
+                // This mitigates the race where the value is disposed after the above check is run.
+                var oldRefCount = this.refCount;
+                var newRefCount = oldRefCount.IncrementCopy();
+
+                // guarantee ref held before lazy evaluated
+                if (oldRefCount == Interlocked.CompareExchange(ref this.refCount, newRefCount, oldRefCount))
+                {
+                    // When Lease is disposed, it calls DecrementReferenceCount
+                    var value = await this.lazy;
+                    return new Lifetime<TValue>(value, this.DecrementReferenceCount);
+                }
+            }
+        }
+
+        private void DecrementReferenceCount()
+        {
+            while (true)
+            {
+                var oldRefCount = this.refCount;
+                var newRefCount = oldRefCount.DecrementCopy();
+
+                if (oldRefCount == Interlocked.CompareExchange(ref this.refCount, newRefCount, oldRefCount))
+                {
+                    if (newRefCount.Count == 0)
+                    {
+                        if (newRefCount.Value.IsValueCreated)
+                        {
+                            newRefCount.Value.Value.Dispose();
+                        }
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!this.isDisposed)
+            {
+                this.DecrementReferenceCount();
+                this.isDisposed = true;
+            }
+        }
+    }
+}

--- a/BitFaster.Caching/LazyExperiments/ScopedLazy.cs
+++ b/BitFaster.Caching/LazyExperiments/ScopedLazy.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace BitFaster.Caching
+{
+    // Enable caching a Lazy disposable object - guarantee single instance, safe disposal
+    public class ScopedLazy<T> : IDisposable
+        where T : IDisposable
+    {
+        private ReferenceCount<Lazy<T>> refCount;
+        private bool isDisposed;
+
+        public ScopedLazy(Func<T> valueFactory)
+        {
+            // TODO: this will cache exceptions
+            var lazy = new Lazy<T>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
+            this.refCount = new ReferenceCount<Lazy<T>>(lazy);
+        }
+
+        public Lifetime<T> CreateLifetime()
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException($"{nameof(T)} is disposed.");
+            }
+
+            while (true)
+            {
+                // IncrementCopy will throw ObjectDisposedException if the referenced object has no references.
+                // This mitigates the race where the value is disposed after the above check is run.
+                var oldRefCount = this.refCount;
+                var newRefCount = oldRefCount.IncrementCopy();
+
+                if (oldRefCount == Interlocked.CompareExchange(ref this.refCount, newRefCount, oldRefCount))
+                {
+                    // When Lease is disposed, it calls DecrementReferenceCount
+                    return new Lifetime<T>(oldRefCount.Value.Value, this.DecrementReferenceCount);
+                }
+            }
+        }
+
+        private void DecrementReferenceCount()
+        {
+            while (true)
+            {
+                var oldRefCount = this.refCount;
+                var newRefCount = oldRefCount.DecrementCopy();
+
+                if (oldRefCount == Interlocked.CompareExchange(ref this.refCount, newRefCount, oldRefCount))
+                {
+                    if (newRefCount.Count == 0)
+                    {
+                        if (newRefCount.Value.IsValueCreated)
+                        {
+                            newRefCount.Value.Value.Dispose();
+                        }
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!this.isDisposed)
+            {
+                this.DecrementReferenceCount();
+                this.isDisposed = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This enables Lru to cache Lazy, which guarantees single invocation of the value create logic.

https://stackoverflow.com/questions/50935483/thread-safe-disposal-of-lazy-initialized-objects