### PR TITLE
events

### DIFF
--- a/BitFaster.Caching.Benchmarks/Lru/LruCycleBench.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruCycleBench.cs
@@ -41,7 +41,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
         [GlobalSetup]
         public void GlobalSetup()
         {
-            concurrentLruEvent.ItemRemoved += OnItemRemoved;
+            concurrentLruEvent.Events.ItemRemoved += OnItemRemoved;
         }
 
         public static int field;

--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
@@ -122,7 +122,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
                     CacheSizePercent = a.CacheSizePercent * 100.0,
                     Samples = a.Samples,
                     IsScan = false,
-                    HitRatio = classicLru.HitRatio * 100.0,
+                    HitRatio = classicLru.Metrics.HitRatio * 100.0,
                     Duration = clruSw.Elapsed,
                 });
 

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -166,6 +166,24 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void EventsAreEnabled()
+        {
+            lru.Events.IsEnabled.Should().BeFalse();
+        }
+
+        [Fact]
+        public void RegisterAndUnregisterIsNoOp()
+        {
+            lru.Events.ItemRemoved += OnItemRemoved;
+            lru.Events.ItemRemoved -= OnItemRemoved;
+        }
+
+        private void OnItemRemoved(object sender, ItemRemovedEventArgs<int, string> e)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Fact]
         public void WhenKeyIsRequestedItIsCreatedAndCached()
         {
             var result1 = lru.GetOrAdd(1, valueFactory.Create);

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -469,12 +469,39 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
-        public void WhenValueEvictedItemRemovedEventIsFired()
+        public void WhenValueEvictedItemRemovedDeprecatedEventIsFired()
         {
             var lruEvents = new ConcurrentLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default);
 #pragma warning disable CS0618 // Type or member is obsolete
             lruEvents.ItemRemoved += OnLruItemRemoved;
 #pragma warning restore CS0618 // Type or member is obsolete
+
+            // First 6 adds
+            // hot[6, 5], warm[2, 1], cold[4, 3]
+            // =>
+            // hot[8, 7], warm[1, 0], cold[6, 5], evicted[4, 3]
+            for (int i = 0; i < 8; i++)
+            {
+                lruEvents.GetOrAdd(i + 1, i => i + 1);
+            }
+
+            removedItems.Count.Should().Be(2);
+
+            removedItems[0].Key.Should().Be(3);
+            removedItems[0].Value.Should().Be(4);
+            removedItems[0].Reason.Should().Be(ItemRemovedReason.Evicted);
+
+            removedItems[1].Key.Should().Be(4);
+            removedItems[1].Value.Should().Be(5);
+            removedItems[1].Reason.Should().Be(ItemRemovedReason.Evicted);
+        }
+
+
+        [Fact]
+        public void WhenValueEvictedItemRemovedEventIsFired()
+        {
+            var lruEvents = new ConcurrentLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default);
+            lruEvents.Events.ItemRemoved += OnLruItemRemoved;
 
             // First 6 adds
             // hot[6, 5], warm[2, 1], cold[4, 3]
@@ -511,10 +538,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var lruEvents = new ConcurrentLru<int, int>(1, 6, EqualityComparer<int>.Default);
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            lruEvents.ItemRemoved += OnLruItemRemoved;
-            lruEvents.ItemRemoved -= OnLruItemRemoved;
-#pragma warning restore CS0618 // Type or member is obsolete
+            lruEvents.Events.ItemRemoved += OnLruItemRemoved;
+            lruEvents.Events.ItemRemoved -= OnLruItemRemoved;
 
             for (int i = 0; i < 6; i++)
             {
@@ -549,9 +574,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsRemovedRemovedEventIsFired()
         {
             var lruEvents = new ConcurrentLru<int, int>(1, 6, EqualityComparer<int>.Default);
-#pragma warning disable CS0618 // Type or member is obsolete
-            lruEvents.ItemRemoved += OnLruItemRemoved;
-#pragma warning restore CS0618 // Type or member is obsolete
+            lruEvents.Events.ItemRemoved += OnLruItemRemoved;
 
             lruEvents.GetOrAdd(1, i => i + 2);
 
@@ -703,29 +726,6 @@ namespace BitFaster.Caching.UnitTests.Lru
 
         [Fact]
         public void WhenItemsArClearedAnEventIsFired()
-        {
-            var lruEvents = new ConcurrentLru<int, int>(1, capacity, EqualityComparer<int>.Default);
-#pragma warning disable CS0618 // Type or member is obsolete
-            lruEvents.ItemRemoved += OnLruItemRemoved;
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            for (int i = 0; i < 6; i++)
-            {
-                lruEvents.GetOrAdd(i + 1, i => i + 1);
-            }
-
-            lruEvents.Clear();
-
-            removedItems.Count.Should().Be(6);
-
-            for (int i = 0; i < 6; i++)
-            {
-                removedItems[i].Reason.Should().Be(ItemRemovedReason.Cleared);
-            }
-        }
-
-        [Fact]
-        public void WhenItemsArClearedAMetricsEventIsFired()
         {
             var lruEvents = new ConcurrentLru<int, int>(1, capacity, EqualityComparer<int>.Default);
             lruEvents.Events.ItemRemoved += OnLruItemRemoved;
@@ -918,9 +918,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemsAreTrimmedAnEventIsFired()
         {
             var lruEvents = new ConcurrentLru<int, int>(1, capacity, EqualityComparer<int>.Default);
-#pragma warning disable CS0618 // Type or member is obsolete
-            lruEvents.ItemRemoved += OnLruItemRemoved;
-#pragma warning restore CS0618 // Type or member is obsolete
+            lruEvents.Events.ItemRemoved += OnLruItemRemoved;
 
             for (int i = 0; i < 6; i++)
             {

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -472,7 +472,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenValueEvictedItemRemovedEventIsFired()
         {
             var lruEvents = new ConcurrentLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default);
+#pragma warning disable CS0618 // Type or member is obsolete
             lruEvents.ItemRemoved += OnLruItemRemoved;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // First 6 adds
             // hot[6, 5], warm[2, 1], cold[4, 3]
@@ -509,8 +511,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var lruEvents = new ConcurrentLru<int, int>(1, 6, EqualityComparer<int>.Default);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             lruEvents.ItemRemoved += OnLruItemRemoved;
             lruEvents.ItemRemoved -= OnLruItemRemoved;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             for (int i = 0; i < 6; i++)
             {
@@ -545,7 +549,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsRemovedRemovedEventIsFired()
         {
             var lruEvents = new ConcurrentLru<int, int>(1, 6, EqualityComparer<int>.Default);
+#pragma warning disable CS0618 // Type or member is obsolete
             lruEvents.ItemRemoved += OnLruItemRemoved;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             lruEvents.GetOrAdd(1, i => i + 2);
 
@@ -699,7 +705,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemsArClearedAnEventIsFired()
         {
             var lruEvents = new ConcurrentLru<int, int>(1, capacity, EqualityComparer<int>.Default);
+#pragma warning disable CS0618 // Type or member is obsolete
             lruEvents.ItemRemoved += OnLruItemRemoved;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             for (int i = 0; i < 6; i++)
             {
@@ -889,7 +897,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemsAreTrimmedAnEventIsFired()
         {
             var lruEvents = new ConcurrentLru<int, int>(1, capacity, EqualityComparer<int>.Default);
+#pragma warning disable CS0618 // Type or member is obsolete
             lruEvents.ItemRemoved += OnLruItemRemoved;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             for (int i = 0; i < 6; i++)
             {

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -725,6 +725,30 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenItemsArClearedAMetricsEventIsFired()
+        {
+            var lruEvents = new ConcurrentLru<int, int>(1, capacity, EqualityComparer<int>.Default);
+            lruEvents.Events.ItemRemoved += OnLruItemRemoved;
+
+            // looks like this struct is being copied defensively, so the assign above is lost
+            var e2 = lru.Events;
+
+            for (int i = 0; i < 6; i++)
+            {
+                lruEvents.GetOrAdd(i + 1, i => i + 1);
+            }
+
+            lruEvents.Clear();
+
+            removedItems.Count.Should().Be(6);
+
+            for (int i = 0; i < 6; i++)
+            {
+                removedItems[i].Reason.Should().Be(ItemRemovedReason.Cleared);
+            }
+        }
+
+        [Fact]
         public void WhenTrimCountIsZeroThrows()
         {
             lru.Invoking(l => lru.Trim(0)).Should().Throw<ArgumentOutOfRangeException>();

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -730,9 +730,6 @@ namespace BitFaster.Caching.UnitTests.Lru
             var lruEvents = new ConcurrentLru<int, int>(1, capacity, EqualityComparer<int>.Default);
             lruEvents.Events.ItemRemoved += OnLruItemRemoved;
 
-            // looks like this struct is being copied defensively, so the assign above is lost
-            var e2 = lru.Events;
-
             for (int i = 0; i < 6; i++)
             {
                 lruEvents.GetOrAdd(i + 1, i => i + 1);

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -86,7 +86,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenValueEvictedItemRemovedEventIsFired()
         {
             var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
+#pragma warning disable CS0618 // Type or member is obsolete
             lruEvents.ItemRemoved += OnLruItemRemoved;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // First 6 adds
             // hot[6, 5], warm[2, 1], cold[4, 3]
@@ -113,8 +115,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             lruEvents.ItemRemoved += OnLruItemRemoved;
             lruEvents.ItemRemoved -= OnLruItemRemoved;
+#pragma warning restore CS0618 // Type or member is obsolete
 
             for (int i = 0; i < 6; i++)
             {

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -83,7 +83,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
-        public void WhenValueEvictedItemRemovedEventIsFired()
+        public void WhenValueEvictedItemRemovedDeprecatedEventIsFired()
         {
             var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -111,14 +111,37 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenValueEvictedItemRemovedEventIsFired()
+        {
+            var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
+            lruEvents.Events.ItemRemoved += OnLruItemRemoved;
+
+            // First 6 adds
+            // hot[6, 5], warm[2, 1], cold[4, 3]
+            // =>
+            // hot[8, 7], warm[1, 0], cold[6, 5], evicted[4, 3]
+            for (int i = 0; i < 8; i++)
+            {
+                lruEvents.GetOrAdd(i + 1, i => i + 1);
+            }
+
+            removedItems.Count.Should().Be(2);
+
+            removedItems[0].Key.Should().Be(3);
+            removedItems[0].Value.Should().Be(4);
+            removedItems[0].Reason.Should().Be(ItemRemovedReason.Evicted);
+
+            removedItems[1].Key.Should().Be(4);
+            removedItems[1].Value.Should().Be(5);
+            removedItems[1].Reason.Should().Be(ItemRemovedReason.Evicted);
+        }
+
+        [Fact]
         public void WhenItemRemovedEventIsUnregisteredEventIsNotFired()
         {
             var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
-
-#pragma warning disable CS0618 // Type or member is obsolete
-            lruEvents.ItemRemoved += OnLruItemRemoved;
-            lruEvents.ItemRemoved -= OnLruItemRemoved;
-#pragma warning restore CS0618 // Type or member is obsolete
+            lruEvents.Events.ItemRemoved += OnLruItemRemoved;
+            lruEvents.Events.ItemRemoved -= OnLruItemRemoved;
 
             for (int i = 0; i < 6; i++)
             {

--- a/BitFaster.Caching.UnitTests/Lru/NoTelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/NoTelemetryPolicyTests.cs
@@ -64,5 +64,16 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             counter.Invoking(c => c.OnItemRemoved(1, 2, ItemRemovedReason.Evicted)).Should().NotThrow();
         }
+
+        [Fact]
+        public void RegisterEventHandlerIsNoOp()
+        {
+            counter.ItemRemoved += OnItemRemoved;
+            counter.ItemRemoved -= OnItemRemoved;
+        }
+
+        private void OnItemRemoved(object sender, ItemRemovedEventArgs<int, int> e)
+        {
+        }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
@@ -11,6 +11,11 @@ namespace BitFaster.Caching.UnitTests.Lru
     {
         private TelemetryPolicy<int, int> telemetryPolicy = default;
 
+        public TelemetryPolicyTests()
+        {
+            telemetryPolicy.SetEventSource(this);
+        }
+
         [Fact]
         public void WhenHitTotalIs1()
         {
@@ -100,9 +105,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             List<object> eventSourceList = new();
 
+            telemetryPolicy.SetEventSource(this);
+
             telemetryPolicy.ItemRemoved += (source, args) => eventSourceList.Add(source);
 
-            telemetryPolicy.SetEventSource(this);
             telemetryPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
 
             eventSourceList.Should().HaveCount(1);

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -29,6 +29,11 @@ namespace BitFaster.Caching
         ICacheMetrics Metrics { get; }
 
         /// <summary>
+        /// Gets the cache events.
+        /// </summary>
+        ICacheEvents<K, V> Events { get; }
+
+        /// <summary>
         /// Attempts to get the value associated with the specified key from the cache.
         /// </summary>
         /// <param name="key">The key of the value to get.</param>

--- a/BitFaster.Caching/ICacheEvents.cs
+++ b/BitFaster.Caching/ICacheEvents.cs
@@ -7,6 +7,10 @@ using BitFaster.Caching.Lru;
 
 namespace BitFaster.Caching
 {
+    /// <summary>
+    /// Represents the events that fire when actions are performed on the cache.
+    /// If events are disabled, no events will be registered, and none will fire.
+    /// </summary>
     public interface ICacheEvents<K, V>
     {
         /// <summary>

--- a/BitFaster.Caching/ICacheEvents.cs
+++ b/BitFaster.Caching/ICacheEvents.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BitFaster.Caching.Lru;
+
+namespace BitFaster.Caching
+{
+    public interface ICacheEvents<K, V>
+    {
+        /// <summary>
+        /// Occurs when an item is removed from the cache.
+        /// </summary>
+        event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
+
+        /// <summary>
+        /// Gets a value indicating whether events are enabled.
+        /// </summary>
+        bool IsEnabled { get; }
+    }
+}

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -31,29 +31,35 @@ namespace BitFaster.Caching
         /// <summary>
         /// Gets the cache events.
         /// </summary>
+        /// <remarks>
+        /// Events expose the Scoped instance wrapping each value. To keep the value alive (blocking Dispose), try to 
+        /// create a Lifetime from the scope.
+        /// </remarks>
         ICacheEvents<K, Scoped<V>> Events { get; }
 
         /// <summary>
         /// Attempts to create a lifetime for the value associated with the specified key from the cache
         /// </summary>
         /// <param name="key">The key of the value to get.</param>
-        /// <param name="lifetime">When this method returns, contains a lifetime for the object from the cache that has the specified key, or the default value of the type if the operation failed.</param>
+        /// <param name="lifetime">When this method returns, contains a lifetime for the object from the cache that 
+        /// has the specified key, or the default value of the type if the operation failed.</param>
         /// <returns>true if the key was found in the cache; otherwise, false.</returns>
         bool ScopedTryGet(K key, out Lifetime<V> lifetime);
 
         /// <summary>
-        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either the new value, or the 
-        /// existing value if the key already exists.
+        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
+        /// the new value, or the existing value if the key already exists.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The factory function used to generate a scoped value for the key.</param>
-        /// <returns>The lifetime for the value associated with the key. The lifetime will be either reference the existing value for the key if the key is already 
-        /// in the cache, or the new value if the key was not in the cache.</returns>
+        /// <returns>The lifetime for the value associated with the key. The lifetime will be either reference the 
+        /// existing value for the key if the key is already in the cache, or the new value if the key was not in 
+        /// the cache.</returns>
         Lifetime<V> ScopedGetOrAdd(K key, Func<K, Scoped<V>> valueFactory);
 
         /// <summary>
-        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either the new value, or the 
-        /// existing value if the key already exists.
+        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
+        /// the new value, or the existing value if the key already exists.
         /// </summary>
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The factory function used to asynchronously generate a scoped value for the key.</param>

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -29,6 +29,11 @@ namespace BitFaster.Caching
         ICacheMetrics Metrics { get; }
 
         /// <summary>
+        /// Gets the cache events.
+        /// </summary>
+        ICacheEvents<K, Scoped<V>> Events { get; }
+
+        /// <summary>
         /// Attempts to create a lifetime for the value associated with the specified key from the cache
         /// </summary>
         /// <param name="key">The key of the value to get.</param>

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -25,6 +25,7 @@ namespace BitFaster.Caching.Lru
         private readonly LinkedList<LruItem> linkedList = new LinkedList<LruItem>();
 
         private readonly CacheMetrics metrics = new CacheMetrics();
+        private readonly CacheEvents events = new CacheEvents();
 
         public ClassicLru(int capacity)
             : this(Defaults.ConcurrencyLevel, capacity, EqualityComparer<K>.Default)
@@ -61,6 +62,8 @@ namespace BitFaster.Caching.Lru
 
         ///<inheritdoc/>
         public ICacheMetrics Metrics => this.metrics;
+
+        public ICacheEvents<K, V> Events => this.events;
 
         /// <summary>
         /// Gets a collection containing the keys in the cache.
@@ -390,6 +393,20 @@ namespace BitFaster.Caching.Lru
             public long Evicted => evictedCount;
 
             public bool IsEnabled => true;
+        }
+
+        private class CacheEvents : ICacheEvents<K, V>
+        {
+            public bool IsEnabled => false;
+
+#pragma warning disable CS0067 // The event 'event' is never used
+            public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
+            {
+                // no-op, nothing is registered
+                add { }
+                remove { }
+            }
+#pragma warning restore CS0067 // The event 'event' is never used
         }
     }
 }

--- a/BitFaster.Caching/Lru/ConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLru.cs
@@ -55,8 +55,8 @@ namespace BitFaster.Caching.Lru
         [ObsoleteAttribute("This property is obsolete. Use Events instead.", false)]
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
         {
-            add { this.telemetryPolicy.ItemRemoved += value; }
-            remove { this.telemetryPolicy.ItemRemoved -= value; }
+            add { this.Events.ItemRemoved += value; }
+            remove { this.Events.ItemRemoved -= value; }
         }
     }
 }

--- a/BitFaster.Caching/Lru/ConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLru.cs
@@ -52,6 +52,7 @@ namespace BitFaster.Caching.Lru
         /// <summary>
         /// Occurs when an item is removed from the cache.
         /// </summary>
+        [ObsoleteAttribute("This property is obsolete. Use Events instead.", false)]
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
         {
             add { this.telemetryPolicy.ItemRemoved += value; }

--- a/BitFaster.Caching/Lru/ConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentTLru.cs
@@ -55,6 +55,7 @@ namespace BitFaster.Caching.Lru
         /// <summary>
         /// Occurs when an item is removed from the cache.
         /// </summary>
+        [ObsoleteAttribute("This property is obsolete. Use Events instead.", false)]
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
         {
             add { this.telemetryPolicy.ItemRemoved += value; }

--- a/BitFaster.Caching/Lru/ConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentTLru.cs
@@ -58,8 +58,8 @@ namespace BitFaster.Caching.Lru
         [ObsoleteAttribute("This property is obsolete. Use Events instead.", false)]
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
         {
-            add { this.telemetryPolicy.ItemRemoved += value; }
-            remove { this.telemetryPolicy.ItemRemoved -= value; }
+            add { this.Events.ItemRemoved += value; }
+            remove { this.Events.ItemRemoved -= value; }
         }
 
         /// <summary>

--- a/BitFaster.Caching/Lru/ITelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/ITelemetryPolicy.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Lru
 {
-    public interface ITelemetryPolicy<K, V> : ICacheMetrics
+    public interface ITelemetryPolicy<K, V> : ICacheMetrics, ICacheEvents<K, V>
     {
         void IncrementMiss();
 

--- a/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
@@ -21,14 +21,14 @@ namespace BitFaster.Caching.Lru
 
         public bool IsEnabled => false;
 
-#pragma warning disable CS0067 // The event 'event' is never used
+#pragma warning disable 0067 // The event 'event' is never used
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
         {
             // no-op, nothing is registered
             add { }
             remove { }
         }
-#pragma warning restore CS0067 // The event 'event' is never used
+#pragma warning restore 0067 // The event 'event' is never used
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void IncrementMiss()

--- a/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
@@ -21,6 +21,15 @@ namespace BitFaster.Caching.Lru
 
         public bool IsEnabled => false;
 
+#pragma warning disable CS0067 // The event 'event' is never used
+        public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
+        {
+            // no-op, nothing is registered
+            add { }
+            remove { }
+        }
+#pragma warning restore CS0067 // The event 'event' is never used
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void IncrementMiss()
         {

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -27,7 +27,7 @@ namespace BitFaster.Caching.Lru
 
         public bool IsEnabled => true;
 
-        public EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
+        public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
 
         public void IncrementMiss()
         {

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -27,7 +27,13 @@ namespace BitFaster.Caching.Lru
 
         public bool IsEnabled => true;
 
-        public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
+        public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
+        {
+            add { this.itemRemoved += value; }
+            remove { this.itemRemoved -= value; }
+        }
+
+        private EventHandler<ItemRemovedEventArgs<K, V>> itemRemoved;
 
         public void IncrementMiss()
         {
@@ -47,7 +53,7 @@ namespace BitFaster.Caching.Lru
             }
 
             // passing 'this' as source boxes the struct, and is anyway the wrong object
-            this.ItemRemoved?.Invoke(this.eventSource, new ItemRemovedEventArgs<K, V>(key, value, reason));
+            this.itemRemoved?.Invoke(this.eventSource, new ItemRemovedEventArgs<K, V>(key, value, reason));
         }
 
         public void SetEventSource(object source)

--- a/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
@@ -94,6 +94,9 @@ namespace BitFaster.Caching.Lru
         ///<inheritdoc/>
         public ICacheMetrics Metrics => this.telemetryPolicy;
 
+        ///<inheritdoc/>
+        public ICacheEvents<K, V> Events => this.telemetryPolicy;
+
         public int HotCount => this.hotCount;
 
         public int WarmCount => this.warmCount;

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -40,8 +40,6 @@ namespace BitFaster.Caching
         ///<inheritdoc/>
         public ICacheMetrics Metrics => this.cache.Metrics;
 
-        // TODO: we need an event unrwap class to hide the scope here.
-        // Or, is it better to expose the scope, then the caller can keep objects alive if needed?
         ///<inheritdoc/>
         public ICacheEvents<K, Scoped<V>> Events => this.cache.Events;
 

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -40,6 +40,11 @@ namespace BitFaster.Caching
         ///<inheritdoc/>
         public ICacheMetrics Metrics => this.cache.Metrics;
 
+        // TODO: we need an event unrwap class to hide the scope here.
+        // Or, is it better to expose the scope, then the caller can keep objects alive if needed?
+        ///<inheritdoc/>
+        public ICacheEvents<K, Scoped<V>> Events => this.cache.Events;
+
         ///<inheritdoc/>
         public void AddOrUpdate(K key, V value)
         {


### PR DESCRIPTION
Follow metrics pattern for events. Later there will be more events (e.g. ItemUpdated etc.), so good to extract this out.

There is a kind of nasty part here due to the telemetry policy being a struct (in order to get the JIT optimizations). If the struct contains an event, += or -= an event handler when the policy has been returned directly seems to cause the struct to be copied.  This doesn't affect the wrapper event in ConcurrentLru/ConcurrentTLru which did the same thing without going through the Events property (these are now updated to go through the Events property).

Therefore, put an 'EventHolder' class inside the struct, and initialize it when the event source is set. It might be better in the long run to eliminate the event from the policy and have the event holder as an explicit class passed into the ctor somehow. That way the struct goes back to only value types/source object.

Perf evaluation: JustGetOrAdd test is as expected - adding the class within the policy has not affected JIT (else 'Fast' latency would match 'non-Fast' variants).