### PR TITLE
Build wrapped value into ItemPolicy

### DIFF
--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
-    // can have this as internal, and inherit ICache<K, V> from ICacheBase<K, V, V> and IScopedCache : ICacheBase<K, V, Scoped<V>>
+    // can have this as internal, and inherit ICache<K, V> from ICacheBase<K, V, V> and IScopedCache : ICacheBase<K, V, Lifetime<V>>
 
     /// <summary>
     /// Represents a generic cache of key/value pairs.

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -6,12 +6,14 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
+    // can have this as internal, and inherit ICache<K, V> from ICacheBase<K, V, V> and IScopedCache : ICacheBase<K, V, Scoped<V>>
+
     /// <summary>
     /// Represents a generic cache of key/value pairs.
     /// </summary>
     /// <typeparam name="K">The type of keys in the cache.</typeparam>
     /// <typeparam name="V">The type of values in the cache.</typeparam>
-    public interface ICache<K, V>
+    public interface ICache<K, V, W>
     {
         /// <summary>
         /// Attempts to get the value associated with the specified key from the cache.
@@ -19,7 +21,7 @@ namespace BitFaster.Caching
         /// <param name="key">The key of the value to get.</param>
         /// <param name="value">When this method returns, contains the object from the cache that has the specified key, or the default value of the type if the operation failed.</param>
         /// <returns>true if the key was found in the cache; otherwise, false.</returns>
-        bool TryGet(K key, out V value);
+        bool TryGet(K key, out W value);
 
         /// <summary>
         /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
@@ -29,7 +31,7 @@ namespace BitFaster.Caching
         /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
         /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
         /// in the cache, or the new value if the key was not in the dictionary.</returns>
-        V GetOrAdd(K key, Func<K, V> valueFactory);
+        W GetOrAdd(K key, Func<K, V> valueFactory);
 
         /// <summary>
         /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
@@ -38,7 +40,7 @@ namespace BitFaster.Caching
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
         /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
-        Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
+        Task<W> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
 
         /// <summary>
         /// Attempts to remove the value that has the specified key.

--- a/BitFaster.Caching/Lru/ConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLru.cs
@@ -7,33 +7,33 @@ using System.Threading.Tasks;
 namespace BitFaster.Caching.Lru
 {
     ///<inheritdoc/>
-    public sealed class ConcurrentLru<K, V> : TemplateConcurrentLru<K, V, LruItem<K, V>, LruPolicy<K, V>, HitCounter>
-    {
-        /// <summary>
-        /// Initializes a new instance of the ConcurrentLru class with the specified capacity that has the default 
-        /// concurrency level, and uses the default comparer for the key type.
-        /// </summary>
-        /// <param name="capacity">The maximum number of elements that the ConcurrentLru can contain.</param>
-        public ConcurrentLru(int capacity)
-            : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new LruPolicy<K, V>(), new HitCounter())
-        {
-        }
+    //public sealed class ConcurrentLru<K, V> : TemplateConcurrentLru<K, V, V, LruItem<K, V>, LruPolicy<K, V>, HitCounter>
+    //{
+    //    /// <summary>
+    //    /// Initializes a new instance of the ConcurrentLru class with the specified capacity that has the default 
+    //    /// concurrency level, and uses the default comparer for the key type.
+    //    /// </summary>
+    //    /// <param name="capacity">The maximum number of elements that the ConcurrentLru can contain.</param>
+    //    public ConcurrentLru(int capacity)
+    //        : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new LruPolicy<K, V>(), new HitCounter())
+    //    {
+    //    }
 
-        /// <summary>
-        /// Initializes a new instance of the ConcurrentLru class that has the specified concurrency level, has the 
-        /// specified initial capacity, and uses the specified IEqualityComparer<T>.
-        /// </summary>
-        /// <param name="concurrencyLevel">The estimated number of threads that will update the ConcurrentLru concurrently.</param>
-        /// <param name="capacity">The maximum number of elements that the ConcurrentLru can contain.</param>
-        /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
-        public ConcurrentLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer)
-            : base(concurrencyLevel, capacity, comparer, new LruPolicy<K, V>(), new HitCounter())
-        {
-        }
+    //    /// <summary>
+    //    /// Initializes a new instance of the ConcurrentLru class that has the specified concurrency level, has the 
+    //    /// specified initial capacity, and uses the specified IEqualityComparer<T>.
+    //    /// </summary>
+    //    /// <param name="concurrencyLevel">The estimated number of threads that will update the ConcurrentLru concurrently.</param>
+    //    /// <param name="capacity">The maximum number of elements that the ConcurrentLru can contain.</param>
+    //    /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
+    //    public ConcurrentLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer)
+    //        : base(concurrencyLevel, capacity, comparer, new LruPolicy<K, V>(), new HitCounter())
+    //    {
+    //    }
 
-        /// <summary>
-        /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
-        /// </summary>
-        public double HitRatio => this.hitCounter.HitRatio;
-    }
+    //    /// <summary>
+    //    /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
+    //    /// </summary>
+    //    public double HitRatio => this.hitCounter.HitRatio;
+    //}
 }

--- a/BitFaster.Caching/Lru/ConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentTLru.cs
@@ -7,35 +7,35 @@ using System.Threading.Tasks;
 namespace BitFaster.Caching.Lru
 {
     ///<inheritdoc/>
-    public sealed class ConcurrentTLru<K, V> : TemplateConcurrentLru<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, HitCounter>
-    {
-        /// <summary>
-        /// Initializes a new instance of the ConcurrentTLru class with the specified capacity and time to live that has the default 
-        /// concurrency level, and uses the default comparer for the key type.
-        /// </summary>
-        /// <param name="capacity">The maximum number of elements that the ConcurrentTLru can contain.</param>
-        /// <param name="timeToLive">The time to live for cached values.</param>
-        public ConcurrentTLru(int capacity, TimeSpan timeToLive)
-            : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), new HitCounter())
-        { 
-        }
+    //public sealed class ConcurrentTLru<K, V> : TemplateConcurrentLru<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, HitCounter>
+    //{
+    //    /// <summary>
+    //    /// Initializes a new instance of the ConcurrentTLru class with the specified capacity and time to live that has the default 
+    //    /// concurrency level, and uses the default comparer for the key type.
+    //    /// </summary>
+    //    /// <param name="capacity">The maximum number of elements that the ConcurrentTLru can contain.</param>
+    //    /// <param name="timeToLive">The time to live for cached values.</param>
+    //    public ConcurrentTLru(int capacity, TimeSpan timeToLive)
+    //        : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), new HitCounter())
+    //    { 
+    //    }
 
-        /// <summary>
-        /// Initializes a new instance of the ConcurrentTLru class that has the specified concurrency level, has the 
-        /// specified initial capacity, uses the specified IEqualityComparer<T>, and has the specified time to live.
-        /// </summary>
-        /// <param name="concurrencyLevel">The estimated number of threads that will update the ConcurrentTLru concurrently.</param>
-        /// <param name="capacity">The maximum number of elements that the ConcurrentTLru can contain.</param>
-        /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
-        /// <param name="timeToLive">The time to live for cached values.</param>
-        public ConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-            : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), new HitCounter())
-        {
-        }
+    //    /// <summary>
+    //    /// Initializes a new instance of the ConcurrentTLru class that has the specified concurrency level, has the 
+    //    /// specified initial capacity, uses the specified IEqualityComparer<T>, and has the specified time to live.
+    //    /// </summary>
+    //    /// <param name="concurrencyLevel">The estimated number of threads that will update the ConcurrentTLru concurrently.</param>
+    //    /// <param name="capacity">The maximum number of elements that the ConcurrentTLru can contain.</param>
+    //    /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
+    //    /// <param name="timeToLive">The time to live for cached values.</param>
+    //    public ConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
+    //        : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), new HitCounter())
+    //    {
+    //    }
 
-        /// <summary>
-        /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
-        /// </summary>
-        public double HitRatio => this.hitCounter.HitRatio;
-    }
+    //    /// <summary>
+    //    /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
+    //    /// </summary>
+    //    public double HitRatio => this.hitCounter.HitRatio;
+    //}
 }

--- a/BitFaster.Caching/Lru/FastConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/FastConcurrentLru.cs
@@ -5,28 +5,28 @@ using System.Text;
 namespace BitFaster.Caching.Lru
 {
     ///<inheritdoc/>
-    public sealed class FastConcurrentLru<K, V> : TemplateConcurrentLru<K, V, LruItem<K, V>, LruPolicy<K, V>, NullHitCounter>
-    {
-        /// <summary>
-        /// Initializes a new instance of the FastConcurrentLru class with the specified capacity that has the default 
-        /// concurrency level, and uses the default comparer for the key type.
-        /// </summary>
-        /// <param name="capacity">The maximum number of elements that the FastConcurrentLru can contain.</param>
-        public FastConcurrentLru(int capacity)
-            : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new LruPolicy<K, V>(), new NullHitCounter())
-        {
-        }
+    //public sealed class FastConcurrentLru<K, V> : TemplateConcurrentLru<K, V, LruItem<K, V>, LruPolicy<K, V>, NullHitCounter>
+    //{
+    //    /// <summary>
+    //    /// Initializes a new instance of the FastConcurrentLru class with the specified capacity that has the default 
+    //    /// concurrency level, and uses the default comparer for the key type.
+    //    /// </summary>
+    //    /// <param name="capacity">The maximum number of elements that the FastConcurrentLru can contain.</param>
+    //    public FastConcurrentLru(int capacity)
+    //        : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new LruPolicy<K, V>(), new NullHitCounter())
+    //    {
+    //    }
 
-        /// <summary>
-        /// Initializes a new instance of the FastConcurrentLru class that has the specified concurrency level, has the 
-        /// specified initial capacity, and uses the specified IEqualityComparer<T>.
-        /// </summary>
-        /// <param name="concurrencyLevel">The estimated number of threads that will update the FastConcurrentLru concurrently.</param>
-        /// <param name="capacity">The maximum number of elements that the FastConcurrentLru can contain.</param>
-        /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
-        public FastConcurrentLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer)
-            : base(concurrencyLevel, capacity, comparer, new LruPolicy<K, V>(), new NullHitCounter())
-        {
-        }
-    }
+    //    /// <summary>
+    //    /// Initializes a new instance of the FastConcurrentLru class that has the specified concurrency level, has the 
+    //    /// specified initial capacity, and uses the specified IEqualityComparer<T>.
+    //    /// </summary>
+    //    /// <param name="concurrencyLevel">The estimated number of threads that will update the FastConcurrentLru concurrently.</param>
+    //    /// <param name="capacity">The maximum number of elements that the FastConcurrentLru can contain.</param>
+    //    /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
+    //    public FastConcurrentLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer)
+    //        : base(concurrencyLevel, capacity, comparer, new LruPolicy<K, V>(), new NullHitCounter())
+    //    {
+    //    }
+    //}
 }

--- a/BitFaster.Caching/Lru/FastConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/FastConcurrentTLru.cs
@@ -5,30 +5,30 @@ using System.Text;
 namespace BitFaster.Caching.Lru
 {
     ///<inheritdoc/>
-    public sealed class FastConcurrentTLru<K, V> : TemplateConcurrentLru<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, NullHitCounter>
-    {
-        /// <summary>
-        /// Initializes a new instance of the FastConcurrentTLru class with the specified capacity and time to live that has the default 
-        /// concurrency level, and uses the default comparer for the key type.
-        /// </summary>
-        /// <param name="capacity">The maximum number of elements that the FastConcurrentTLru can contain.</param>
-        /// <param name="timeToLive">The time to live for cached values.</param>
-        public FastConcurrentTLru(int capacity, TimeSpan timeToLive)
-            : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), new NullHitCounter())
-        {
-        }
+    //public sealed class FastConcurrentTLru<K, V> : TemplateConcurrentLru<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, NullHitCounter>
+    //{
+    //    /// <summary>
+    //    /// Initializes a new instance of the FastConcurrentTLru class with the specified capacity and time to live that has the default 
+    //    /// concurrency level, and uses the default comparer for the key type.
+    //    /// </summary>
+    //    /// <param name="capacity">The maximum number of elements that the FastConcurrentTLru can contain.</param>
+    //    /// <param name="timeToLive">The time to live for cached values.</param>
+    //    public FastConcurrentTLru(int capacity, TimeSpan timeToLive)
+    //        : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), new NullHitCounter())
+    //    {
+    //    }
 
-        /// <summary>
-        /// Initializes a new instance of the FastConcurrentTLru class that has the specified concurrency level, has the 
-        /// specified initial capacity, uses the specified IEqualityComparer<T>, and has the specified time to live.
-        /// </summary>
-        /// <param name="concurrencyLevel">The estimated number of threads that will update the FastConcurrentTLru concurrently.</param>
-        /// <param name="capacity">The maximum number of elements that the FastConcurrentTLru can contain.</param>
-        /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
-        /// <param name="timeToLive">The time to live for cached values.</param>
-        public FastConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-            : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), new NullHitCounter())
-        {
-        }
-    }
+    //    /// <summary>
+    //    /// Initializes a new instance of the FastConcurrentTLru class that has the specified concurrency level, has the 
+    //    /// specified initial capacity, uses the specified IEqualityComparer<T>, and has the specified time to live.
+    //    /// </summary>
+    //    /// <param name="concurrencyLevel">The estimated number of threads that will update the FastConcurrentTLru concurrently.</param>
+    //    /// <param name="capacity">The maximum number of elements that the FastConcurrentTLru can contain.</param>
+    //    /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
+    //    /// <param name="timeToLive">The time to live for cached values.</param>
+    //    public FastConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
+    //        : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), new NullHitCounter())
+    //    {
+    //    }
+    //}
 }

--- a/BitFaster.Caching/Lru/IPolicy.cs
+++ b/BitFaster.Caching/Lru/IPolicy.cs
@@ -20,4 +20,20 @@ namespace BitFaster.Caching.Lru
 
         ItemDestination RouteCold(I item);
     }
+
+    // now item is wrapped in W via policy
+    public interface IItemPolicy<in K, in V, in W, I> where I : LruItem<K, W>
+    {
+        I CreateItem(K key, V value);
+
+        void Touch(I item);
+
+        bool ShouldDiscard(I item);
+
+        ItemDestination RouteHot(I item);
+
+        ItemDestination RouteWarm(I item);
+
+        ItemDestination RouteCold(I item);
+    }
 }

--- a/BitFaster.Caching/Lru/ScopedConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/ScopedConcurrentLru.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.Lru
+{
+    public class ScopedConcurrentLru<K, V> : TemplateConcurrentLru<K, V, Scoped<V>, LruItem<K, Scoped<V>>, ScopedLruPolicy<K, V>, HitCounter> where V : IDisposable
+    {
+        public ScopedConcurrentLru(int capacity)
+            : base(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default, new ScopedLruPolicy<K, V>(), new HitCounter())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the ConcurrentLru class that has the specified concurrency level, has the 
+        /// specified initial capacity, and uses the specified IEqualityComparer<T>.
+        /// </summary>
+        /// <param name="concurrencyLevel">The estimated number of threads that will update the ConcurrentLru concurrently.</param>
+        /// <param name="capacity">The maximum number of elements that the ConcurrentLru can contain.</param>
+        /// <param name="comparer">The IEqualityComparer<T> implementation to use when comparing keys.</param>
+        public ScopedConcurrentLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer)
+            : base(concurrencyLevel, capacity, comparer, new ScopedLruPolicy<K, V>(), new HitCounter())
+        {
+        }
+
+        /// <summary>
+        /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
+        /// </summary>
+        public double HitRatio => this.hitCounter.HitRatio;
+
+
+        // Now it is possible to create these methods as extensions without value factory wrappers
+
+        public Lifetime<V> ScopedGetOrAdd(K key, Func<K, V> valueFactory)
+        {
+            while (true)
+            {
+                var scope = this.GetOrAdd(key, valueFactory);
+
+                if (scope.TryCreateLifetime(out var lifetime))
+                {
+                    return lifetime;
+                }
+            }
+        }
+
+        public async Task<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        {
+            while (true)
+            {
+                var scope = await this.GetOrAddAsync(key, valueFactory);
+
+                if (scope.TryCreateLifetime(out var lifetime))
+                {
+                    return lifetime;
+                }
+            }
+        }
+    }
+}

--- a/BitFaster.Caching/Lru/ScopedLruPolicy.cs
+++ b/BitFaster.Caching/Lru/ScopedLruPolicy.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.Lru
+{
+    /// <summary>
+    /// Discards the least recently used items first. 
+    /// </summary>
+    public readonly struct ScopedLruPolicy<K, V> : IItemPolicy<K, V, Scoped<V>, LruItem<K, Scoped<V>>> where V : IDisposable
+    {
+        // This handles creating the scope, so caller can't mess it up
+        public LruItem<K, Scoped<V>> CreateItem(K key, V value)
+        {
+            return new LruItem<K, Scoped<V>>(key, new Scoped<V>(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Touch(LruItem<K, Scoped<V>> item)
+        {
+            item.WasAccessed = true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ShouldDiscard(LruItem<K, Scoped<V>> item)
+        {
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteHot(LruItem<K, Scoped<V>> item)
+        {
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Cold;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteWarm(LruItem<K, Scoped<V>> item)
+        {
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Cold;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteCold(LruItem<K, Scoped<V>> item)
+        {
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Remove;
+        }
+
+
+    }
+}


### PR DESCRIPTION
It is awkward to handle caches of Scoped<V> - either need a wrapper factory Func<> to convert which is always a closure (alloc), or user can pass in Scoped, which opens the door to creating a Disposed scoped object which can put the cache into an invalid state. See this [PR](https://github.com/bitfaster/BitFaster.Caching/pull/69) for impl.

Now make policy have a type param W for the wrapped type, which can be Scoped.

- Problem remains that we return Scoped, and therefore enable the user to dispose scopes still in the cache and corrupt it (since a non removed item now cannot create lifetimes)
- Then introduce type param R, return type of GetOrAdd
- Policy has a method to convert W into R, which would create lifetime for Scoped, and just return the value for non wrapped types which presumably the JIT can completely elide. 


Does this extend to Atomic etc. ? Would need to extend policy so that CreateItem accepts factory and to have an init method that accepts the factory. Then inside policy choose when factory is called. Question here is whether JIT will eliminate unnecessary args for specialized policies (factory is invoked at one call site or the other).