### PR TITLE
cleanup builders

### DIFF
--- a/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
@@ -20,7 +20,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     {
         // if the cache value is a value type, value task has no effect - so use string to repro.
         private static readonly IAsyncCache<int, string> concurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().Build();
-        private static readonly IAsyncCache<int, string> atomicConcurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().WithAtomicCreate().Build();
+        private static readonly IAsyncCache<int, string> atomicConcurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().WithAtomicValueFactory().Build();
 
         private static Task<string> returnTask = Task.FromResult("1");
 

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -44,7 +44,7 @@ namespace BitFaster.Caching.Benchmarks
         private static readonly FastConcurrentLru<int, int> fastConcurrentLru = new FastConcurrentLru<int, int>(8, 9, EqualityComparer<int>.Default);
         private static readonly FastConcurrentTLru<int, int> fastConcurrentTLru = new FastConcurrentTLru<int, int>(8, 9, EqualityComparer<int>.Default, TimeSpan.FromMinutes(1));
 
-        private static readonly ICache<int, int> atomicFastLru = new ConcurrentLruBuilder<int, int>().WithConcurrencyLevel(8).WithCapacity(9).WithAtomicCreate().Build();
+        private static readonly ICache<int, int> atomicFastLru = new ConcurrentLruBuilder<int, int>().WithConcurrencyLevel(8).WithCapacity(9).WithAtomicValueFactory().Build();
 
         private static readonly int key = 1;
         private static System.Runtime.Caching.MemoryCache memoryCache = System.Runtime.Caching.MemoryCache.Default;

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -196,7 +196,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithScopedValues()
         {
             IScopedCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithScopedValues()
+                .AsScopedCache()
                 .WithCapacity(3)
                 .Build();
 
@@ -209,7 +209,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicFactory()
         {
             ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
-                .WithAtomicCreate()
+                .WithAtomicValueFactory()
                 .WithCapacity(3)
                 .Build();
 
@@ -233,8 +233,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicWithScope()
         {
             IScopedCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithAtomicCreate()
-                .WithScopedValues()
+                .WithAtomicValueFactory()
+                .AsScopedCache()
                 .WithCapacity(3)
                 .Build();
 
@@ -247,8 +247,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithScopedWithAtomic()
         {
             IScopedCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithScopedValues()
-                .WithAtomicCreate()
+                .AsScopedCache()
+                .WithAtomicValueFactory()
                 .WithCapacity(3)
                 .Build();
 
@@ -262,7 +262,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsAsyncCache()
-                .WithScopedValues()
+                .AsScopedCache()
                 .WithCapacity(3)
                 .Build();
 
@@ -276,7 +276,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithScopedAsAsync()
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithScopedValues()
+                .AsScopedCache()
                 .AsAsyncCache()           
                 .WithCapacity(3)
                 .Build();
@@ -290,7 +290,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicAsAsync()
         {
             IAsyncCache<int, int> lru = new ConcurrentLruBuilder<int, int>()
-                .WithAtomicCreate()
+                .WithAtomicValueFactory()
                 .AsAsyncCache()
                 .WithCapacity(3)
                 .Build();
@@ -304,7 +304,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             IAsyncCache<int, int> lru = new ConcurrentLruBuilder<int, int>()
                 .AsAsyncCache()
-                .WithAtomicCreate()
+                .WithAtomicValueFactory()
                 .WithCapacity(3)
                 .Build();
 
@@ -316,8 +316,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicWithScopedAsAsync()
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithAtomicCreate()
-                .WithScopedValues()
+                .WithAtomicValueFactory()
+                .AsScopedCache()
                 .AsAsyncCache()
                 .WithCapacity(3)
                 .Build();
@@ -330,9 +330,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicAsAsyncWithScoped()
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithAtomicCreate()
+                .WithAtomicValueFactory()
                 .AsAsyncCache()
-                .WithScopedValues()
+                .AsScopedCache()
                 .WithCapacity(3)
                 .Build();
 
@@ -344,8 +344,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithScopedWithAtomicAsAsync()
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithScopedValues()
-                .WithAtomicCreate()
+                .AsScopedCache()
+                .WithAtomicValueFactory()
                 .AsAsyncCache()
                 .WithCapacity(3)
                 .Build();
@@ -358,9 +358,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithScopedAsAsyncWithAtomic()
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithScopedValues()
+                .AsScopedCache()
                 .AsAsyncCache()
-                .WithAtomicCreate()
+                .WithAtomicValueFactory()
                 .WithCapacity(3)
                 .Build();
 
@@ -373,8 +373,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsAsyncCache()
-                .WithScopedValues()
-                .WithAtomicCreate()
+                .AsScopedCache()
+                .WithAtomicValueFactory()
                 .WithCapacity(3)
                 .Build();
 
@@ -387,8 +387,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsAsyncCache()
-                .WithAtomicCreate()
-                .WithScopedValues()
+                .WithAtomicValueFactory()
+                .AsScopedCache()
                 .WithCapacity(3)
                 .Build();
 

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -315,8 +315,6 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WithAtomicWithScopedAsAsync()
         {
-            // TODO: this will not resolve a TLru
-
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .WithAtomicCreate()
                 .WithScopedValues()
@@ -331,8 +329,6 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WithAtomicAsAsyncWithScoped()
         {
-            // TODO: this will not resolve a TLru
-
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .WithAtomicCreate()
                 .AsAsyncCache()
@@ -347,8 +343,6 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WithScopedWithAtomicAsAsync()
         {
-            // TODO: this will not resolve a TLru
-
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .WithScopedValues()
                 .WithAtomicCreate()
@@ -363,8 +357,6 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WithScopedAsAsyncWithAtomic()
         {
-            // TODO: this will not resolve a TLru
-
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .WithScopedValues()
                 .AsAsyncCache()
@@ -379,8 +371,6 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void AsAsyncWithScopedWithAtomic()
         {
-            // TODO: this will not resolve a TLru
-
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsAsyncCache()
                 .WithScopedValues()
@@ -395,8 +385,6 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void AsAsyncWithAtomicWithScoped()
         {
-            // TODO: this will not resolve a TLru
-
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsAsyncCache()
                 .WithAtomicCreate()

--- a/BitFaster.Caching/Lru/Builder/AtomicAsyncConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/Builder/AtomicAsyncConcurrentLruBuilder.cs
@@ -7,11 +7,11 @@ using BitFaster.Caching.Synchronized;
 
 namespace BitFaster.Caching.Lru.Builder
 {
-    public class AsyncAtomicLruBuilder<K, V> : LruBuilderBase<K, V, AsyncAtomicLruBuilder<K, V>, IAsyncCache<K, V>>
+    public class AtomicAsyncConcurrentLruBuilder<K, V> : LruBuilderBase<K, V, AtomicAsyncConcurrentLruBuilder<K, V>, IAsyncCache<K, V>>
     {
         private readonly ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>> inner;
 
-        internal AsyncAtomicLruBuilder(ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>> inner)
+        internal AtomicAsyncConcurrentLruBuilder(ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>> inner)
             : base(inner.info)
         {
             this.inner = inner;

--- a/BitFaster.Caching/Lru/Builder/AtomicConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/Builder/AtomicConcurrentLruBuilder.cs
@@ -7,11 +7,11 @@ using BitFaster.Caching.Synchronized;
 
 namespace BitFaster.Caching.Lru.Builder
 {
-    public class AtomicLruBuilder<K, V> : LruBuilderBase<K, V, AtomicLruBuilder<K, V>, ICache<K, V>>
+    public class AtomicConcurrentLruBuilder<K, V> : LruBuilderBase<K, V, AtomicConcurrentLruBuilder<K, V>, ICache<K, V>>
     {
         private readonly ConcurrentLruBuilder<K, AtomicFactory<K, V>> inner;
 
-        internal AtomicLruBuilder(ConcurrentLruBuilder<K, AtomicFactory<K, V>> inner)
+        internal AtomicConcurrentLruBuilder(ConcurrentLruBuilder<K, AtomicFactory<K, V>> inner)
             : base(inner.info)
         {
             this.inner = inner;

--- a/BitFaster.Caching/Lru/Builder/AtomicScopedAsyncConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/Builder/AtomicScopedAsyncConcurrentLruBuilder.cs
@@ -7,11 +7,11 @@ using BitFaster.Caching.Synchronized;
 
 namespace BitFaster.Caching.Lru.Builder
 {
-    public sealed class ScopedAsyncAtomicLruBuilder<K, V> : LruBuilderBase<K, V, ScopedAsyncAtomicLruBuilder<K, V>, IScopedAsyncCache<K, V>> where V : IDisposable
+    public sealed class AtomicScopedAsyncConcurrentLruBuilder<K, V> : LruBuilderBase<K, V, AtomicScopedAsyncConcurrentLruBuilder<K, V>, IScopedAsyncCache<K, V>> where V : IDisposable
     {
         private readonly AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>> inner;
 
-        internal ScopedAsyncAtomicLruBuilder(AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>> inner)
+        internal AtomicScopedAsyncConcurrentLruBuilder(AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>> inner)
             : base(inner.info)
         {
             this.inner = inner;

--- a/BitFaster.Caching/Lru/Builder/AtomicScopedConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/Builder/AtomicScopedConcurrentLruBuilder.cs
@@ -7,11 +7,11 @@ using BitFaster.Caching.Synchronized;
 
 namespace BitFaster.Caching.Lru.Builder
 {
-    public class ScopedAtomicLruBuilder<K, V> : LruBuilderBase<K, V, ScopedAtomicLruBuilder<K, V>, IScopedCache<K, V>> where V : IDisposable
+    public class AtomicScopedConcurrentLruBuilder<K, V> : LruBuilderBase<K, V, AtomicScopedConcurrentLruBuilder<K, V>, IScopedCache<K, V>> where V : IDisposable
     {
         private readonly ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>> inner;
 
-        internal ScopedAtomicLruBuilder(ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>> inner)
+        internal AtomicScopedConcurrentLruBuilder(ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>> inner)
             : base(inner.info)
         {
             this.inner = inner;

--- a/BitFaster.Caching/Lru/Builder/ScopedAsyncConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/Builder/ScopedAsyncConcurrentLruBuilder.cs
@@ -6,11 +6,11 @@ using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Lru.Builder
 {
-    public sealed class ScopedAsyncLruBuilder<K, V> : LruBuilderBase<K, V, ScopedAsyncLruBuilder<K, V>, IScopedAsyncCache<K, V>> where V : IDisposable
+    public sealed class ScopedAsyncConcurrentLruBuilder<K, V> : LruBuilderBase<K, V, ScopedAsyncConcurrentLruBuilder<K, V>, IScopedAsyncCache<K, V>> where V : IDisposable
     {
         private readonly AsyncConcurrentLruBuilder<K, Scoped<V>> inner;
 
-        internal ScopedAsyncLruBuilder(AsyncConcurrentLruBuilder<K, Scoped<V>> inner)
+        internal ScopedAsyncConcurrentLruBuilder(AsyncConcurrentLruBuilder<K, Scoped<V>> inner)
             : base(inner.info)
         {
             this.inner = inner;

--- a/BitFaster.Caching/Lru/Builder/ScopedConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/Builder/ScopedConcurrentLruBuilder.cs
@@ -7,11 +7,11 @@ using BitFaster.Caching.Synchronized;
 
 namespace BitFaster.Caching.Lru.Builder
 {
-    public sealed class ScopedLruBuilder<K, V, W> : LruBuilderBase<K, V, ScopedLruBuilder<K, V, W>, IScopedCache<K, V>> where V : IDisposable where W : IScoped<V>
+    public sealed class ScopedConcurrentLruBuilder<K, V, W> : LruBuilderBase<K, V, ScopedConcurrentLruBuilder<K, V, W>, IScopedCache<K, V>> where V : IDisposable where W : IScoped<V>
     {
         private readonly ConcurrentLruBuilder<K, W> inner;
 
-        internal ScopedLruBuilder(ConcurrentLruBuilder<K, W> inner)
+        internal ScopedConcurrentLruBuilder(ConcurrentLruBuilder<K, W> inner)
             : base(inner.info)
         {
             this.inner = inner;

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
@@ -24,7 +24,7 @@ namespace BitFaster.Caching.Lru
     public sealed class ConcurrentLruBuilder<K, V> : LruBuilderBase<K, V, ConcurrentLruBuilder<K, V>, ICache<K, V>>
     {
         /// <summary>
-        /// Creates a ConcurrentLruBuilder.
+        /// Creates a ConcurrentLruBuilder. Chain method calls onto ConcurrentLruBuilder to configure the cache then call Build to create a cache instance.
         /// </summary>
         public ConcurrentLruBuilder()
             : base(new LruInfo<K>())

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilderExtensions.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilderExtensions.cs
@@ -17,77 +17,161 @@ namespace BitFaster.Caching.Lru
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The ConcurrentLruBuilder to chain method calls onto.</param>
-        /// <returns>A ScopedLruBuilder</returns>
+        /// <returns>A ScopedConcurrentLruBuilder.</returns>
         public static ScopedConcurrentLruBuilder<K, V, Scoped<V>> WithScopedValues<K, V>(this ConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
-            var scoped = new ConcurrentLruBuilder<K, Scoped<V>>(builder.info);
-            return new ScopedConcurrentLruBuilder<K, V, Scoped<V>>(scoped);
+            var convertBuilder = new ConcurrentLruBuilder<K, Scoped<V>>(builder.info);
+            return new ScopedConcurrentLruBuilder<K, V, Scoped<V>>(convertBuilder);
         }
 
-        public static AtomicConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this ConcurrentLruBuilder<K, V> b)
+        /// <summary>
+        /// Wrap IDisposable values in a lifetime scope. Scoped caches return lifetimes that prevent
+        /// values from being disposed until the calling code completes.
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The AtomicConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AtomicScopedConcurrentLruBuilder.</returns>
+        public static AtomicScopedConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AtomicConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
-            var a = new ConcurrentLruBuilder<K, AtomicFactory<K, V>>(b.info);
-            return new AtomicConcurrentLruBuilder<K, V>(a);
+            var convertBuilder = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(builder.info);
+            return new AtomicScopedConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
-        public static AtomicScopedConcurrentLruBuilder<K, V> WithAtomicCreate<K, V, W>(this ScopedConcurrentLruBuilder<K, V, W> b) where V : IDisposable where W : IScoped<V>
+        /// <summary>
+        /// Wrap IDisposable values in a lifetime scope. Scoped caches return lifetimes that prevent
+        /// values from being disposed until the calling code completes.
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The AsyncConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>A ScopedAsyncConcurrentLruBuilder.</returns>
+        public static ScopedAsyncConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
-            var atomicScoped = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(b.info);
-
-            return new AtomicScopedConcurrentLruBuilder<K, V>(atomicScoped);
+            var convertBuilder = new AsyncConcurrentLruBuilder<K, Scoped<V>>(builder.info);
+            return new ScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
-        public static AtomicScopedConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AtomicConcurrentLruBuilder<K, V> b) where V : IDisposable
+        /// <summary>
+        /// Wrap IDisposable values in a lifetime scope. Scoped caches return lifetimes that prevent
+        /// values from being disposed until the calling code completes.
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The AtomicAsyncConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AtomicScopedAsyncConcurrentLruBuilder.</returns>
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AtomicAsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
-            var atomicScoped = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(b.info);
-            return new AtomicScopedConcurrentLruBuilder<K, V>(atomicScoped);
+            var convertBuilder = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(builder.info);
+            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
+        /// <summary>
+        /// Execute the cache's GetOrAdd value factory atomically, such that it is applied at most once per key. Other threads
+        /// attempting to update the same key will be blocked until value factory completes.
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The ConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AtomicConcurrentLruBuilder.</returns>
+        public static AtomicConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this ConcurrentLruBuilder<K, V> builder)
+        {
+            var convertBuilder = new ConcurrentLruBuilder<K, AtomicFactory<K, V>>(builder.info);
+            return new AtomicConcurrentLruBuilder<K, V>(convertBuilder);
+        }
+
+        /// <summary>
+        /// Execute the cache's ScopedGetOrAdd value factory atomically, such that it is applied at most once per key. Other threads
+        /// attempting to update the same key will be blocked until value factory completes.
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <typeparam name="W">The wrapped value type.</typeparam>
+        /// <param name="builder">The ScopedConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AtomicScopedConcurrentLruBuilder.</returns>
+        public static AtomicScopedConcurrentLruBuilder<K, V> WithAtomicCreate<K, V, W>(this ScopedConcurrentLruBuilder<K, V, W> builder) where V : IDisposable where W : IScoped<V>
+        {
+            var convertBuilder = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(builder.info);
+            return new AtomicScopedConcurrentLruBuilder<K, V>(convertBuilder);
+        }
+
+        /// <summary>
+        /// Execute the cache's GetOrAddAsync value factory atomically, such that it is applied at most once per key. Other threads
+        /// attempting to update the same key will wait on the same value factory task.
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The AsyncConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AtomicAsyncConcurrentLruBuilder.</returns>
+        public static AtomicAsyncConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this AsyncConcurrentLruBuilder<K, V> builder)
+        {
+            var convertBuilder = new ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>>(builder.info);
+            return new AtomicAsyncConcurrentLruBuilder<K, V>(convertBuilder);
+        }
+
+        /// <summary>
+        /// Execute the cache's ScopedGetOrAddAsync value factory atomically, such that it is applied at most once per key. Other threads
+        /// attempting to update the same key will wait on the same value factory task.
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The ScopedAsyncConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AtomicScopedAsyncConcurrentLruBuilder.</returns>
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this ScopedAsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
+        {
+            var convertBuilder = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(builder.info);
+            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);
+        }
+
+        /// <summary>
+        /// Build an IAsyncCache, the GetOrAdd method becomes GetOrAddAsync. 
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The ConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AsyncConcurrentLruBuilder.</returns>
         public static AsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this ConcurrentLruBuilder<K, V> builder)
         {
             return new AsyncConcurrentLruBuilder<K, V>(builder.info);
         }
 
-        public static ScopedAsyncConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AsyncConcurrentLruBuilder<K, V> b) where V : IDisposable
+        /// <summary>
+        /// Build an IScopedAsyncCache, the ScopedGetOrAdd method becomes ScopedGetOrAddAsync. 
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The ScopedConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>A ScopedAsyncConcurrentLruBuilder.</returns>
+        public static ScopedAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this ScopedConcurrentLruBuilder<K, V, Scoped<V>> builder) where V : IDisposable
         {
-            var asyncScoped = new AsyncConcurrentLruBuilder<K, Scoped<V>>(b.info);
-            return new ScopedAsyncConcurrentLruBuilder<K, V>(asyncScoped);
+            var convertBuilder = new AsyncConcurrentLruBuilder<K, Scoped<V>>(builder.info);
+            return new ScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
-        public static ScopedAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this ScopedConcurrentLruBuilder<K, V, Scoped<V>> b) where V : IDisposable
+        /// <summary>
+        /// Build an IAsyncCache, the GetOrAdd method becomes GetOrAddAsync. 
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The AtomicConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AtomicAsyncConcurrentLruBuilder.</returns>
+        public static AtomicAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this AtomicConcurrentLruBuilder<K, V> builder)
         {
-            var asyncScoped = new AsyncConcurrentLruBuilder<K, Scoped<V>>(b.info);
-            return new ScopedAsyncConcurrentLruBuilder<K, V>(asyncScoped);
+            var convertBuilder = new ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>>(builder.info);
+            return new AtomicAsyncConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
-        public static AtomicAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this AtomicConcurrentLruBuilder<K, V> b)
+        /// <summary>
+        /// Build an IScopedAsyncCache, the ScopedGetOrAdd method becomes ScopedGetOrAddAsync.
+        /// </summary>
+        /// <typeparam name="K">The type of keys in the cache.</typeparam>
+        /// <typeparam name="V">The type of values in the cache.</typeparam>
+        /// <param name="builder">The AtomicScopedConcurrentLruBuilder to chain method calls onto.</param>
+        /// <returns>An AtomicScopedAsyncConcurrentLruBuilder.</returns>
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this AtomicScopedConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
-            var a = new ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>>(b.info);
-            return new AtomicAsyncConcurrentLruBuilder<K, V>(a);
-        }
-
-        public static AtomicAsyncConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this AsyncConcurrentLruBuilder<K, V> b)
-        {
-            var a = new ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>>(b.info);
-            return new AtomicAsyncConcurrentLruBuilder<K, V>(a);
-        }
-
-        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this AtomicScopedConcurrentLruBuilder<K, V> b) where V : IDisposable
-        {
-            var a = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(b.info);
-            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(a);
-        }
-
-        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AtomicAsyncConcurrentLruBuilder<K, V> b) where V : IDisposable
-        {
-            var a = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(b.info);
-            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(a);
-        }
-
-        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this ScopedAsyncConcurrentLruBuilder<K, V> b) where V : IDisposable
-        {
-            var a = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(b.info);
-            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(a);
+            var convertBuilder = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(builder.info);
+            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);
         }
     }
 }

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilderExtensions.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilderExtensions.cs
@@ -11,56 +11,56 @@ namespace BitFaster.Caching.Lru
     public static class ConcurrentLruBuilderExtensions
     {
         /// <summary>
-        /// Wrap IDisposable values in a lifetime scope. Scoped caches return lifetimes that prevent
+        /// Build an IScopedCache. IDisposable values are wrapped in a lifetime scope. Scoped caches return lifetimes that prevent
         /// values from being disposed until the calling code completes.
         /// </summary>
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The ConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>A ScopedConcurrentLruBuilder.</returns>
-        public static ScopedConcurrentLruBuilder<K, V, Scoped<V>> WithScopedValues<K, V>(this ConcurrentLruBuilder<K, V> builder) where V : IDisposable
+        public static ScopedConcurrentLruBuilder<K, V, Scoped<V>> AsScopedCache<K, V>(this ConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
             var convertBuilder = new ConcurrentLruBuilder<K, Scoped<V>>(builder.info);
             return new ScopedConcurrentLruBuilder<K, V, Scoped<V>>(convertBuilder);
         }
 
         /// <summary>
-        /// Wrap IDisposable values in a lifetime scope. Scoped caches return lifetimes that prevent
+        /// Build an IScopedCache. IDisposable values are wrapped in a lifetime scope. Scoped caches return lifetimes that prevent
         /// values from being disposed until the calling code completes.
         /// </summary>
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The AtomicConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicScopedConcurrentLruBuilder.</returns>
-        public static AtomicScopedConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AtomicConcurrentLruBuilder<K, V> builder) where V : IDisposable
+        public static AtomicScopedConcurrentLruBuilder<K, V> AsScopedCache<K, V>(this AtomicConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
             var convertBuilder = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(builder.info);
             return new AtomicScopedConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
         /// <summary>
-        /// Wrap IDisposable values in a lifetime scope. Scoped caches return lifetimes that prevent
+        /// Build an IScopedAsyncCache. IDisposable values are wrapped in a lifetime scope. Scoped caches return lifetimes that prevent
         /// values from being disposed until the calling code completes.
         /// </summary>
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The AsyncConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>A ScopedAsyncConcurrentLruBuilder.</returns>
-        public static ScopedAsyncConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
+        public static ScopedAsyncConcurrentLruBuilder<K, V> AsScopedCache<K, V>(this AsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
             var convertBuilder = new AsyncConcurrentLruBuilder<K, Scoped<V>>(builder.info);
             return new ScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
         /// <summary>
-        /// Wrap IDisposable values in a lifetime scope. Scoped caches return lifetimes that prevent
+        /// Build an IScopedAsyncCache. IDisposable values are wrapped in a lifetime scope. Scoped caches return lifetimes that prevent
         /// values from being disposed until the calling code completes.
         /// </summary>
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The AtomicAsyncConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicScopedAsyncConcurrentLruBuilder.</returns>
-        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AtomicAsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> AsScopedCache<K, V>(this AtomicAsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
             var convertBuilder = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(builder.info);
             return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);
@@ -74,7 +74,7 @@ namespace BitFaster.Caching.Lru
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The ConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicConcurrentLruBuilder.</returns>
-        public static AtomicConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this ConcurrentLruBuilder<K, V> builder)
+        public static AtomicConcurrentLruBuilder<K, V> WithAtomicValueFactory<K, V>(this ConcurrentLruBuilder<K, V> builder)
         {
             var convertBuilder = new ConcurrentLruBuilder<K, AtomicFactory<K, V>>(builder.info);
             return new AtomicConcurrentLruBuilder<K, V>(convertBuilder);
@@ -89,7 +89,7 @@ namespace BitFaster.Caching.Lru
         /// <typeparam name="W">The wrapped value type.</typeparam>
         /// <param name="builder">The ScopedConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicScopedConcurrentLruBuilder.</returns>
-        public static AtomicScopedConcurrentLruBuilder<K, V> WithAtomicCreate<K, V, W>(this ScopedConcurrentLruBuilder<K, V, W> builder) where V : IDisposable where W : IScoped<V>
+        public static AtomicScopedConcurrentLruBuilder<K, V> WithAtomicValueFactory<K, V, W>(this ScopedConcurrentLruBuilder<K, V, W> builder) where V : IDisposable where W : IScoped<V>
         {
             var convertBuilder = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(builder.info);
             return new AtomicScopedConcurrentLruBuilder<K, V>(convertBuilder);
@@ -103,7 +103,7 @@ namespace BitFaster.Caching.Lru
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The AsyncConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicAsyncConcurrentLruBuilder.</returns>
-        public static AtomicAsyncConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this AsyncConcurrentLruBuilder<K, V> builder)
+        public static AtomicAsyncConcurrentLruBuilder<K, V> WithAtomicValueFactory<K, V>(this AsyncConcurrentLruBuilder<K, V> builder)
         {
             var convertBuilder = new ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>>(builder.info);
             return new AtomicAsyncConcurrentLruBuilder<K, V>(convertBuilder);
@@ -117,7 +117,7 @@ namespace BitFaster.Caching.Lru
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The ScopedAsyncConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicScopedAsyncConcurrentLruBuilder.</returns>
-        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this ScopedAsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithAtomicValueFactory<K, V>(this ScopedAsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
             var convertBuilder = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(builder.info);
             return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilderExtensions.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilderExtensions.cs
@@ -18,29 +18,29 @@ namespace BitFaster.Caching.Lru
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The ConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>A ScopedLruBuilder</returns>
-        public static ScopedLruBuilder<K, V, Scoped<V>> WithScopedValues<K, V>(this ConcurrentLruBuilder<K, V> builder) where V : IDisposable
+        public static ScopedConcurrentLruBuilder<K, V, Scoped<V>> WithScopedValues<K, V>(this ConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
             var scoped = new ConcurrentLruBuilder<K, Scoped<V>>(builder.info);
-            return new ScopedLruBuilder<K, V, Scoped<V>>(scoped);
+            return new ScopedConcurrentLruBuilder<K, V, Scoped<V>>(scoped);
         }
 
-        public static AtomicLruBuilder<K, V> WithAtomicCreate<K, V>(this ConcurrentLruBuilder<K, V> b)
+        public static AtomicConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this ConcurrentLruBuilder<K, V> b)
         {
             var a = new ConcurrentLruBuilder<K, AtomicFactory<K, V>>(b.info);
-            return new AtomicLruBuilder<K, V>(a);
+            return new AtomicConcurrentLruBuilder<K, V>(a);
         }
 
-        public static ScopedAtomicLruBuilder<K, V> WithAtomicCreate<K, V, W>(this ScopedLruBuilder<K, V, W> b) where V : IDisposable where W : IScoped<V>
+        public static AtomicScopedConcurrentLruBuilder<K, V> WithAtomicCreate<K, V, W>(this ScopedConcurrentLruBuilder<K, V, W> b) where V : IDisposable where W : IScoped<V>
         {
             var atomicScoped = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(b.info);
 
-            return new ScopedAtomicLruBuilder<K, V>(atomicScoped);
+            return new AtomicScopedConcurrentLruBuilder<K, V>(atomicScoped);
         }
 
-        public static ScopedAtomicLruBuilder<K, V> WithScopedValues<K, V>(this AtomicLruBuilder<K, V> b) where V : IDisposable
+        public static AtomicScopedConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AtomicConcurrentLruBuilder<K, V> b) where V : IDisposable
         {
             var atomicScoped = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(b.info);
-            return new ScopedAtomicLruBuilder<K, V>(atomicScoped);
+            return new AtomicScopedConcurrentLruBuilder<K, V>(atomicScoped);
         }
 
         public static AsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this ConcurrentLruBuilder<K, V> builder)
@@ -48,46 +48,46 @@ namespace BitFaster.Caching.Lru
             return new AsyncConcurrentLruBuilder<K, V>(builder.info);
         }
 
-        public static ScopedAsyncLruBuilder<K, V> WithScopedValues<K, V>(this AsyncConcurrentLruBuilder<K, V> b) where V : IDisposable
+        public static ScopedAsyncConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AsyncConcurrentLruBuilder<K, V> b) where V : IDisposable
         {
             var asyncScoped = new AsyncConcurrentLruBuilder<K, Scoped<V>>(b.info);
-            return new ScopedAsyncLruBuilder<K, V>(asyncScoped);
+            return new ScopedAsyncConcurrentLruBuilder<K, V>(asyncScoped);
         }
 
-        public static ScopedAsyncLruBuilder<K, V> AsAsyncCache<K, V>(this ScopedLruBuilder<K, V, Scoped<V>> b) where V : IDisposable
+        public static ScopedAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this ScopedConcurrentLruBuilder<K, V, Scoped<V>> b) where V : IDisposable
         {
             var asyncScoped = new AsyncConcurrentLruBuilder<K, Scoped<V>>(b.info);
-            return new ScopedAsyncLruBuilder<K, V>(asyncScoped);
+            return new ScopedAsyncConcurrentLruBuilder<K, V>(asyncScoped);
         }
 
-        public static AsyncAtomicLruBuilder<K, V> AsAsyncCache<K, V>(this AtomicLruBuilder<K, V> b)
+        public static AtomicAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this AtomicConcurrentLruBuilder<K, V> b)
         {
             var a = new ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>>(b.info);
-            return new AsyncAtomicLruBuilder<K, V>(a);
+            return new AtomicAsyncConcurrentLruBuilder<K, V>(a);
         }
 
-        public static AsyncAtomicLruBuilder<K, V> WithAtomicCreate<K, V>(this AsyncConcurrentLruBuilder<K, V> b)
+        public static AtomicAsyncConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this AsyncConcurrentLruBuilder<K, V> b)
         {
             var a = new ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>>(b.info);
-            return new AsyncAtomicLruBuilder<K, V>(a);
+            return new AtomicAsyncConcurrentLruBuilder<K, V>(a);
         }
 
-        public static ScopedAsyncAtomicLruBuilder<K, V> AsAsyncCache<K, V>(this ScopedAtomicLruBuilder<K, V> b) where V : IDisposable
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> AsAsyncCache<K, V>(this AtomicScopedConcurrentLruBuilder<K, V> b) where V : IDisposable
         {
             var a = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(b.info);
-            return new ScopedAsyncAtomicLruBuilder<K, V>(a);
+            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(a);
         }
 
-        public static ScopedAsyncAtomicLruBuilder<K, V> WithScopedValues<K, V>(this AsyncAtomicLruBuilder<K, V> b) where V : IDisposable
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithScopedValues<K, V>(this AtomicAsyncConcurrentLruBuilder<K, V> b) where V : IDisposable
         {
             var a = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(b.info);
-            return new ScopedAsyncAtomicLruBuilder<K, V>(a);
+            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(a);
         }
 
-        public static ScopedAsyncAtomicLruBuilder<K, V> WithAtomicCreate<K, V>(this ScopedAsyncLruBuilder<K, V> b) where V : IDisposable
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithAtomicCreate<K, V>(this ScopedAsyncConcurrentLruBuilder<K, V> b) where V : IDisposable
         {
             var a = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(b.info);
-            return new ScopedAsyncAtomicLruBuilder<K, V>(a);
+            return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(a);
         }
     }
 }


### PR DESCRIPTION
Name builder types with a consistent order:

async => cache
scoped => async
atomic => scoped, async

Rename builder extension methods so that methods changing the cache type have prefix 'As', and configuration methods have prefix 'With', e.g.

```cs
var lru = new ConcurrentLruBuilder<int, Disposable>()
   .WithAtomicValueFactory()
   .AsAsyncCache()
   .AsScopedCache()
   .WithCapacity(3)
   .Build();
```
Add descriptive comments to the builder extension methods making it easier to use.