### PR TITLE
LRU: atomic ConcurrentDictionary.Remove()

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -386,6 +386,19 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenKeyExistsTryUpdateDisposesOldValue()
+        {
+            var lruOfDisposable = new ConcurrentLru<int, DisposableItem>(1, 6, EqualityComparer<int>.Default);
+            var disposableValueFactory = new DisposableValueFactory();
+            var newValue = new DisposableItem();
+
+            lruOfDisposable.GetOrAdd(1, disposableValueFactory.Create);
+            lruOfDisposable.TryUpdate(1, newValue);
+
+            disposableValueFactory.Items[1].IsDisposed.Should().BeTrue();
+        }
+
+        [Fact]
         public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
         {
             lru.GetOrAdd(1, valueFactory.Create);
@@ -403,13 +416,26 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
-        public void WhenKeyExistsAddOrUpdatUpdatesExistingItem()
+        public void WhenKeyExistsAddOrUpdateUpdatesExistingItem()
         {
             lru.AddOrUpdate(1, "1");
             lru.AddOrUpdate(1, "2");
 
             lru.TryGet(1, out var value).Should().BeTrue();
             value.Should().Be("2");
+        }
+
+        [Fact]
+        public void WhenKeyExistsAddOrUpdateDisposesOldValue()
+        {
+            var lruOfDisposable = new ConcurrentLru<int, DisposableItem>(1, 6, EqualityComparer<int>.Default);
+            var disposableValueFactory = new DisposableValueFactory();
+            var newValue = new DisposableItem();
+
+            lruOfDisposable.GetOrAdd(1, disposableValueFactory.Create);
+            lruOfDisposable.AddOrUpdate(1, newValue);
+
+            disposableValueFactory.Items[1].IsDisposed.Should().BeTrue();
         }
 
         [Fact]


### PR DESCRIPTION
Summary:

1. Update LRU removal logic, use the [atomic remove method from ICollection](https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/)
2. Dispose previous items on update if value is IDisposable

The atomic remove based on the reference to the existing item mitigates this race scenario because LruItem1 and LruItem1* will be different memory references (thus Thread C cannot remove LruItem1*):

> Thread A TryRemove(1), removes LruItem1, has reference to removed item but not yet marked as removed
> Thread B GetOrAdd(1) => Adds LruItem1*
> Thread C GetOrAdd(2), Cycle, Move(LruItem1, Removed)
 
> Thread C can run and remove LruItem1* from this.dictionary before Thread A has marked LruItem1 as removed.

> In this situation, a subsequent attempt to fetch 1 will be a miss. The queues will still contain LruItem1*, 
and it will not be marked as removed. If key 1 is fetched while LruItem1* is still in the queue, there will 
be two queue entries for key 1, and neither is marked as removed. Thus when LruItem1 * ages out, it will  
incorrectly remove 1 from the dictionary, and this cycle can repeat.

WasRemoved mitigates another potential race in TryUpdate. If lookup gets an existing item, then enters the lock after TryRemove has removed it we would replace a removed item. We would return true even though nothing was updated, and the new item would not be referenced by the cache, and would not be disposed.

Locks are kept to synchronize Dispose calls - probably most classes stored as values in the cache do not have a thread safe dispose so this seems like a reasonable choice.

Grouped methods like this and analyzed for potential races:

* TryUpdate/AddOrUpdate (AddOrUpdate uses TryUpdate internally)
* GetOrAdd
* TryGet
* TryRemove/Move to removed (these cannot race one another since ConcurrentDictionary Remove is atomic)

It is possible for an item to be removed (either by calling TryRemove, or by it cycling out) or replaced, and the cache to dispose the item immediately after it is returned to the caller. This is mitigated by using the Scoped class.