### PR TITLE
analyze hit rate from wikibench

### DIFF
--- a/BitFaster.Caching.HitRateAnalysis.Wikibench/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis.Wikibench/Analysis.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BitFaster.Caching.Lru;
+
+namespace BitFaster.Caching.HitRateAnalysis.Wikibench
+{
+    public class Analysis
+    {
+        private readonly ConcurrentLru<Uri, int> concurrentLru;
+        private readonly ClassicLru<Uri, int> classicLru;
+
+        public Analysis(int cacheSize)
+        {
+            this.concurrentLru = new ConcurrentLru<Uri, int>(1, cacheSize, EqualityComparer<Uri>.Default);
+            this.classicLru = new ClassicLru<Uri, int>(1, cacheSize, EqualityComparer<Uri>.Default);
+        }
+
+        public void TestUri(Uri uri)
+        {
+            this.concurrentLru.GetOrAdd(uri, u => 1);
+            this.classicLru.GetOrAdd(uri, u => 1);
+        }
+
+        public void Compare()
+        {
+            Console.WriteLine($"Size {this.concurrentLru.Capacity} Classic HitRate {FormatHits(this.classicLru.HitRatio)} Concurrent HitRate {FormatHits(this.concurrentLru.HitRatio)}");
+        }
+
+        private static string FormatHits(double hitRate)
+        { 
+            return string.Format("{0:N2}%", hitRate * 100.0);
+        }
+    }
+}

--- a/BitFaster.Caching.HitRateAnalysis.Wikibench/BitFaster.Caching.HitRateAnalysis.Wikibench.csproj
+++ b/BitFaster.Caching.HitRateAnalysis.Wikibench/BitFaster.Caching.HitRateAnalysis.Wikibench.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BitFaster.Caching\BitFaster.Caching.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/BitFaster.Caching.HitRateAnalysis.Wikibench/Program.cs
+++ b/BitFaster.Caching.HitRateAnalysis.Wikibench/Program.cs
@@ -1,0 +1,50 @@
+﻿// See http://www.wikibench.eu/ for data
+// Should result in the same URLs as the parser here:
+// https://github.com/ben-manes/caffeine/blob/master/simulator/src/main/java/com/github/benmanes/caffeine/cache/simulator/parser/wikipedia/WikipediaTraceReader.java
+
+using System.Diagnostics;
+using BitFaster.Caching.HitRateAnalysis.Wikibench;
+
+string[] wikiUris = 
+    { 
+        "http://www.wikibench.eu/wiki/2007-09/wiki.1190153705.gz",
+        "http://www.wikibench.eu/wiki/2007-09/wiki.1190157306.gz",
+        "http://www.wikibench.eu/wiki/2007-09/wiki.1190160907.gz",
+        "http://www.wikibench.eu/wiki/2007-09/wiki.1190164508.gz",
+        "http://www.wikibench.eu/wiki/2007-09/wiki.1190168109.gz",
+    };
+
+//var wikiFile = new WikiBenchFile(1, new Uri("http://www.wikibench.eu/wiki/2007-09/wiki.1190153705.gz"));
+
+int[] cacheSizes = { 25, 50, 75, 100, 125, 150, 175, 200 };
+var analysis = cacheSizes.Select(s => new Analysis(s)).ToList();
+
+var dataSet = new WikiDataSet(wikiUris);
+
+await dataSet.Download();
+
+Console.WriteLine("Running...");
+
+int count = 0;
+
+var sw = Stopwatch.StartNew();
+
+foreach (var url in dataSet.EnumerateUris())
+{
+    foreach (var a in analysis)
+    { 
+        a.TestUri(url);
+    }
+    count++;
+    if (count % 100000 == 0)
+    {
+        Console.WriteLine($"Processed {count} URIs...");
+    }
+}
+
+Console.WriteLine($"Tested {count} URIs in {sw.Elapsed}");
+
+foreach (var a in analysis)
+{
+    a.Compare();
+}

--- a/BitFaster.Caching.HitRateAnalysis.Wikibench/Program.cs
+++ b/BitFaster.Caching.HitRateAnalysis.Wikibench/Program.cs
@@ -5,28 +5,22 @@
 using System.Diagnostics;
 using BitFaster.Caching.HitRateAnalysis.Wikibench;
 
-string[] wikiUris = 
-    { 
+int[] cacheSizes = { 25, 50, 75, 100, 125, 150, 175, 200 };
+var analysis = cacheSizes.Select(s => new Analysis(s)).ToList();
+
+string[] wikiUris =
+    {
         "http://www.wikibench.eu/wiki/2007-09/wiki.1190153705.gz",
         "http://www.wikibench.eu/wiki/2007-09/wiki.1190157306.gz",
         "http://www.wikibench.eu/wiki/2007-09/wiki.1190160907.gz",
         "http://www.wikibench.eu/wiki/2007-09/wiki.1190164508.gz",
         "http://www.wikibench.eu/wiki/2007-09/wiki.1190168109.gz",
     };
-
-//var wikiFile = new WikiBenchFile(1, new Uri("http://www.wikibench.eu/wiki/2007-09/wiki.1190153705.gz"));
-
-int[] cacheSizes = { 25, 50, 75, 100, 125, 150, 175, 200 };
-var analysis = cacheSizes.Select(s => new Analysis(s)).ToList();
-
 var dataSet = new WikiDataSet(wikiUris);
-
-await dataSet.Download();
+await dataSet.DownloadIfNotExistsAsync();
 
 Console.WriteLine("Running...");
-
 int count = 0;
-
 var sw = Stopwatch.StartNew();
 
 foreach (var url in dataSet.EnumerateUris())
@@ -35,8 +29,8 @@ foreach (var url in dataSet.EnumerateUris())
     { 
         a.TestUri(url);
     }
-    count++;
-    if (count % 100000 == 0)
+    
+    if (count++ % 100000 == 0)
     {
         Console.WriteLine($"Processed {count} URIs...");
     }

--- a/BitFaster.Caching.HitRateAnalysis.Wikibench/WikiBenchFile.cs
+++ b/BitFaster.Caching.HitRateAnalysis.Wikibench/WikiBenchFile.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.HitRateAnalysis.Wikibench
+{
+    public class WikiBenchFile
+    {
+        public WikiBenchFile(int id, Uri uri)
+        {
+            this.Id = id;
+            this.Uri = uri;
+            this.FilePath = $"currenttmp{id}";
+        }
+
+        public int Id { get; }
+
+        public Uri Uri { get; }
+
+        public string FilePath { get; }
+
+        public async Task DownloadIfNotExists()
+        {
+            var zipped = this.FilePath + ".gz";
+
+            if (!File.Exists(zipped))
+            {
+                Console.WriteLine($"Downloading {Uri}...");
+                HttpClient client = new HttpClient();
+                var response = await client.GetAsync(Uri);
+                using (var fs = new FileStream(
+                    zipped,
+                    FileMode.CreateNew))
+                {
+                    await response.Content.CopyToAsync(fs);
+                }
+            }
+
+            if (!File.Exists(this.FilePath))
+            {
+                Console.WriteLine($"Decompressing {Uri}...");
+                
+                using (FileStream originalFileStream = new FileInfo(zipped).OpenRead())
+                {
+                    using (var decompressedFileStream = File.Create(this.FilePath))
+                    {
+                        using (var decompressionStream = new GZipStream(originalFileStream, CompressionMode.Decompress))
+                        {
+                            decompressionStream.CopyTo(decompressedFileStream);
+                        }
+                    }
+                }
+            }
+        }
+
+        public IEnumerable<Uri> EnumerateUris()
+        {
+            using (StreamReader sr = new StreamReader(this.FilePath))
+            {
+                while (sr.Peek() >= 0)
+                {
+                    var line = sr.ReadLine();
+
+                    // reads end with -
+                    if (line?.EndsWith('-') ?? false)
+                    {
+                        var parsed = ParseLine(line);
+                        if (parsed != null)
+                        {
+                            if (Uri.TryCreate(parsed, UriKind.Relative, out var result))
+                            { 
+                                yield return result; 
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static readonly string[] containsFilters = 
+            { 
+                "?search = ",
+                "User+talk",
+                "User_talk",
+                "User_talk",
+                "&search=",
+                "User+talk",
+                "User_talk",
+                "User:",
+                "Talk:",
+                "&diff=",
+                "&action=rollback",
+                "Special:Watchlist",
+            };
+
+        private static readonly string[] startswithFilters =
+            {
+                "/wiki/Special:Search", 
+                "/w/query.php", 
+                "/wiki/Talk:", 
+                "/wiki/Special:AutoLogin",
+                "/Special:UserLogin", 
+                "/w/api.php", 
+                "/error:"
+            };
+
+        private static string? ParseLine(string line)
+        {
+            // Example lines
+            // 929840853 1190146243.326 http://upload.wikimedia.org/wikipedia/en/thumb/e/e4/James_Johnson.jpg/200px-James_Johnson.jpg -
+            // 929840930 1190146243.320 http://meta.wikimedia.org/w/index.php?title=MediaWiki:Wikiminiatlas.js&action=raw&ctype=text/javascript&smaxage=21600&maxage=86400 -
+
+            if (line.Length < 25 + 7)
+            {
+                return null;
+            }
+
+            int start = line.IndexOf('/', 25+7);
+
+            if (start == -1)
+            {
+                return null;
+            }
+
+            var url = line.Substring(start, line.Length - start - 2);
+
+            url = url.Replace("%2F", "/", StringComparison.Ordinal);
+            url = url.Replace("%20", " ", StringComparison.Ordinal);
+            url = url.Replace("&amp;", "&", StringComparison.Ordinal);
+            url = url.Replace("%3A", ":", StringComparison.Ordinal);
+
+            foreach (var filter in startswithFilters)
+            {
+                if (url.StartsWith(filter, StringComparison.Ordinal))
+                {
+                    return null;
+                }
+            }
+
+            foreach (var filter in containsFilters)
+            {
+                if (url.Contains(filter, StringComparison.Ordinal))
+                {
+                    return null;
+                }
+            }
+
+            return url;
+        }
+    }
+}

--- a/BitFaster.Caching.HitRateAnalysis.Wikibench/WikiDataSet.cs
+++ b/BitFaster.Caching.HitRateAnalysis.Wikibench/WikiDataSet.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.HitRateAnalysis.Wikibench
+{
+    public class WikiDataSet
+    {
+        List<WikiBenchFile> files = new List<WikiBenchFile>();
+
+        public WikiDataSet(IEnumerable<string> urls)
+        {
+            int n = 1;
+            foreach (string url in urls)
+            {
+                files.Add(new WikiBenchFile(n++, new Uri(url)));
+            }
+        }
+
+        public async Task Download()
+        {
+            var tasks = new List<Task>();
+
+            foreach (var f in files)
+            {
+                tasks.Add(Task.Run(async () => await f.DownloadIfNotExists()));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        public IEnumerable<Uri> EnumerateUris()
+        {
+            foreach (var f in files)
+            {
+                foreach (var uri in f.EnumerateUris())
+                {
+                    yield return uri;
+                }
+            }
+        }
+    }
+}

--- a/BitFaster.Caching.HitRateAnalysis.Wikibench/WikiDataSet.cs
+++ b/BitFaster.Caching.HitRateAnalysis.Wikibench/WikiDataSet.cs
@@ -19,13 +19,13 @@ namespace BitFaster.Caching.HitRateAnalysis.Wikibench
             }
         }
 
-        public async Task Download()
+        public async Task DownloadIfNotExistsAsync()
         {
             var tasks = new List<Task>();
 
             foreach (var f in files)
             {
-                tasks.Add(Task.Run(async () => await f.DownloadIfNotExists()));
+                tasks.Add(Task.Run(async () => await f.DownloadIfNotExistsAsync()));
             }
 
             await Task.WhenAll(tasks);

--- a/BitFaster.sln
+++ b/BitFaster.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitFaster.Caching.HitRateAn
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitFaster.Caching.ThroughputAnalysis", "BitFaster.Caching.ThroughputAnalysis\BitFaster.Caching.ThroughputAnalysis.csproj", "{EF9968AF-10B2-4205-9C42-19A594BC98C1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitFaster.Caching.HitRateAnalysis.Wikibench", "BitFaster.Caching.HitRateAnalysis.Wikibench\BitFaster.Caching.HitRateAnalysis.Wikibench.csproj", "{9ACAEAE7-9C41-41FA-9B6B-B5455B0D67AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{EF9968AF-10B2-4205-9C42-19A594BC98C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF9968AF-10B2-4205-9C42-19A594BC98C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF9968AF-10B2-4205-9C42-19A594BC98C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9ACAEAE7-9C41-41FA-9B6B-B5455B0D67AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9ACAEAE7-9C41-41FA-9B6B-B5455B0D67AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9ACAEAE7-9C41-41FA-9B6B-B5455B0D67AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9ACAEAE7-9C41-41FA-9B6B-B5455B0D67AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Implement a simple test harness to analyze hit rate using the wikibench data set.

```
Tested 44,846,065 URIs in 00:06:25.4379518

Size 25 Classic HitRate 12.34% Concurrent HitRate 30.75%
Size 50 Classic HitRate 21.44% Concurrent HitRate 38.54%
Size 75 Classic HitRate 27.84% Concurrent HitRate 42.52%
Size 100 Classic HitRate 32.26% Concurrent HitRate 45.10%
Size 125 Classic HitRate 35.31% Concurrent HitRate 47.22%
Size 150 Classic HitRate 37.48% Concurrent HitRate 48.69%
Size 175 Classic HitRate 39.10% Concurrent HitRate 49.93%
Size 200 Classic HitRate 40.36% Concurrent HitRate 50.83%
```

![image](https://user-images.githubusercontent.com/12851828/178196172-b643eed0-9586-47c9-88e7-73b0518bf74d.png)

