### PR TITLE
bench atomic factory get

### DIFF
--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -44,6 +44,8 @@ namespace BitFaster.Caching.Benchmarks
         private static readonly FastConcurrentLru<int, int> fastConcurrentLru = new FastConcurrentLru<int, int>(8, 9, EqualityComparer<int>.Default);
         private static readonly FastConcurrentTLru<int, int> fastConcurrentTLru = new FastConcurrentTLru<int, int>(8, 9, EqualityComparer<int>.Default, TimeSpan.FromMinutes(1));
 
+        private static readonly ICache<int, int> atomicFastLru = new ConcurrentLruBuilder<int, int>().WithConcurrencyLevel(8).WithCapacity(9).WithAtomicCreate().Build();
+
         private static readonly int key = 1;
         private static System.Runtime.Caching.MemoryCache memoryCache = System.Runtime.Caching.MemoryCache.Default;
 
@@ -76,6 +78,13 @@ namespace BitFaster.Caching.Benchmarks
         {
             Func<int, int> func = x => x;
             concurrentLru.GetOrAdd(1, func);
+        }
+
+        [Benchmark()]
+        public void AtomicFastLru()
+        {
+            Func<int, int> func = x => x;
+            atomicFastLru.GetOrAdd(1, func);
         }
 
         [Benchmark()]


### PR DESCRIPTION

Test cache hit perf:

|                   Method |            Runtime |       Mean |     Error |    StdDev | Ratio | Code Size | Allocated |
|------------------------- |------------------- |-----------:|----------:|----------:|------:|----------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   7.464 ns | 0.1457 ns | 0.1292 ns |  1.00 |   1,523 B |         - |
|        FastConcurrentLru |           .NET 6.0 |  10.086 ns | 0.0920 ns | 0.0768 ns |  1.36 |   2,352 B |         - |
|            ConcurrentLru |           .NET 6.0 |  13.762 ns | 0.1698 ns | 0.1418 ns |  1.85 |   2,378 B |         - |
|            AtomicFastLru |           .NET 6.0 |  19.864 ns | 0.3901 ns | 0.3458 ns |  2.66 |     846 B |         - |
|       FastConcurrentTLru |           .NET 6.0 |  25.805 ns | 0.2143 ns | 0.1789 ns |  3.47 |   2,544 B |         - |
|           ConcurrentTLru |           .NET 6.0 |  29.237 ns | 0.1691 ns | 0.1499 ns |  3.92 |   2,619 B |         - |
|               ClassicLru |           .NET 6.0 |  48.410 ns | 0.3152 ns | 0.2632 ns |  6.50 |   3,041 B |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 113.930 ns | 0.7662 ns | 0.6792 ns | 15.27 |      49 B |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  53.693 ns | 0.4258 ns | 0.3555 ns |  7.21 |      78 B |      24 B |
|                          |                    |            |           |           |       |           |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  13.788 ns | 0.1387 ns | 0.1230 ns |  1.00 |   4,207 B |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  14.947 ns | 0.3063 ns | 0.2715 ns |  1.08 |  15,182 B |         - |
|            ConcurrentLru | .NET Framework 4.8 |  17.265 ns | 0.2214 ns | 0.1963 ns |  1.25 |  15,212 B |         - |
|            AtomicFastLru | .NET Framework 4.8 |  37.870 ns | 0.7494 ns | 0.6643 ns |  2.75 |     358 B |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  45.358 ns | 0.3857 ns | 0.3419 ns |  3.29 |  15,358 B |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  48.821 ns | 0.6934 ns | 0.6146 ns |  3.54 |  15,403 B |         - |
|               ClassicLru | .NET Framework 4.8 |  63.516 ns | 0.7653 ns | 0.6391 ns |  4.60 |   6,945 B |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 282.858 ns | 1.7724 ns | 1.6579 ns | 20.51 |      33 B |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 115.978 ns | 2.3292 ns | 1.8185 ns |  8.40 |      82 B |      24 B |