### PR TITLE
valuetask

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
   </ItemGroup>
+    
+  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>-->
 
   <ItemGroup>
     <ProjectReference Include="..\BitFaster.Caching\BitFaster.Caching.csproj" />

--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -19,10 +19,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
     <PackageReference Include="System.Runtime.Caching" Version="6.0.0" />
   </ItemGroup>
-    
-  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-  </ItemGroup>-->
 
   <ItemGroup>
     <ProjectReference Include="..\BitFaster.Caching\BitFaster.Caching.csproj" />

--- a/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BitFaster.Caching.Lru;
+
+namespace BitFaster.Caching.Benchmarks.Lru
+{
+    /// <summary>
+    /// Verify 0 allocs for GetOrAddAsync cache hits.
+    /// </summary>
+    [SimpleJob(RuntimeMoniker.Net48)]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+    [MemoryDiagnoser]
+    public class LruAsyncGet
+    {
+        // if the cache value is a value type, value task has no effect - so use string to repro.
+        private static readonly IAsyncCache<int, string> concurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().Build();
+        private static readonly IAsyncCache<int, string> atomicConcurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().WithAtomicCreate().Build();
+
+        private static Task<string> returnTask = Task.FromResult("1");
+
+        [Benchmark()]
+        public async ValueTask<string> GetOrAddAsync()
+        {
+            Func<int, Task<string>> func = x => returnTask;
+
+            return await concurrentLru.GetOrAddAsync(1, func);
+        }
+
+        [Benchmark()]
+        public async ValueTask<string> AtomicGetOrAddAsync()
+        {
+            Func<int, Task<string>> func = x => returnTask;
+
+            return await atomicConcurrentLru.GetOrAddAsync(1, func);
+        }
+    }
+}

--- a/BitFaster.Caching.UnitTests/Synchronized/AsyncAtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Synchronized/AsyncAtomicFactoryTests.cs
@@ -70,7 +70,7 @@ namespace BitFaster.Caching.UnitTests.Synchronized
             var result = 0;
             var winnerCount = 0;
 
-            Task<int> first = atomicFactory.GetValueAsync(1, async k =>
+            var first = atomicFactory.GetValueAsync(1, async k =>
             {
                 enter.SetResult(true);
                 await resume.Task;
@@ -80,7 +80,7 @@ namespace BitFaster.Caching.UnitTests.Synchronized
                 return 1;
             });
 
-            Task<int> second = atomicFactory.GetValueAsync(1, async k =>
+            var second = atomicFactory.GetValueAsync(1, async k =>
             {
                 enter.SetResult(true);
                 await resume.Task;

--- a/BitFaster.Caching.UnitTests/Synchronized/AtomicFactoryCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Synchronized/AtomicFactoryCacheTests.cs
@@ -107,14 +107,6 @@ namespace BitFaster.Caching.UnitTests.Synchronized
         }
 
         [Fact]
-        public async Task GetOrAddAsyncThrows()
-        {
-            Func<Task> getOrAdd = async () => { await this.cache.GetOrAddAsync(1, k => Task.FromResult(k)); };
-
-            await getOrAdd.Should().ThrowAsync<NotImplementedException>();
-        }
-
-        [Fact]
         public void WhenCacheContainsValuesTrim1RemovesColdestValue()
         {
             this.cache.AddOrUpdate(0, 0);

--- a/BitFaster.Caching.UnitTests/Synchronized/ScopedAsyncAtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Synchronized/ScopedAsyncAtomicFactoryTests.cs
@@ -98,7 +98,7 @@ namespace BitFaster.Caching.UnitTests.Synchronized
             var winningNumber = 0;
             var winnerCount = 0;
 
-            Task<(bool r, Lifetime<IntHolder> l)> first = atomicFactory.TryCreateLifetimeAsync(1, async k =>
+            ValueTask<(bool r, Lifetime<IntHolder> l)> first = atomicFactory.TryCreateLifetimeAsync(1, async k =>
             {
                 enter.SetResult(true);
                 await resume.Task;
@@ -108,7 +108,7 @@ namespace BitFaster.Caching.UnitTests.Synchronized
                 return new Scoped<IntHolder>(new IntHolder() { actualNumber = 1 });
             });
 
-            Task<(bool r, Lifetime<IntHolder> l)> second = atomicFactory.TryCreateLifetimeAsync(1, async k =>
+            ValueTask<(bool r, Lifetime<IntHolder> l)> second = atomicFactory.TryCreateLifetimeAsync(1, async k =>
             {
                 enter.SetResult(true);
                 await resume.Task;
@@ -142,7 +142,7 @@ namespace BitFaster.Caching.UnitTests.Synchronized
             var atomicFactory = new ScopedAsyncAtomicFactory<int, IntHolder>();
             var holder = new IntHolder() { actualNumber = 1 };
 
-            Task<(bool r, Lifetime<IntHolder> l)> first = atomicFactory.TryCreateLifetimeAsync(1, async k =>
+            ValueTask<(bool r, Lifetime<IntHolder> l)> first = atomicFactory.TryCreateLifetimeAsync(1, async k =>
             {
                 enter.SetResult(true);
                 await resume.Task;
@@ -171,7 +171,7 @@ namespace BitFaster.Caching.UnitTests.Synchronized
             var atomicFactory = new ScopedAsyncAtomicFactory<int, IntHolder>();
             var holder = new IntHolder() { actualNumber = 1 };
 
-            Task<(bool r, Lifetime<IntHolder> l)> first = atomicFactory.TryCreateLifetimeAsync(1, async k =>
+            ValueTask<(bool r, Lifetime<IntHolder> l)> first = atomicFactory.TryCreateLifetimeAsync(1, async k =>
             {
                 enter.SetResult(true);
                 await resume.Task;

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -39,4 +39,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netstandard2.0'">
+     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+  </ItemGroup>
+
 </Project>

--- a/BitFaster.Caching/IAsyncCache.cs
+++ b/BitFaster.Caching/IAsyncCache.cs
@@ -48,7 +48,7 @@ namespace BitFaster.Caching
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
         /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
-        Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
+        ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
 
         /// <summary>
         /// Attempts to remove the value that has the specified key.

--- a/BitFaster.Caching/IScopedAsyncCache.cs
+++ b/BitFaster.Caching/IScopedAsyncCache.cs
@@ -53,7 +53,7 @@ namespace BitFaster.Caching
         /// <param name="key">The key of the element to add.</param>
         /// <param name="valueFactory">The factory function used to asynchronously generate a scoped value for the key.</param>
         /// <returns>A task that represents the asynchronous ScopedGetOrAdd operation.</returns>
-        Task<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
+        ValueTask<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
 
         /// <summary>
         /// Attempts to remove the value that has the specified key.

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -149,7 +149,7 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
-        public async Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        public async ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
         {
             if (this.TryGet(key, out var value))
             {

--- a/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/TemplateConcurrentLru.cs
@@ -184,7 +184,7 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
-        public async Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        public async ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
         {
             while (true)
             {

--- a/BitFaster.Caching/ScopedAsyncCache.cs
+++ b/BitFaster.Caching/ScopedAsyncCache.cs
@@ -53,7 +53,7 @@ namespace BitFaster.Caching
         }
 
         ///<inheritdoc/>
-        public async Task<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
+        public async ValueTask<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
         {
             int c = 0;
             var spinwait = new SpinWait();

--- a/BitFaster.Caching/Synchronized/AsyncAtomicFactory.cs
+++ b/BitFaster.Caching/Synchronized/AsyncAtomicFactory.cs
@@ -26,7 +26,7 @@ namespace BitFaster.Caching.Synchronized
             this.value = value;
         }
 
-        public async Task<V> GetValueAsync(K key, Func<K, Task<V>> valueFactory)
+        public async ValueTask<V> GetValueAsync(K key, Func<K, Task<V>> valueFactory)
         {
             if (initializer == null)
             {
@@ -51,7 +51,7 @@ namespace BitFaster.Caching.Synchronized
             }
         }
 
-        private async Task<V> CreateValueAsync(K key, Func<K, Task<V>> valueFactory)
+        private async ValueTask<V> CreateValueAsync(K key, Func<K, Task<V>> valueFactory)
         {
             var init = initializer;
 
@@ -70,7 +70,7 @@ namespace BitFaster.Caching.Synchronized
             private bool isInitialized;
             private Task<V> valueTask;
 
-            public async Task<V> CreateValueAsync(K key, Func<K, Task<V>> valueFactory)
+            public async ValueTask<V> CreateValueAsync(K key, Func<K, Task<V>> valueFactory)
             {
                 var tcs = new TaskCompletionSource<V>(TaskCreationOptions.RunContinuationsAsynchronously);
 

--- a/BitFaster.Caching/Synchronized/AtomicFactoryAsyncCache.cs
+++ b/BitFaster.Caching/Synchronized/AtomicFactoryAsyncCache.cs
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.Synchronized
             cache.Clear();
         }
 
-        public Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        public ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
         {
             var synchronized = cache.GetOrAdd(key, _ => new AsyncAtomicFactory<K, V>());
             return synchronized.GetValueAsync(key, valueFactory);

--- a/BitFaster.Caching/Synchronized/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Synchronized/AtomicFactoryCache.cs
@@ -46,11 +46,6 @@ namespace BitFaster.Caching.Synchronized
             return atomicFactory.GetValue(key, valueFactory);
         }
 
-        public Task<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
-        {
-            throw new NotImplementedException();
-        }
-
         public void Trim(int itemCount)
         {
             this.cache.Trim(itemCount);

--- a/BitFaster.Caching/Synchronized/AtomicFactoryScopedAsyncCache.cs
+++ b/BitFaster.Caching/Synchronized/AtomicFactoryScopedAsyncCache.cs
@@ -41,7 +41,7 @@ namespace BitFaster.Caching.Synchronized
             this.cache.Clear();
         }
 
-        public async Task<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
+        public async ValueTask<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
         {
             int c = 0;
             var spinwait = new SpinWait();

--- a/BitFaster.Caching/Synchronized/ScopedAsyncAtomicFactory.cs
+++ b/BitFaster.Caching/Synchronized/ScopedAsyncAtomicFactory.cs
@@ -46,7 +46,7 @@ namespace BitFaster.Caching.Synchronized
             return scope.TryCreateLifetime(out lifetime);
         }
 
-        public async Task<(bool success, Lifetime<V> lifetime)> TryCreateLifetimeAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
+        public async ValueTask<(bool success, Lifetime<V> lifetime)> TryCreateLifetimeAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
         {
             // if disposed, return
             if (scope?.IsDisposed ?? false)
@@ -64,7 +64,7 @@ namespace BitFaster.Caching.Synchronized
             return (res, lifetime);
         }
 
-        private async Task InitializeScopeAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
+        private async ValueTask InitializeScopeAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
         {
             var init = initializer;
 
@@ -97,7 +97,7 @@ namespace BitFaster.Caching.Synchronized
             private bool isDisposeRequested;
             private Task<Scoped<V>> task;
 
-            public async Task<Scoped<V>> CreateScopeAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
+            public async ValueTask<Scoped<V>> CreateScopeAsync(K key, Func<K, Task<Scoped<V>>> valueFactory)
             {
                 var tcs = new TaskCompletionSource<Scoped<V>>(TaskCreationOptions.RunContinuationsAsynchronously);
 


### PR DESCRIPTION
Use ValueTask for async methods, eliminate Task allocs.

Before:

|              Method |            Runtime |      Mean |    Error |   StdDev | Code Size |  Gen 0 | Allocated |
|-------------------- |------------------- |----------:|---------:|---------:|----------:|-------:|----------:|
|       GetOrAddAsync |           .NET 6.0 |  84.79 ns | 1.618 ns | 4.059 ns |   1,683 B | 0.0167 |      72 B |
| AtomicGetOrAddAsync |           .NET 6.0 |  77.26 ns | 0.587 ns | 0.549 ns |   1,847 B | 0.0167 |      72 B |
|       GetOrAddAsync | .NET Framework 4.8 | 172.44 ns | 1.518 ns | 1.268 ns |  12,202 B | 0.0184 |      80 B |
| AtomicGetOrAddAsync | .NET Framework 4.8 | 178.61 ns | 1.501 ns | 1.253 ns |  12,202 B | 0.0184 |      80 B |

After:

|              Method |            Runtime |      Mean |    Error |   StdDev | Code Size | Allocated |
|-------------------- |------------------- |----------:|---------:|---------:|----------:|----------:|
|       GetOrAddAsync |           .NET 6.0 |  79.65 ns | 0.754 ns | 0.668 ns |   1,935 B |         - |
| AtomicGetOrAddAsync |           .NET 6.0 |  83.76 ns | 0.465 ns | 0.388 ns |   2,099 B |         - |
|       GetOrAddAsync | .NET Framework 4.8 | 173.62 ns | 0.915 ns | 0.811 ns |  12,513 B |         - |
| AtomicGetOrAddAsync | .NET Framework 4.8 | 183.51 ns | 1.019 ns | 0.903 ns |  12,513 B |         - |