### PR TITLE
scopedec

### DIFF
--- a/BitFaster.Caching.UnitTests/Disposable.cs
+++ b/BitFaster.Caching.UnitTests/Disposable.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public class Disposable : IDisposable
+    {
+        public bool IsDisposed { get; set; }
+
+        public void Dispose()
+        {
+            this.IsDisposed.Should().BeFalse();
+            IsDisposed = true;
+        }
+    }
+}

--- a/BitFaster.Caching.UnitTests/DisposableValueFactory.cs
+++ b/BitFaster.Caching.UnitTests/DisposableValueFactory.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public class DisposableValueFactory
+    {
+        public Disposable Disposable { get; } = new Disposable();
+
+        public Scoped<Disposable> Create(int key)
+        {
+            return new Scoped<Disposable>(this.Disposable);
+        }
+    }
+}

--- a/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
@@ -162,9 +162,6 @@ namespace BitFaster.Caching.UnitTests
             getOrAdd.Should().ThrowAsync<InvalidOperationException>();
         }
 
-
-        // TODO: start lifetime, cycle value out of the cache, verify alive then dead
-
         [Fact]
         public void WhenCacheContainsValuesTrim1RemovesColdestValue()
         {

--- a/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BitFaster.Caching.Lru;
+using FluentAssertions;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public class ScopedCacheTests
+    {
+        private const int capacity = 6;
+        private readonly ScopedCache<int, Disposable> cache = new (new ConcurrentLru<int, Scoped<Disposable>>(capacity));
+
+        [Fact]
+        public void WhenInnerCacheIsNullCtorThrows()
+        {
+            Action constructor = () => { var x = new ScopedCache<int, Disposable>(null); };
+
+            constructor.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void WhenCreatedCapacityPropertyWrapsInnerCache()
+        {
+            this.cache.Capacity.Should().Be(capacity);
+        }
+
+        [Fact]
+        public void WhenItemIsAddedCountIsCorrect()
+        {
+            this.cache.Count.Should().Be(0);
+
+            this.cache.AddOrUpdate(1, new Disposable());
+
+            this.cache.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()
+        {
+            var d = new Disposable();
+            this.cache.AddOrUpdate(1, d);
+
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            lifetime.Value.Should().Be(d);
+        }
+
+        [Fact]
+        public void WhenKeyExistsAddOrUpdateUpdatesExistingItem()
+        {
+            var d1 = new Disposable();
+            var d2 = new Disposable();
+            this.cache.AddOrUpdate(1, d1);
+            this.cache.AddOrUpdate(1, d2);
+
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            lifetime.Value.Should().Be(d2);
+        }
+
+        [Fact]
+        public void WhenItemUpdatedOldValueIsAliveUntilLifetimeCompletes()
+        {
+            var d1 = new Disposable();
+            var d2 = new Disposable();
+
+            // start a lifetime on 1
+            this.cache.AddOrUpdate(1, d1);
+            this.cache.ScopedTryGet(1, out var lifetime1).Should().BeTrue();
+
+            using (lifetime1)
+            {
+                // replace 1
+                this.cache.AddOrUpdate(1, d2);
+
+                // cache reflects replacement
+                this.cache.ScopedTryGet(1, out var lifetime2).Should().BeTrue();
+                lifetime2.Value.Should().Be(d2);
+
+                d1.IsDisposed.Should().BeFalse();
+            }
+
+            d1.IsDisposed.Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenClearedItemsAreDisposed()
+        {
+            var d = new Disposable();
+            this.cache.AddOrUpdate(1, d);
+
+            this.cache.Clear();
+
+            d.IsDisposed.Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenItemExistsTryGetReturnsLifetime()
+        {
+            this.cache.AddOrUpdate(1, new Disposable());
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+
+            lifetime.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void WhenItemDoesNotExistTryGetReturnsFalse()
+        {
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenScopeIsDisposedTryGetReturnsFalse()
+        {
+            var scope = new Scoped<Disposable>(new Disposable());
+            
+            this.cache.ScopedGetOrAdd(1, k => scope);
+
+            scope.Dispose();
+
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetOrAddDisposedScopeThrows()
+        {
+            var scope = new Scoped<Disposable>(new Disposable());
+            scope.Dispose();
+            
+
+            Action getOrAdd = () => { this.cache.ScopedGetOrAdd(1, k => scope); };
+
+            getOrAdd.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void GetOrAddAsyncDisposedScopeThrows()
+        {
+            var scope = new Scoped<Disposable>(new Disposable());
+            scope.Dispose();
+
+            Func<Task> getOrAdd = async () => { await this.cache.ScopedGetOrAddAsync(1, k => Task.FromResult(scope)); };
+
+            getOrAdd.Should().ThrowAsync<InvalidOperationException>();
+        }
+
+
+        // TODO: start lifetime, cycle value out of the cache, verify alive then dead
+
+        [Fact]
+        public void WhenCacheContainsValuesTrim1RemovesColdestValue()
+        {
+            this.cache.AddOrUpdate(0, new Disposable());
+            this.cache.AddOrUpdate(1, new Disposable());
+            this.cache.AddOrUpdate(2, new Disposable());
+
+            this.cache.Trim(1);
+
+            this.cache.ScopedTryGet(0, out var lifetime).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenKeyDoesNotExistTryRemoveReturnsFalse() 
+        {
+            this.cache.TryRemove(1).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenKeyExistsTryRemoveReturnsTrue() 
+        {
+            this.cache.AddOrUpdate(1, new Disposable());
+            this.cache.TryRemove(1).Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenKeyDoesNotExistTryUpdateReturnsFalse() 
+        {
+            this.cache.TryUpdate(1, new Disposable()).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenKeyExistsTryUpdateReturnsTrue() 
+        {
+            this.cache.AddOrUpdate(1, new Disposable());
+
+            this.cache.TryUpdate(1, new Disposable()).Should().BeTrue();
+        }
+    }
+}

--- a/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
@@ -124,6 +124,22 @@ namespace BitFaster.Caching.UnitTests
         }
 
         [Fact]
+        public void WhenKeyDoesNotExistGetOrAddAddsValue()
+        {
+            this.cache.ScopedGetOrAdd(1, k => new Scoped<Disposable>(new Disposable()));
+
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task WhenKeyDoesNotExistGetOrAddAsyncAddsValue()
+        {
+            await this.cache.ScopedGetOrAddAsync(1, k => Task.FromResult(new Scoped<Disposable>(new Disposable())));
+
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+        }
+
+        [Fact]
         public void GetOrAddDisposedScopeThrows()
         {
             var scope = new Scoped<Disposable>(new Disposable());

--- a/BitFaster.Caching.UnitTests/ScopedTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedTests.cs
@@ -77,26 +77,5 @@ namespace BitFaster.Caching.UnitTests
 
             valueFactory.Disposable.IsDisposed.Should().BeTrue();
         }
-
-        private class DisposableValueFactory
-        {
-            public Disposable Disposable { get; } = new Disposable();
-
-            public Scoped<Disposable> Create(int key)
-            {
-                return new Scoped<Disposable>(this.Disposable);
-            }
-        }
-
-        private class Disposable : IDisposable
-        {
-            public bool IsDisposed { get; set; }
-
-            public void Dispose()
-            {
-                this.IsDisposed.Should().BeFalse();
-                IsDisposed = true;
-            }
-        }
     }
 }

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -38,7 +38,7 @@ namespace BitFaster.Caching
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
         /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
-        /// in the cache, or the new value if the key was not in the dictionary.</returns>
+        /// in the cache, or the new value if the key was not in the cache.</returns>
         V GetOrAdd(K key, Func<K, V> valueFactory);
 
         /// <summary>

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -6,6 +6,11 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
+    /// <summary>
+    /// Represents a generic cache of key/scoped IDisposable value pairs.
+    /// </summary>
+    /// <typeparam name="K">The type of keys in the cache.</typeparam>
+    /// <typeparam name="V">The type of values in the cache.</typeparam>
     public interface IScopedCache<K, V> where V : IDisposable
     {
         /// <summary>
@@ -19,31 +24,31 @@ namespace BitFaster.Caching
         int Count { get; }
 
         /// <summary>
-        /// Attempts to get the value associated with the specified key from the cache.
+        /// Attempts to create a lifetime for the value associated with the specified key from the cache
         /// </summary>
         /// <param name="key">The key of the value to get.</param>
-        /// <param name="lifetime">When this method returns, contains the object from the cache that has the specified key, or the default value of the type if the operation failed.</param>
+        /// <param name="lifetime">When this method returns, contains a lifetime for the object from the cache that has the specified key, or the default value of the type if the operation failed.</param>
         /// <returns>true if the key was found in the cache; otherwise, false.</returns>
-        bool TryGet(K key, out Lifetime<V> lifetime);
+        bool ScopedTryGet(K key, out Lifetime<V> lifetime);
 
         /// <summary>
-        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either the new value, or the 
         /// existing value if the key already exists.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
-        /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
-        /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
-        /// in the cache, or the new value if the key was not in the dictionary.</returns>
-        Lifetime<V> GetOrAdd(K key, Func<K, Scoped<V>> valueFactory);
+        /// <param name="valueFactory">The factory function used to generate a scoped value for the key.</param>
+        /// <returns>The lifetime for the value associated with the key. The lifetime will be either reference the existing value for the key if the key is already 
+        /// in the cache, or the new value if the key was not in the cache.</returns>
+        Lifetime<V> ScopedGetOrAdd(K key, Func<K, Scoped<V>> valueFactory);
 
         /// <summary>
-        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either the new value, or the 
         /// existing value if the key already exists.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
-        /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
-        /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
-        Task<Lifetime<V>> GetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
+        /// <param name="valueFactory">The factory function used to asynchronously generate a scoped value for the key.</param>
+        /// <returns>A task that represents the asynchronous ScopedGetOrAdd operation.</returns>
+        Task<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
 
         /// <summary>
         /// Attempts to remove the value that has the specified key.

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching
+{
+    public interface IScopedCache<K, V> where V : IDisposable
+    {
+        /// <summary>
+        /// Gets the total number of items that can be stored in the cache.
+        /// </summary>
+        int Capacity { get; }
+
+        /// <summary>
+        /// Gets the number of items currently held in the cache.
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// Attempts to get the value associated with the specified key from the cache.
+        /// </summary>
+        /// <param name="key">The key of the value to get.</param>
+        /// <param name="lifetime">When this method returns, contains the object from the cache that has the specified key, or the default value of the type if the operation failed.</param>
+        /// <returns>true if the key was found in the cache; otherwise, false.</returns>
+        bool TryGet(K key, out Lifetime<V> lifetime);
+
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
+        /// in the cache, or the new value if the key was not in the dictionary.</returns>
+        Lifetime<V> GetOrAdd(K key, Func<K, Scoped<V>> valueFactory);
+
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
+        /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
+        Task<Lifetime<V>> GetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
+
+        /// <summary>
+        /// Attempts to remove the value that has the specified key.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <returns>true if the object was removed successfully; otherwise, false.</returns>
+        bool TryRemove(K key);
+
+        /// <summary>
+        /// Attempts to update the value that has the specified key.
+        /// </summary>
+        /// <param name="key">The key of the element to update.</param>
+        /// <param name="value">The new value.</param>
+        /// <returns>true if the object was updated successfully; otherwise, false.</returns>
+        bool TryUpdate(K key, V value);
+
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist, or updates a key/value pair if the 
+        /// key already exists.
+        /// </summary>
+        /// <param name="key">The key of the element to update.</param>
+        /// <param name="value">The new value.</param>
+        void AddOrUpdate(K key, V value);
+
+        /// <summary>
+        /// Removes all keys and values from the cache.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
+        /// Trim the specified number of items from the cache.
+        /// </summary>
+        /// <param name="itemCount">The number of items to remove.</param>
+        void Trim(int itemCount);
+    }
+}

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -16,8 +16,10 @@ namespace BitFaster.Caching
     /// <typeparam name="V">The type of values in the cache.</typeparam>
     public class ScopedCache<K, V> : IScopedCache<K, V> where V : IDisposable
     {
-        private const int MaxRetry = 5;
         private readonly ICache<K, Scoped<V>> cache;
+
+        private const int MaxRetry = 5;
+        private static readonly string RetryFailureMessage = $"Exceeded {MaxRetry} attempts to create a lifetime.";
 
         public ScopedCache(ICache<K, Scoped<V>> cache)
         {
@@ -65,7 +67,7 @@ namespace BitFaster.Caching
 
                 if (c++ > MaxRetry)
                 {
-                    throw new InvalidOperationException();
+                    throw new InvalidOperationException(RetryFailureMessage);
                 }
             }
         }
@@ -88,7 +90,7 @@ namespace BitFaster.Caching
 
                 if (c++ > MaxRetry)
                 {
-                    throw new InvalidOperationException();
+                    throw new InvalidOperationException(RetryFailureMessage);
                 }
             }
         }

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -21,6 +21,11 @@ namespace BitFaster.Caching
 
         public ScopedCache(ICache<K, Scoped<V>> cache)
         {
+            if (cache == null)
+            {
+                throw new ArgumentNullException(nameof(cache));
+            }
+
             this.cache = cache;
         }
 

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching
+{
+    // simple decorator, compatible with all ICache
+    public class ScopedCache<K, V> : IScopedCache<K, V> where V : IDisposable
+    {
+        private readonly ICache<K, Scoped<V>> cache;
+
+        public ScopedCache(ICache<K, Scoped<V>> cache)
+        {
+            this.cache = cache;
+        }
+
+        public int Capacity => this.cache.Capacity;
+
+        public int Count => this.cache.Count;
+
+        public void AddOrUpdate(K key, V value)
+        {
+            this.cache.AddOrUpdate(key, new Scoped<V>(value));
+        }
+
+        public void Clear()
+        {
+            this.cache.Clear();
+        }
+
+        public Lifetime<V> GetOrAdd(K key, Func<K, Scoped<V>> valueFactory)
+        {
+            var spinwait = new SpinWait();
+            while (true)
+            {
+                var scope = cache.GetOrAdd(key, k => valueFactory(k));
+
+                if (scope.TryCreateLifetime(out var lifetime))
+                {
+                    return lifetime;
+                }
+
+                spinwait.SpinOnce();
+            }
+        }
+
+        public async Task<Lifetime<V>> GetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
+        {
+            var spinwait = new SpinWait();
+            while (true)
+            {
+                var scope = await cache.GetOrAddAsync(key, valueFactory);
+
+                if (scope.TryCreateLifetime(out var lifetime))
+                {
+                    return lifetime;
+                }
+
+                spinwait.SpinOnce();
+            }
+        }
+
+        public void Trim(int itemCount)
+        {
+            this.cache.Trim(itemCount);
+        }
+
+        public bool TryGet(K key, out Lifetime<V> lifetime)
+        {
+            if (this.cache.TryGet(key, out var scope))
+            {
+                if (scope.TryCreateLifetime(out lifetime))
+                {
+                    return true;
+                }
+            }
+
+            lifetime = default;
+            return false;
+        }
+
+        public bool TryRemove(K key)
+        {
+            return this.cache.TryRemove(key);
+        }
+
+        public bool TryUpdate(K key, V value)
+        {
+            return this.cache.TryUpdate(key, new Scoped<V>(value));
+        }
+    }
+}


### PR DESCRIPTION
Provide an explicit ScopedCache to ease working with scoped IDisposable values. All read operations are prefixed with 'Scoped' and return lifetimes instead of values. Scoped methods implement logic to ensure the lifetime returned is always valid.

```cs
public class Foo
{
    private const int capacity = 666;
    private ScopedCache<int, SomeDisposable> lru = new(new ConcurrentLru<int, Scoped<SomeDisposable>>(capacity));

    public void Bar()
    {
        var valueFactory = new SomeDisposableValueFactory();

        using (var lifetime = lru.ScopedGetOrAdd(1, k => valueFactory.Create(k)))
        {
            // lifetime.Value is guaranteed to be alive until the lifetime is disposed
        }
    }
}

public class SomeDisposableValueFactory
{
    public Scoped<SomeDisposable> Create(int key)
    {
        return new Scoped<SomeDisposable>(new SomeDisposable(key));
    }
}
```
