### PR TITLE
test valuetask

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;net48;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/BitFaster.Caching.Benchmarks/Lru/AsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/AsyncGet.cs
@@ -15,29 +15,25 @@ namespace BitFaster.Caching.Benchmarks.Lru
     [MemoryDiagnoser]
     public class AsyncGet
     {
-        private static readonly IAsyncCache<int, int> concurrentLru = new ConcurrentLruBuilder<int, int>().AsAsyncCache().Build();
-        private static readonly IAsyncCache<int, int> atomicConcurrentLru = new ConcurrentLruBuilder<int, int>().AsAsyncCache().WithAtomicCreate().Build();
+        private static readonly IAsyncCache<int, string> concurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().Build();
+        private static readonly IAsyncCache<int, string> atomicConcurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().WithAtomicCreate().Build();
 
-        private static Task<int> returnTask = Task.FromResult(1);
-
-        private static int[] data = new int[128];
+        private static Task<string> returnTask = Task.FromResult("1");
 
         [Benchmark()]
-        public async Task GetOrAddAsync()
+        public async ValueTask<string> GetOrAddAsync()
         {
-            Func<int, Task<int>> func = x => returnTask;
+            Func<int, Task<string>> func = x => returnTask;
 
-            for (int i = 0; i < 128; i++)
-                data[i] = await concurrentLru.GetOrAddAsync(i, func);
+            return await concurrentLru.GetOrAddAsync(1, func);
         }
 
         [Benchmark()]
-        public async Task AtomicGetOrAddAsync()
+        public async ValueTask<string> AtomicGetOrAddAsync()
         {
-            Func<int, Task<int>> func = x => returnTask;
+            Func<int, Task<string>> func = x => returnTask;
 
-            for (int i = 0; i < 128; i++)
-                data[i] = await atomicConcurrentLru.GetOrAddAsync(i, func);
+            return await atomicConcurrentLru.GetOrAddAsync(1, func);
         }
     }
 }

--- a/BitFaster.Caching.Benchmarks/Lru/AsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/AsyncGet.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BitFaster.Caching.Lru;
+
+namespace BitFaster.Caching.Benchmarks.Lru
+{
+    [SimpleJob(RuntimeMoniker.Net48)]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+    [MemoryDiagnoser]
+    public class AsyncGet
+    {
+        private static readonly IAsyncCache<int, int> concurrentLru = new ConcurrentLruBuilder<int, int>().AsAsyncCache().Build();
+        private static readonly IAsyncCache<int, int> atomicConcurrentLru = new ConcurrentLruBuilder<int, int>().AsAsyncCache().WithAtomicCreate().Build();
+
+        private static Task<int> returnTask = Task.FromResult(1);
+
+        private static int[] data = new int[128];
+
+        [Benchmark()]
+        public async Task GetOrAddAsync()
+        {
+            Func<int, Task<int>> func = x => returnTask;
+
+            for (int i = 0; i < 128; i++)
+                data[i] = await concurrentLru.GetOrAddAsync(i, func);
+        }
+
+        [Benchmark()]
+        public async Task AtomicGetOrAddAsync()
+        {
+            Func<int, Task<int>> func = x => returnTask;
+
+            for (int i = 0; i < 128; i++)
+                data[i] = await atomicConcurrentLru.GetOrAddAsync(i, func);
+        }
+    }
+}

--- a/BitFaster.Caching.UnitTests/Synchronized/AsyncAtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Synchronized/AsyncAtomicFactoryTests.cs
@@ -70,7 +70,7 @@ namespace BitFaster.Caching.UnitTests.Synchronized
             var result = 0;
             var winnerCount = 0;
 
-            Task<int> first = atomicFactory.GetValueAsync(1, async k =>
+            var first = atomicFactory.GetValueAsync(1, async k =>
             {
                 enter.SetResult(true);
                 await resume.Task;
@@ -80,7 +80,7 @@ namespace BitFaster.Caching.UnitTests.Synchronized
                 return 1;
             });
 
-            Task<int> second = atomicFactory.GetValueAsync(1, async k =>
+            var second = atomicFactory.GetValueAsync(1, async k =>
             {
                 enter.SetResult(true);
                 await resume.Task;

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net48;netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Authors>Alex Peck</Authors>
     <Company />
     <Product>BitFaster.Caching</Product>

--- a/BitFaster.Caching/IAsyncCache.cs
+++ b/BitFaster.Caching/IAsyncCache.cs
@@ -48,7 +48,7 @@ namespace BitFaster.Caching
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
         /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
-        Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
+        ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
 
         /// <summary>
         /// Attempts to remove the value that has the specified key.

--- a/BitFaster.Caching/IScopedAsyncCache.cs
+++ b/BitFaster.Caching/IScopedAsyncCache.cs
@@ -53,7 +53,7 @@ namespace BitFaster.Caching
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The factory function used to asynchronously generate a scoped value for the key.</param>
         /// <returns>A task that represents the asynchronous ScopedGetOrAdd operation.</returns>
-        Task<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
+        ValueTask<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
 
         /// <summary>
         /// Attempts to remove the value that has the specified key.

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -149,7 +149,7 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
-        public async Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        public async ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
         {
             if (this.TryGet(key, out var value))
             {

--- a/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
@@ -184,7 +184,7 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
-        public async Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        public async ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
         {
             while (true)
             {

--- a/BitFaster.Caching/ScopedAsyncCache.cs
+++ b/BitFaster.Caching/ScopedAsyncCache.cs
@@ -53,7 +53,7 @@ namespace BitFaster.Caching
         }
 
         ///<inheritdoc/>
-        public async Task<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
+        public async ValueTask<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
         {
             int c = 0;
             var spinwait = new SpinWait();

--- a/BitFaster.Caching/Synchronized/AsyncAtomicFactory.cs
+++ b/BitFaster.Caching/Synchronized/AsyncAtomicFactory.cs
@@ -26,7 +26,7 @@ namespace BitFaster.Caching.Synchronized
             this.value = value;
         }
 
-        public async Task<V> GetValueAsync(K key, Func<K, Task<V>> valueFactory)
+        public async ValueTask<V> GetValueAsync(K key, Func<K, Task<V>> valueFactory)
         {
             if (initializer == null)
             {
@@ -51,7 +51,7 @@ namespace BitFaster.Caching.Synchronized
             }
         }
 
-        private async Task<V> CreateValueAsync(K key, Func<K, Task<V>> valueFactory)
+        private async ValueTask<V> CreateValueAsync(K key, Func<K, Task<V>> valueFactory)
         {
             var init = initializer;
 
@@ -70,7 +70,7 @@ namespace BitFaster.Caching.Synchronized
             private bool isInitialized;
             private Task<V> valueTask;
 
-            public async Task<V> CreateValueAsync(K key, Func<K, Task<V>> valueFactory)
+            public async ValueTask<V> CreateValueAsync(K key, Func<K, Task<V>> valueFactory)
             {
                 var tcs = new TaskCompletionSource<V>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/BitFaster.Caching/Synchronized/AtomicFactoryAsyncCache.cs
+++ b/BitFaster.Caching/Synchronized/AtomicFactoryAsyncCache.cs
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.Synchronized
             cache.Clear();
         }
 
-        public Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        public ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
         {
             var synchronized = cache.GetOrAdd(key, _ => new AsyncAtomicFactory<K, V>());
             return synchronized.GetValueAsync(key, valueFactory);

--- a/BitFaster.Caching/Synchronized/AtomicFactoryScopedAsyncCache.cs
+++ b/BitFaster.Caching/Synchronized/AtomicFactoryScopedAsyncCache.cs
@@ -41,7 +41,7 @@ namespace BitFaster.Caching.Synchronized
             this.cache.Clear();
         }
 
-        public async Task<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
+        public async ValueTask<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
         {
             int c = 0;
             var spinwait = new SpinWait();


### PR DESCRIPTION
Baseline, no code changes from main:

|              Method |            Runtime |      Mean |    Error |   StdDev | Code Size |  Gen 0 | Allocated |
|-------------------- |------------------- |----------:|---------:|---------:|----------:|-------:|----------:|
|       GetOrAddAsync |           .NET 6.0 |  72.05 ns | 1.522 ns | 2.032 ns |   1,179 B | 0.0334 |     144 B |
| AtomicGetOrAddAsync |           .NET 6.0 |  76.70 ns | 1.114 ns | 0.988 ns |   1,343 B | 0.0334 |     144 B |
|       GetOrAddAsync | .NET Framework 4.8 | 170.12 ns | 1.611 ns | 1.258 ns |  29,493 B | 0.0370 |     160 B |
| AtomicGetOrAddAsync | .NET Framework 4.8 | 182.79 ns | 2.485 ns | 2.203 ns |  29,493 B | 0.0370 |     160 B |


With code changes to switch to value task (not supported on fwk/std2.0):

|              Method |            Runtime |     Mean |    Error |   StdDev |  Gen 0 | Code Size | Allocated |
|-------------------- |------------------- |---------:|---------:|---------:|-------:|----------:|----------:|
|       GetOrAddAsync |           .NET 6.0 | 71.87 ns | 0.628 ns | 0.524 ns | 0.0167 |   1,431 B |      72 B |
| AtomicGetOrAddAsync |           .NET 6.0 | 78.09 ns | 0.878 ns | 0.734 ns | 0.0167 |   1,595 B |      72 B |
|       GetOrAddAsync | .NET Framework 4.8 |       NA |       NA |       NA |      - |         - |         - |
| AtomicGetOrAddAsync | .NET Framework 4.8 |       NA |       NA |       NA |      - |         - |         - |

This drops to zero allocs in both cases when the bench method itself uses valuetask.