### PR TITLE
Provide extension methods to create Lifetime<T> for ICache Scoped<T>

### DIFF
--- a/BitFaster.Caching.UnitTests/ScopedCacheExtensionsTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheExtensionsTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BitFaster.Caching.Lru;
+using FluentAssertions;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public class ScopedCacheExtensionsTests
+    {
+        [Fact]
+        public void WhenCacheReturnsDisposedValueNewValueIsRequested()
+        {
+            var lru = new ConcurrentLru<int, Scoped<Disposable>>(2, 9, EqualityComparer<int>.Default);
+            var valueFactory = new DisposableValueFactory();
+
+            valueFactory.ScopedDisposables.Add(new Scoped<Disposable>(new Disposable()));
+            valueFactory.ScopedDisposables.Add(new Scoped<Disposable>(new Disposable()));
+
+            valueFactory.ScopedDisposables[0].Dispose();
+
+            // This will infinite loop because the disposed Scope is in the cache (value factory never called)
+            // Therefore, it is better to encapsulate Scoped, so that a caller cannot break it.
+            using (var lifetime = lru.ScopedGetOrAdd(1, valueFactory.Create))
+            {
+                lifetime.Value.IsDisposed.Should().BeFalse();
+            }
+        }
+
+        private class DisposableValueFactory
+        {
+            int count;
+
+            public List<Scoped<Disposable>> ScopedDisposables { get; } = new List<Scoped<Disposable>>();
+
+            public Scoped<Disposable> Create(int key)
+            {
+                return ScopedDisposables[count++];
+            }
+        }
+
+        private class Disposable : IDisposable
+        {
+            public bool IsDisposed { get; set; }
+
+            public void Dispose()
+            {
+                this.IsDisposed.Should().BeFalse();
+                IsDisposed = true;
+            }
+        }
+    }
+}

--- a/BitFaster.Caching.UnitTests/ScopedTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedTests.cs
@@ -51,6 +51,16 @@ namespace BitFaster.Caching.UnitTests
         }
 
         [Fact]
+        public void WhenScopeIsDisposedTryCreateScopeReturnsFalse()
+        {
+            var disposable = new Disposable();
+            var scope = new Scoped<Disposable>(disposable);
+            scope.Dispose();
+
+            scope.TryCreateLifetime(out var _).Should().BeFalse();
+        }
+
+        [Fact]
         public void WhenScopedIsCreatedFromCacheItemHasExpectedLifetime()
         {
             var lru = new ConcurrentLru<int, Scoped<Disposable>>(2, 9, EqualityComparer<int>.Default);

--- a/BitFaster.Caching/CacheLifetimeExtensions.cs
+++ b/BitFaster.Caching/CacheLifetimeExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching
+{
+    public static class CacheLifetimeExtensions
+    {
+        public static Lifetime<T> ScopedGetOrAdd<K, S, T>(this ICache<K, S> cache, K key, Func<K, S> valueFactory)
+            where S : Scoped<T>
+            where T : IDisposable 
+        { 
+            while (true)
+            {
+                var scope = cache.GetOrAdd(key, valueFactory);
+
+                if (scope.TryCreateLifetime(out var lifetime))
+                {
+                    return lifetime;
+                }
+            }
+        }
+        public static async Task<Lifetime<T>> ScopedGetOrAdd<K, S, T>(this ICache<K, S> cache, K key, Func<K, Task<S>> valueFactory)
+            where S : Scoped<T>
+            where T : IDisposable
+        {
+            while (true)
+            {
+                var scope = await cache.GetOrAddAsync(key, valueFactory);
+
+                if (scope.TryCreateLifetime(out var lifetime))
+                {
+                    return lifetime;
+                }
+            }
+        }
+    }
+}

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching
+{
+    public interface IScopedCache<K, T> where T : IDisposable
+    {
+        bool TryGet(K key, out Lifetime<T> value);
+
+        Lifetime<T> GetOrAdd(K key, Func<K, Scoped<T>> valueFactory);
+
+        Task<Lifetime<T>> GetOrAddAsync(K key, Func<K, Task<Scoped<T>>> valueFactory);
+
+        bool TryRemove(K key);
+
+        bool TryUpdate(K key, T value);
+
+        void AddOrUpdate(K key, T value);
+    }
+}

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching
+{
+    // what happens if we completely encapsulate scoped?
+    // we can't implement ICache, since return types will now be Lifetime, not T
+    public class ScopedCache<K, T> where T : IDisposable
+    {
+        private readonly ICache<K, Scoped<T>> innerCache;
+
+        public ScopedCache(ICache<K, Scoped<T>> innerCache)
+        {
+            this.innerCache = innerCache;
+        }
+
+        public Lifetime<T> GetOrAdd(K key, Func<K, T> valueFactory)
+        {
+            // additional alloc
+            var scopedFactory = new ScopedFactory(valueFactory);
+
+            while (true)
+            {
+                var scope = innerCache.GetOrAdd(key, scopedFactory.Create);
+
+                if (scope.TryCreateLifetime(out var lifetime))
+                {
+                    return lifetime;
+                }
+            }
+        }
+
+        public bool TryUpdate(K key, T value)
+        { 
+            // scoped finializer does not call dispose, so if this fails, discarded new Scoped will not dispose value.
+            return this.innerCache.TryUpdate(key, new Scoped<T>(value));
+        }
+
+        private class ScopedFactory
+        { 
+            private Func<K, T> valueFactory;
+
+            public ScopedFactory(Func<K, T> valueFactory)
+            { 
+                this.valueFactory = valueFactory;   
+            }
+
+            public Scoped<T> Create(K key)
+            {
+                return new Scoped<T>(valueFactory(key));
+            }
+        }
+    }
+}

--- a/BitFaster.Caching/ScopedCacheExtensions.cs
+++ b/BitFaster.Caching/ScopedCacheExtensions.cs
@@ -6,10 +6,19 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
-    public static class CacheLifetimeExtensions
+    public static class ScopedCacheExtensions
     {
-        public static Lifetime<T> ScopedGetOrAdd<K, S, T>(this ICache<K, S> cache, K key, Func<K, S> valueFactory)
-            where S : Scoped<T>
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="K"></typeparam>
+        /// <typeparam name="S"></typeparam>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="cache"></param>
+        /// <param name="key"></param>
+        /// <param name="valueFactory"></param>
+        /// <returns></returns>
+        public static Lifetime<T> ScopedGetOrAdd<K, T>(this ICache<K, Scoped<T>> cache, K key, Func<K, Scoped<T>> valueFactory)
             where T : IDisposable 
         { 
             while (true)
@@ -22,8 +31,8 @@ namespace BitFaster.Caching
                 }
             }
         }
-        public static async Task<Lifetime<T>> ScopedGetOrAdd<K, S, T>(this ICache<K, S> cache, K key, Func<K, Task<S>> valueFactory)
-            where S : Scoped<T>
+
+        public static async Task<Lifetime<T>> ScopedGetOrAdd<K, T>(this ICache<K, Scoped<T>> cache, K key, Func<K, Task<Scoped<T>>> valueFactory)
             where T : IDisposable
         {
             while (true)


### PR DESCRIPTION
Extension methods to pull values from the cache when they are scoped, automatically retrying if the scope cannot be created because there was a race causing the scoped object to be disposed just as it was returned (by a race in cache eviction).

This could also be implemented as a decorator on top of ICache, so that all of the methods transparently transform to scope/lifetime (e.g. TryUpdate would scope input arg).

Should Lifetime be a struct? Could rely on the IsDisposed flag from the inner RefCount object. This would eliminate a heap alloc, and would be immutable since it only holds pointers.