### PR TITLE
Implement GetOrAdd

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -296,6 +296,17 @@ namespace BitFaster.Caching.UnitTests.Lru
             value.Should().Be("2");
         }
 
-        // TODO: test update correctly maintains LRU order.
+        [Fact]
+        public void WhenKeyDoesNotExistAddOrUpdateMaintainsLruOrder()
+        {
+            lru.AddOrUpdate(1, "1");
+            lru.AddOrUpdate(2, "2");
+            lru.AddOrUpdate(3, "3");
+            lru.AddOrUpdate(4, "4");
+
+            // verify first item added is removed
+            lru.Count.Should().Be(3);
+            lru.TryGet(1, out var value).Should().BeFalse();
+        }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -308,5 +308,24 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.Count.Should().Be(3);
             lru.TryGet(1, out var value).Should().BeFalse();
         }
+
+        [Fact]
+        public void WhenAddOrUpdateExpiresItemsTheyAreDisposed()
+        {
+            var lruOfDisposable = new ClassicLru<int, DisposableItem>(1, 3, EqualityComparer<int>.Default);
+
+            var items = Enumerable.Range(1, 4).Select(i => new DisposableItem()).ToList();
+
+            for (int i = 0; i < 4; i++)
+            {
+                lruOfDisposable.AddOrUpdate(i, items[i]);
+            }
+
+            // first item is evicted and disposed
+            items[0].IsDisposed.Should().BeTrue();
+
+            // all other items are not disposed
+            items.Skip(1).All(i => i.IsDisposed == false).Should().BeTrue();
+        }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -276,5 +276,26 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.TryUpdate(2, "3").Should().BeFalse();
         }
+
+        [Fact]
+        public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()
+        {
+            lru.AddOrUpdate(1, "1");
+
+            lru.TryGet(1, out var value).Should().BeTrue();
+            value.Should().Be("1");
+        }
+
+        [Fact]
+        public void WhenKeyExistsAddOrUpdatUpdatesExistingItem()
+        {
+            lru.AddOrUpdate(1, "1");
+            lru.AddOrUpdate(1, "2");
+
+            lru.TryGet(1, out var value).Should().BeTrue();
+            value.Should().Be("2");
+        }
+
+        // TODO: test update correctly maintains LRU order.
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -412,6 +412,16 @@ namespace BitFaster.Caching.UnitTests.Lru
             value.Should().Be("2");
         }
 
-        // TODO: test update correctly maintains LRU order.
+        [Fact]
+        public void WhenKeyDoesNotExistAddOrUpdateMaintainsLruOrder()
+        {
+            lru.AddOrUpdate(1, "1");
+            lru.AddOrUpdate(2, "2");
+            lru.AddOrUpdate(3, "3");
+            lru.AddOrUpdate(4, "4");
+
+            lru.HotCount.Should().Be(3);
+            lru.ColdCount.Should().Be(1); // items must have been enqueued and cycled for one of them to reach the cold queue
+        }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -392,5 +392,26 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.TryUpdate(2, "3").Should().BeFalse();
         }
+
+        [Fact]
+        public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()
+        {
+            lru.AddOrUpdate(1, "1");
+
+            lru.TryGet(1, out var value).Should().BeTrue();
+            value.Should().Be("1");
+        }
+
+        [Fact]
+        public void WhenKeyExistsAddOrUpdatUpdatesExistingItem()
+        {
+            lru.AddOrUpdate(1, "1");
+            lru.AddOrUpdate(1, "2");
+
+            lru.TryGet(1, out var value).Should().BeTrue();
+            value.Should().Be("2");
+        }
+
+        // TODO: test update correctly maintains LRU order.
     }
 }

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -54,5 +54,13 @@ namespace BitFaster.Caching
         /// <param name="value">The new value.</param>
         /// <returns>true if the object was updated successfully; otherwise, false.</returns>
         bool TryUpdate(K key, V value);
+
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist, or updates a key/value pair if the 
+        /// key already exists.
+        /// </summary>
+        /// <param name="key">The key of the element to update.</param>
+        /// <param name="value">The new value.</param>
+        void AddOrUpdate(K key, V value);
     }
 }

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -252,8 +252,6 @@ namespace BitFaster.Caching.Lru
                 }
 
                 return;
-
-
             }
 
             // if both update and add failed there was a race, try again

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -207,7 +207,7 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
-        ///<remarks>Note: Updates to existing items do not affect LRU order. New items are at the top of the LRU.</remarks>
+        ///<remarks>Note: Updates to existing items do not affect LRU order. Added items are at the top of the LRU.</remarks>
         public void AddOrUpdate(K key, V value)
         { 
             // first, try to update

--- a/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
@@ -243,7 +243,7 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
-        ///<remarks>Note: Updates to existing items do not affect LRU order. New items are at the top of the LRU.</remarks>
+        ///<remarks>Note: Updates to existing items do not affect LRU order. Added items are at the top of the LRU.</remarks>
         public void AddOrUpdate(K key, V value)
         { 
             // first, try to update


### PR DESCRIPTION
Implement GetOrAdd.

Only new items will affect LRU order. Considered adding a flag to control whether the item is touched, but flag params are [evil](https://martinfowler.com/bliki/FlagArgument.html). There is some precedent for only updating the LRU order for new items - this is the same way [add ](https://github.com/memcached/memcached/wiki/Commands#add)and [replace](https://github.com/memcached/memcached/wiki/Commands#replace) work in the memcached API.