### PR TITLE
Fix ctor rounding

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -50,6 +50,34 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenCapacityIs4HotHasCapacity1AndColdHasCapacity2()
+        {
+            var lru = new ConcurrentLru<int, int>(4);
+
+            for (int i = 0; i < 5; i++)
+            {
+                lru.GetOrAdd(i, x => x);
+            }
+
+            lru.HotCount.Should().Be(1);
+            lru.ColdCount.Should().Be(2);
+        }
+
+        [Fact]
+        public void WhenCapacityIs5HotHasCapacity2AndColdHasCapacity2()
+        {
+            var lru = new ConcurrentLru<int, int>(5);
+
+            for (int i = 0; i < 5; i++)
+            {
+                lru.GetOrAdd(i, x => x);
+            }
+
+            lru.HotCount.Should().Be(2);
+            lru.ColdCount.Should().Be(2);
+        }
+
+        [Fact]
         public void ConstructAddAndRetrieveWithDefaultCtorReturnsValue()
         {
             var x = new ConcurrentLru<int, int>(3);

--- a/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
@@ -68,11 +68,12 @@ namespace BitFaster.Caching.Lru
             if (comparer == null)
             {
                 throw new ArgumentNullException(nameof(comparer));
-            }    
+            }
 
-            this.hotCapacity = capacity / 3;
-            this.warmCapacity = capacity / 3;
-            this.coldCapacity = capacity / 3;
+            var queueCapacity = ComputeQueueCapacity(capacity);
+            this.hotCapacity = queueCapacity.hot;
+            this.warmCapacity = queueCapacity.warm;
+            this.coldCapacity = queueCapacity.cold;
 
             this.hotQueue = new ConcurrentQueue<I>();
             this.warmQueue = new ConcurrentQueue<I>();
@@ -386,6 +387,28 @@ namespace BitFaster.Caching.Lru
 
                     break;
             }
+        }
+
+        private static (int hot, int warm, int cold) ComputeQueueCapacity(int capacity)
+        {
+            int hotCapacity = capacity / 3;
+            int warmCapacity = capacity / 3;
+            int coldCapacity = capacity / 3;
+
+            int remainder = capacity % 3;
+
+            switch (remainder)
+            {
+                case 1:
+                    coldCapacity++;
+                    break;
+                case 2:
+                    hotCapacity++;
+                    coldCapacity++;
+                    break;
+            }
+
+            return (hotCapacity, warmCapacity, coldCapacity);
         }
     }
 }


### PR DESCRIPTION
When the ctor capacity arg is not divisible by 3, actual ConcurrentLru capacity is less than the specified amount. 

Internally, there are 3 queues, and each queue size = capacity/3.

All items are guaranteed to flow through hot and cold at least once, so fix is to pad the cold and hot queues. 