### PR TITLE
metrics

### DIFF
--- a/BitFaster.Caching.HitRateAnalysis/Arc/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Analysis.cs
@@ -24,9 +24,9 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
 
         public int CacheSize => concurrentLru.Capacity;
 
-        public double ConcurrentLruHitRate => concurrentLru.HitRatio * 100;
+        public double ConcurrentLruHitRate => concurrentLru.Metrics.HitRatio * 100;
 
-        public double ClassicLruHitRate => classicLru.HitRatio * 100;
+        public double ClassicLruHitRate => classicLru.Metrics.HitRatio * 100;
 
         public void TestKey(long key)
         {

--- a/BitFaster.Caching.HitRateAnalysis/Glimpse/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Glimpse/Analysis.cs
@@ -24,9 +24,9 @@ namespace BitFaster.Caching.HitRateAnalysis.Glimpse
 
         public int CacheSize => this.concurrentLru.Capacity;
 
-        public double ConcurrentLruHitRate => this.concurrentLru.HitRatio * 100;
+        public double ConcurrentLruHitRate => this.concurrentLru.Metrics.HitRatio * 100;
 
-        public double ClassicLruHitRate => this.classicLru.HitRatio * 100;
+        public double ClassicLruHitRate => this.classicLru.Metrics.HitRatio * 100;
 
         public void TestKey(long key)
         {

--- a/BitFaster.Caching.HitRateAnalysis/Wikibench/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Wikibench/Analysis.cs
@@ -24,9 +24,9 @@ namespace BitFaster.Caching.HitRateAnalysis.Wikibench
 
         public int CacheSize => this.concurrentLru.Capacity;
 
-        public double ConcurrentLruHitRate => this.concurrentLru.HitRatio * 100;
+        public double ConcurrentLruHitRate => this.concurrentLru.Metrics.HitRatio * 100;
 
-        public double ClassicLruHitRate => this.classicLru.HitRatio * 100;
+        public double ClassicLruHitRate => this.classicLru.Metrics.HitRatio * 100;
 
         public void TestUri(Uri uri)
         {

--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
@@ -134,7 +134,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
                     CacheSizePercent = a.CacheSizePercent * 100.0,
                     Samples = a.Samples,
                     IsScan = false,
-                    HitRatio = concurrentLru.HitRatio * 100.0,
+                    HitRatio = concurrentLru.Metrics.HitRatio * 100.0,
                     Duration = lruSw.Elapsed,
                 });
 
@@ -146,7 +146,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
                     CacheSizePercent = a.CacheSizePercent * 100.0,
                     Samples = a.Samples,
                     IsScan = true,
-                    HitRatio = classicLruScan.HitRatio * 100.0,
+                    HitRatio = classicLruScan.Metrics.HitRatio * 100.0,
                     Duration = clruSwScan.Elapsed,
                 });
 
@@ -158,7 +158,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
                     CacheSizePercent = a.CacheSizePercent * 100.0,
                     Samples = a.Samples,
                     IsScan = true,
-                    HitRatio = concurrentLruScan.HitRatio * 100.0,
+                    HitRatio = concurrentLruScan.Metrics.HitRatio * 100.0,
                     Duration = lruSwScan.Elapsed,
                 });
             }

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -118,7 +118,51 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             lru.HitRatio.Should().Be(0.5);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [Fact]
+        public void MetricsAreEnabled()
+        {
+            lru.Metrics.IsEnabled.Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenItemIsAddedThenRetrievedMetricHitRatioIsHalf()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+            bool result = lru.TryGet(1, out var value);
+
+            lru.Metrics.HitRatio.Should().Be(0.5);
+        }
+
+        [Fact]
+        public void WhenItemIsAddedThenRetrievedMetricHitsIs1()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+            bool result = lru.TryGet(1, out var value);
+
+            lru.Metrics.Hits.Should().Be(1);
+        }
+
+        [Fact]
+        public void WhenItemIsAddedThenRetrievedMetricTotalIs2()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+            bool result = lru.TryGet(1, out var value);
+
+            lru.Metrics.Total.Should().Be(2);
+        }
+
+        [Fact]
+        public void WhenItemDoesNotExistTryGetIncrementsMiss()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+            bool result = lru.TryGet(1, out var value);
+
+            lru.Metrics.Misses.Should().Be(1);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -184,7 +184,9 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             lru.HitRatio.Should().Be(0.5);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -190,6 +190,15 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenItemIsAddedThenRetrievedMetricHitRatioIsHalf()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+            bool result = lru.TryGet(1, out var value);
+
+            lru.Metrics.HitRatio.Should().Be(0.5);
+        }
+
+        [Fact]
         public void WhenKeyIsRequestedItIsCreatedAndCached()
         {
             var result1 = lru.GetOrAdd(1, valueFactory.Create);

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -130,7 +130,9 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             lru.HitRatio.Should().Be(0.5);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/NoTelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/NoTelemetryPolicyTests.cs
@@ -18,6 +18,30 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void TotalIsZero()
+        {
+            counter.Total.Should().Be(0);
+        }
+
+        [Fact]
+        public void HitsIsZero()
+        {
+            counter.Hits.Should().Be(0);
+        }
+
+        [Fact]
+        public void MissesIsZero()
+        {
+            counter.Misses.Should().Be(0);
+        }
+
+        [Fact]
+        public void IsEnabledIsFalse()
+        {
+            counter.IsEnabled.Should().BeFalse();
+        }
+
+        [Fact]
         public void IncrementHitCountIsNoOp()
         {
             counter.Invoking(c => c.IncrementHit()).Should().NotThrow();

--- a/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
@@ -12,6 +12,36 @@ namespace BitFaster.Caching.UnitTests.Lru
         private TelemetryPolicy<int, int> telemetryPolicy = default;
 
         [Fact]
+        public void WhenHitTotalIs1()
+        {
+            telemetryPolicy.Total.Should().Be(0);
+            telemetryPolicy.IncrementHit();
+            telemetryPolicy.Total.Should().Be(1);
+        }
+
+        [Fact]
+        public void WhenHitHitsIs1()
+        {
+            telemetryPolicy.Hits.Should().Be(0);
+            telemetryPolicy.IncrementHit();
+            telemetryPolicy.Hits.Should().Be(1);
+        }
+
+        [Fact]
+        public void WhenMissMissesIs1()
+        {
+            telemetryPolicy.Misses.Should().Be(0);
+            telemetryPolicy.IncrementMiss();
+            telemetryPolicy.Misses.Should().Be(1);
+        }
+
+        [Fact]
+        public void IsEnabledIsTrue()
+        {
+            telemetryPolicy.IsEnabled.Should().BeTrue();
+        }
+
+        [Fact]
         public void WhenHitCountAndTotalCountAreEqualRatioIs1()
         {
             telemetryPolicy.IncrementHit();

--- a/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
@@ -39,6 +39,16 @@ namespace BitFaster.Caching.UnitTests
         }
 
         [Fact]
+        public void WhenItemIsAddedThenLookedUpMetricsAreCorrect()
+        {
+            this.cache.AddOrUpdate(1, new Disposable());
+            this.cache.ScopedGetOrAdd(1, k => new Scoped<Disposable>(new Disposable()));
+
+            this.cache.Metrics.Misses.Should().Be(0);
+            this.cache.Metrics.Hits.Should().Be(1);
+        }
+
+        [Fact]
         public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()
         {
             var d = new Disposable();

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -23,6 +23,8 @@ namespace BitFaster.Caching
         /// </summary>
         int Count { get; }
 
+        ICacheMetrics Metrics { get; }
+
         /// <summary>
         /// Attempts to get the value associated with the specified key from the cache.
         /// </summary>

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -23,6 +23,9 @@ namespace BitFaster.Caching
         /// </summary>
         int Count { get; }
 
+        /// <summary>
+        /// Gets the cache metrics.
+        /// </summary>
         ICacheMetrics Metrics { get; }
 
         /// <summary>

--- a/BitFaster.Caching/ICacheMetrics.cs
+++ b/BitFaster.Caching/ICacheMetrics.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching
+{
+    public interface ICacheMetrics
+    {
+        /// <summary>
+        /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
+        /// </summary>
+        double HitRatio { get; }
+
+        /// <summary>
+        /// Gets the total number of requests made to the cache.
+        /// </summary>
+        long Total { get; }
+
+        //bool IsEnabled { get; }
+    }
+}

--- a/BitFaster.Caching/ICacheMetrics.cs
+++ b/BitFaster.Caching/ICacheMetrics.cs
@@ -6,6 +6,11 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
+    /// <summary>
+    /// Represents cache metrics collected over the lifetime of the cache.
+    /// If metrics are disabled, the IsEnabled property returns false
+    /// and all other properties return zero.
+    /// </summary>
     public interface ICacheMetrics
     {
         /// <summary>
@@ -18,6 +23,19 @@ namespace BitFaster.Caching
         /// </summary>
         long Total { get; }
 
-        //bool IsEnabled { get; }
+        /// <summary>
+        /// Gets the total number of cache hits.
+        /// </summary>
+        long Hits { get; }
+
+        /// <summary>
+        /// Gets the total number of cache misses.
+        /// </summary>
+        long Misses { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether metrics are enabled.
+        /// </summary>
+        bool IsEnabled { get; }
     }
 }

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -24,6 +24,11 @@ namespace BitFaster.Caching
         int Count { get; }
 
         /// <summary>
+        /// Gets the cache metrics.
+        /// </summary>
+        ICacheMetrics Metrics { get; }
+
+        /// <summary>
         /// Attempts to create a lifetime for the value associated with the specified key from the cache
         /// </summary>
         /// <param name="key">The key of the value to get.</param>

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -56,6 +56,7 @@ namespace BitFaster.Caching.Lru
         /// <summary>
         /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
         /// </summary>
+        [ObsoleteAttribute("This property is obsolete. Use Metrics instead.", false)]
         public double HitRatio => this.Metrics.HitRatio;
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -59,7 +59,7 @@ namespace BitFaster.Caching.Lru
         public double HitRatio => this.Metrics.HitRatio;
 
         ///<inheritdoc/>
-        public ICacheMetrics Metrics => this.Metrics;
+        public ICacheMetrics Metrics => this.metrics;
 
         /// <summary>
         /// Gets a collection containing the keys in the cache.

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -24,8 +24,7 @@ namespace BitFaster.Caching.Lru
         private readonly ConcurrentDictionary<K, LinkedListNode<LruItem>> dictionary;
         private readonly LinkedList<LruItem> linkedList = new LinkedList<LruItem>();
 
-        private long requestHitCount;
-        private long requestTotalCount;
+        private readonly CacheMetrics metrics = new CacheMetrics();
 
         public ClassicLru(int capacity)
             : this(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default)
@@ -57,7 +56,10 @@ namespace BitFaster.Caching.Lru
         /// <summary>
         /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
         /// </summary>
-        public double HitRatio => (double)requestHitCount / (double)requestTotalCount;
+        public double HitRatio => this.Metrics.HitRatio;
+
+        ///<inheritdoc/>
+        public ICacheMetrics Metrics => this.Metrics;
 
         /// <summary>
         /// Gets a collection containing the keys in the cache.
@@ -83,12 +85,12 @@ namespace BitFaster.Caching.Lru
         ///<inheritdoc/>
         public bool TryGet(K key, out V value)
         {
-            Interlocked.Increment(ref requestTotalCount);
+            Interlocked.Increment(ref this.metrics.requestTotalCount);
 
             if (dictionary.TryGetValue(key, out var node))
             {
                 LockAndMoveToEnd(node);
-                Interlocked.Increment(ref requestHitCount);
+                Interlocked.Increment(ref this.metrics.requestHitCount);
                 value = node.Value.Value;
                 return true;
             }
@@ -365,6 +367,16 @@ namespace BitFaster.Caching.Lru
             public K Key { get; }
 
             public V Value { get; set; }
+        }
+
+        private class CacheMetrics : ICacheMetrics
+        {
+            public long requestHitCount;
+            public long requestTotalCount;
+
+            public double HitRatio => (double)requestHitCount / (double)requestTotalCount;
+
+            public long Total => requestTotalCount;
         }
     }
 }

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -377,6 +377,12 @@ namespace BitFaster.Caching.Lru
             public double HitRatio => (double)requestHitCount / (double)requestTotalCount;
 
             public long Total => requestTotalCount;
+
+            public long Hits => requestHitCount;
+
+            public long Misses => requestTotalCount - requestHitCount;
+
+            public bool IsEnabled => true;
         }
     }
 }

--- a/BitFaster.Caching/Lru/ConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLru.cs
@@ -46,6 +46,7 @@ namespace BitFaster.Caching.Lru
         /// <summary>
         /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
         /// </summary>
+        [ObsoleteAttribute("This property is obsolete. Use Metrics instead.", false)]
         public double HitRatio => this.telemetryPolicy.HitRatio;
 
         /// <summary>

--- a/BitFaster.Caching/Lru/ConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentTLru.cs
@@ -49,6 +49,7 @@ namespace BitFaster.Caching.Lru
         /// <summary>
         /// Gets the ratio of hits to misses, where a value of 1 indicates 100% hits.
         /// </summary>
+        [ObsoleteAttribute("This property is obsolete. Use Metrics instead.", false)]
         public double HitRatio => this.telemetryPolicy.HitRatio;
 
         /// <summary>

--- a/BitFaster.Caching/Lru/ITelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/ITelemetryPolicy.cs
@@ -14,8 +14,6 @@ namespace BitFaster.Caching.Lru
 
         void OnItemRemoved(K key, V value, ItemRemovedReason reason);
 
-        //double HitRatio { get; }
-
         void SetEventSource(object source);
     }
 }

--- a/BitFaster.Caching/Lru/ITelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/ITelemetryPolicy.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Lru
 {
-    public interface ITelemetryPolicy<K, V>
+    public interface ITelemetryPolicy<K, V> : ICacheMetrics
     {
         void IncrementMiss();
 
@@ -14,7 +14,7 @@ namespace BitFaster.Caching.Lru
 
         void OnItemRemoved(K key, V value, ItemRemovedReason reason);
 
-        double HitRatio { get; }
+        //double HitRatio { get; }
 
         void SetEventSource(object source);
     }

--- a/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
@@ -11,6 +11,8 @@ namespace BitFaster.Caching.Lru
     {
         public double HitRatio => 0.0;
 
+        public long Total => 0;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void IncrementMiss()
         {

--- a/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
@@ -13,6 +13,12 @@ namespace BitFaster.Caching.Lru
 
         public long Total => 0;
 
+        public long Hits => 0;
+
+        public long Misses => 0;
+
+        public bool IsEnabled => false;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void IncrementMiss()
         {

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -18,6 +18,12 @@ namespace BitFaster.Caching.Lru
 
         public long Total => this.hitCount + this.missCount;
 
+        public long Hits => this.hitCount;
+
+        public long Misses => this.missCount;
+
+        public bool IsEnabled => true;
+
         public EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
 
         public void IncrementMiss()

--- a/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
@@ -91,6 +91,7 @@ namespace BitFaster.Caching.Lru
         ///<inheritdoc/>
         public int Capacity => this.capacity.Hot + this.capacity.Warm + this.capacity.Cold;
 
+        ///<inheritdoc/>
         public ICacheMetrics Metrics => this.telemetryPolicy;
 
         public int HotCount => this.hotCount;

--- a/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
@@ -91,6 +91,8 @@ namespace BitFaster.Caching.Lru
         ///<inheritdoc/>
         public int Capacity => this.capacity.Hot + this.capacity.Warm + this.capacity.Cold;
 
+        public ICacheMetrics Metrics => this.telemetryPolicy;
+
         public int HotCount => this.hotCount;
 
         public int WarmCount => this.warmCount;

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -37,6 +37,8 @@ namespace BitFaster.Caching
         ///<inheritdoc/>
         public int Count => this.cache.Count;
 
+        public ICacheMetrics Metrics => this.cache.Metrics;
+
         ///<inheritdoc/>
         public void AddOrUpdate(K key, V value)
         {

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -37,6 +37,7 @@ namespace BitFaster.Caching
         ///<inheritdoc/>
         public int Count => this.cache.Count;
 
+        ///<inheritdoc/>
         public ICacheMetrics Metrics => this.cache.Metrics;
 
         ///<inheritdoc/>


### PR DESCRIPTION
Provide ICacheMetrics, and plumb through ICache and IScopedCache, enabling metrics to be used consistently with all caches. Mark old HitRatio as obsolete and fix references.

First step towards having common base interfaces for all combinations of metrics/events/policy etc.