### PR TITLE
enable metrics ref

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -199,6 +199,19 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenRefToMetricsIsCapturedResultIsCorrect()
+        {
+            // this detects the case where the struct is copied. If the internal Data class
+            // doesn't work, this test fails.
+            var m = lru.Metrics;
+
+            lru.GetOrAdd(1, valueFactory.Create);
+            bool result = lru.TryGet(1, out var value);
+
+            m.HitRatio.Should().Be(0.5);
+        }
+
+        [Fact]
         public void WhenKeyIsRequestedItIsCreatedAndCached()
         {
             var result1 = lru.GetOrAdd(1, valueFactory.Create);

--- a/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
@@ -23,6 +23,7 @@ namespace BitFaster.Caching.Lru
 
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
         {
+            // no-op, nothing is registered
             add { }
             remove { }
         }

--- a/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
@@ -21,14 +21,11 @@ namespace BitFaster.Caching.Lru
 
         public bool IsEnabled => false;
 
-#pragma warning disable 0067 // The event 'event' is never used
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
         {
-            // no-op, nothing is registered
             add { }
             remove { }
         }
-#pragma warning restore 0067 // The event 'event' is never used
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void IncrementMiss()

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -58,10 +58,9 @@ namespace BitFaster.Caching.Lru
             this.data.eventSource = source;
         }
 
-        // Data exists because TelemetryPolicy is a struct (to get magic JIT optimizations),
-        // but returning it as a property from TemplateConcurrentLru causes a defensive copy
-        // to be made. By storing all the data in an encapsulated reference type, the 
-        // defensive copies of the value type have no effect - they point to the same ref.
+        // Data exists because TelemetryPolicy is a struct (to get magic JIT optimizations).
+        // By storing all the data in an encapsulated reference type, the struct is effectively
+        // immutable and defensive copies of the value type have no effect - they point to the same ref.
         private class Data
         {
             public long hitCount;

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -10,10 +10,10 @@ namespace BitFaster.Caching.Lru
 {
     public struct TelemetryPolicy<K, V> : ITelemetryPolicy<K, V>
     {
-        public long hitCount;
-        public long missCount;
-        public long evictedCount;
-        public object eventSource;
+        private long hitCount;
+        private long missCount;
+        private long evictedCount;
+        private object eventSource;
 
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
 

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
@@ -92,10 +92,10 @@ namespace BitFaster.Caching.Lru
         public int Capacity => this.capacity.Hot + this.capacity.Warm + this.capacity.Cold;
 
         ///<inheritdoc/>
-        public ICacheMetrics Metrics => new MetricsProxy(this);
+        public ICacheMetrics Metrics => new Proxy(this);
 
         ///<inheritdoc/>
-        public ICacheEvents<K, V> Events => new EventsProxy(this);
+        public ICacheEvents<K, V> Events => new Proxy(this);
 
         public int HotCount => this.hotCount;
 
@@ -619,11 +619,11 @@ namespace BitFaster.Caching.Lru
         // it becomes immutable. However, this object is then somewhere else on the 
         // heap, which slows down the policies with hit counter logic in benchmarks. Likely
         // this approach keeps the structs data members in the same CPU cache line as the LRU.
-        private class MetricsProxy : ICacheMetrics
+        private class Proxy : ICacheMetrics, ICacheEvents<K, V>
         {
             private readonly TemplateConcurrentLru<K, V, I, P, T> lru;
 
-            public MetricsProxy(TemplateConcurrentLru<K, V, I, P, T> lru)
+            public Proxy(TemplateConcurrentLru<K, V, I, P, T> lru)
             {
                 this.lru = lru;
             }
@@ -639,18 +639,6 @@ namespace BitFaster.Caching.Lru
             public long Evicted => lru.telemetryPolicy.Evicted;
 
             public bool IsEnabled => (lru.telemetryPolicy as ICacheMetrics).IsEnabled;
-        }
-
-        private class EventsProxy : ICacheEvents<K, V>
-        {
-            private readonly TemplateConcurrentLru<K, V, I, P, T> lru;
-
-            public EventsProxy(TemplateConcurrentLru<K, V, I, P, T> lru)
-            {
-                this.lru = lru;
-            }
-
-            public bool IsEnabled => (lru.telemetryPolicy as ICacheEvents<K, V>).IsEnabled;
 
             public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
             {


### PR DESCRIPTION
Enable passing around a reference to the Metrics. Previously this failed because the backing impl is a struct and when it is mutated after it was copied, all changes are lost.

By storing all the data in a reference type, the struct is effectively immutable (after the ref type is created).