### PR TITLE
write tables as markdown

### DIFF
--- a/BitFaster.Caching.HitRateAnalysis/Arc/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Analysis.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
+using ConsoleTables;
 using CsvHelper;
 
 namespace BitFaster.Caching.HitRateAnalysis.Arc
@@ -33,16 +34,6 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
             classicLru.GetOrAdd(key, u => 1);
         }
 
-        public void Compare()
-        {
-            Console.WriteLine($"Size {concurrentLru.Capacity} Classic HitRate {FormatHits(classicLru.HitRatio)} Concurrent HitRate {FormatHits(concurrentLru.HitRatio)}");
-        }
-
-        private static string FormatHits(double hitRate)
-        {
-            return string.Format("{0:N2}%", hitRate * 100.0);
-        }
-
         public static void WriteToFile(string path, IEnumerable<Analysis> results)
         {
             using (var writer = new StreamWriter(path))
@@ -50,6 +41,14 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
             {
                 csv.WriteRecords(results);
             }
+        }
+
+        public static void WriteToConsole(IEnumerable<Analysis> results)
+        {
+            ConsoleTable
+                .From(results)
+                .Configure(o => o.NumberAlignment = Alignment.Right)
+                .Write(Format.MarkDown);
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Arc/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Analysis.cs
@@ -42,13 +42,5 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
                 csv.WriteRecords(results);
             }
         }
-
-        public static void WriteToConsole(IEnumerable<Analysis> results)
-        {
-            ConsoleTable
-                .From(results)
-                .Configure(o => o.NumberAlignment = Alignment.Right)
-                .Write(Format.MarkDown);
-        }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
@@ -40,11 +40,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
 
             Console.WriteLine($"Tested {count} keys in {sw.Elapsed}");
 
-            foreach (var a in this.config.Analysis)
-            {
-                a.Compare();
-            }
-
+            Analysis.WriteToConsole(this.config.Analysis);
             Analysis.WriteToFile(this.config.Name, this.config.Analysis);
         }
     }

--- a/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
 
             Console.WriteLine($"Tested {count} keys in {sw.Elapsed}");
 
-            Analysis.WriteToConsole(this.config.Analysis);
+            this.config.Analysis.WriteToConsole();
             Analysis.WriteToFile(this.config.Name, this.config.Analysis);
         }
     }

--- a/BitFaster.Caching.HitRateAnalysis/Glimpse/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Glimpse/Analysis.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
+using ConsoleTables;
 using CsvHelper;
 
 namespace BitFaster.Caching.HitRateAnalysis.Glimpse
@@ -33,16 +34,6 @@ namespace BitFaster.Caching.HitRateAnalysis.Glimpse
             this.classicLru.GetOrAdd(key, u => 1);
         }
 
-        public void Compare()
-        {
-            Console.WriteLine($"Size {this.concurrentLru.Capacity} Classic HitRate {FormatHits(this.classicLru.HitRatio)} Concurrent HitRate {FormatHits(this.concurrentLru.HitRatio)}");
-        }
-
-        private static string FormatHits(double hitRate)
-        { 
-            return string.Format("{0:N2}%", hitRate * 100.0);
-        }
-
         public static void WriteToFile(string path, IEnumerable<Analysis> results)
         {
             using (var writer = new StreamWriter(path))
@@ -50,6 +41,14 @@ namespace BitFaster.Caching.HitRateAnalysis.Glimpse
             {
                 csv.WriteRecords(results);
             }
+        }
+
+        public static void WriteToConsole(IEnumerable<Analysis> results)
+        {
+            ConsoleTable
+                .From(results)
+                .Configure(o => o.NumberAlignment = Alignment.Right)
+                .Write(Format.MarkDown);
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Glimpse/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Glimpse/Analysis.cs
@@ -42,13 +42,5 @@ namespace BitFaster.Caching.HitRateAnalysis.Glimpse
                 csv.WriteRecords(results);
             }
         }
-
-        public static void WriteToConsole(IEnumerable<Analysis> results)
-        {
-            ConsoleTable
-                .From(results)
-                .Configure(o => o.NumberAlignment = Alignment.Right)
-                .Write(Format.MarkDown);
-        }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Glimpse/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Glimpse/Runner.cs
@@ -34,12 +34,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Glimpse
             }
 
             Console.WriteLine($"Tested {count} keys in {sw.Elapsed}");
-
-            foreach (var a in analysis)
-            {
-                a.Compare();
-            }
-
+            Analysis.WriteToConsole(analysis);
             Analysis.WriteToFile("results.glimpse.csv", analysis);
         }
     }

--- a/BitFaster.Caching.HitRateAnalysis/Glimpse/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Glimpse/Runner.cs
@@ -34,7 +34,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Glimpse
             }
 
             Console.WriteLine($"Tested {count} keys in {sw.Elapsed}");
-            Analysis.WriteToConsole(analysis);
+            analysis.WriteToConsole();
             Analysis.WriteToFile("results.glimpse.csv", analysis);
         }
     }

--- a/BitFaster.Caching.HitRateAnalysis/ResultExtensions.cs
+++ b/BitFaster.Caching.HitRateAnalysis/ResultExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ConsoleTables;
+
+namespace BitFaster.Caching.HitRateAnalysis
+{
+    public static class ResultExtensions
+    {
+        public static void WriteToConsole<T>(this IEnumerable<T> results)
+        {
+            ConsoleTable
+                .From(results)
+                .Configure(o => o.NumberAlignment = Alignment.Right)
+                .Write(Format.MarkDown);
+        }
+    }
+}

--- a/BitFaster.Caching.HitRateAnalysis/Wikibench/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Wikibench/Analysis.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
+using ConsoleTables;
 using CsvHelper;
 
 namespace BitFaster.Caching.HitRateAnalysis.Wikibench
@@ -33,16 +34,6 @@ namespace BitFaster.Caching.HitRateAnalysis.Wikibench
             this.classicLru.GetOrAdd(uri, u => 1);
         }
 
-        public void Compare()
-        {
-            Console.WriteLine($"Size {this.concurrentLru.Capacity} Classic HitRate {FormatHits(this.classicLru.HitRatio)} Concurrent HitRate {FormatHits(this.concurrentLru.HitRatio)}");
-        }
-
-        private static string FormatHits(double hitRate)
-        { 
-            return string.Format("{0:N2}%", hitRate * 100.0);
-        }
-
         public static void WriteToFile(string path, IEnumerable<Analysis> results)
         {
             using (var writer = new StreamWriter(path))
@@ -50,6 +41,14 @@ namespace BitFaster.Caching.HitRateAnalysis.Wikibench
             {
                 csv.WriteRecords(results);
             }
+        }
+
+        public static void WriteToConsole(IEnumerable<Analysis> results)
+        {
+            ConsoleTable
+                .From(results)
+                .Configure(o => o.NumberAlignment = Alignment.Right)
+                .Write(Format.MarkDown);
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Wikibench/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Wikibench/Analysis.cs
@@ -42,13 +42,5 @@ namespace BitFaster.Caching.HitRateAnalysis.Wikibench
                 csv.WriteRecords(results);
             }
         }
-
-        public static void WriteToConsole(IEnumerable<Analysis> results)
-        {
-            ConsoleTable
-                .From(results)
-                .Configure(o => o.NumberAlignment = Alignment.Right)
-                .Write(Format.MarkDown);
-        }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Wikibench/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Wikibench/Runner.cs
@@ -45,8 +45,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Wikibench
             }
 
             Console.WriteLine($"Tested {count} URIs in {sw.Elapsed}");
-
-            Analysis.WriteToConsole(analysis);
+            analysis.WriteToConsole();
             Analysis.WriteToFile("results.wikibench.csv", analysis);
         }
     }

--- a/BitFaster.Caching.HitRateAnalysis/Wikibench/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Wikibench/Runner.cs
@@ -46,11 +46,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Wikibench
 
             Console.WriteLine($"Tested {count} URIs in {sw.Elapsed}");
 
-            foreach (var a in analysis)
-            {
-                a.Compare();
-            }
-
+            Analysis.WriteToConsole(analysis);
             Analysis.WriteToFile("results.wikibench.csv", analysis);
         }
     }

--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/AnalysisResult.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/AnalysisResult.cs
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
             ConsoleTable
                 .From(results)
                 .Configure(o => o.NumberAlignment = Alignment.Right)
-                .Write(Format.Alternative);
+                .Write(Format.MarkDown);
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/AnalysisResult.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/AnalysisResult.cs
@@ -34,13 +34,5 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
                 csv.WriteRecords(results);
             }
         }
-
-        public static void WriteToConsole(IEnumerable<AnalysisResult> results)
-        {
-            ConsoleTable
-                .From(results)
-                .Configure(o => o.NumberAlignment = Alignment.Right)
-                .Write(Format.MarkDown);
-        }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
@@ -163,7 +163,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
                 });
             }
 
-            AnalysisResult.WriteToConsole(results);
+            results.WriteToConsole();
             AnalysisResult.WriteToFile("results.zipf.csv", results);
 
             Console.ReadLine();


### PR DESCRIPTION
Console output as markdown table, e.g.


| CacheSize | ConcurrentLruHitRate |  ClassicLruHitRate |
|-----------|----------------------|--------------------|
|       250 |   15.314747660382105 | 16.473425988218498 |
|       500 |    26.88391885313599 | 23.445405269404745 |
|       750 |    32.04305662668395 |  28.28074320813438 |
|      1000 |   35.357738651964404 |  32.83089663018449 |
|      1250 |    37.96881238753152 | 36.209682271412085 |
|      1500 |    40.05600862007668 |  38.69604931383971 |
|      1750 |   41.877710866438036 |   40.7881681790088 |
|      2000 |    43.49200619157792 |  42.46973948334236 |