### PR TITLE
getoradd

### DIFF
--- a/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
@@ -20,7 +20,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     {
         // if the cache value is a value type, value task has no effect - so use string to repro.
         private static readonly IAsyncCache<int, string> concurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().Build();
-        private static readonly IAsyncCache<int, string> atomicConcurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().WithAtomicValueFactory().Build();
+        private static readonly IAsyncCache<int, string> atomicConcurrentLru = new ConcurrentLruBuilder<int, string>().AsAsyncCache().WithAtomicGetOrAdd().Build();
 
         private static Task<string> returnTask = Task.FromResult("1");
 

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -44,7 +44,7 @@ namespace BitFaster.Caching.Benchmarks
         private static readonly FastConcurrentLru<int, int> fastConcurrentLru = new FastConcurrentLru<int, int>(8, 9, EqualityComparer<int>.Default);
         private static readonly FastConcurrentTLru<int, int> fastConcurrentTLru = new FastConcurrentTLru<int, int>(8, 9, EqualityComparer<int>.Default, TimeSpan.FromMinutes(1));
 
-        private static readonly ICache<int, int> atomicFastLru = new ConcurrentLruBuilder<int, int>().WithConcurrencyLevel(8).WithCapacity(9).WithAtomicValueFactory().Build();
+        private static readonly ICache<int, int> atomicFastLru = new ConcurrentLruBuilder<int, int>().WithConcurrencyLevel(8).WithCapacity(9).WithAtomicGetOrAdd().Build();
 
         private static readonly int key = 1;
         private static System.Runtime.Caching.MemoryCache memoryCache = System.Runtime.Caching.MemoryCache.Default;

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -209,7 +209,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicFactory()
         {
             ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .WithCapacity(3)
                 .Build();
 
@@ -233,7 +233,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicWithScope()
         {
             IScopedCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .AsScopedCache()
                 .WithCapacity(3)
                 .Build();
@@ -248,7 +248,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             IScopedCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsScopedCache()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .WithCapacity(3)
                 .Build();
 
@@ -290,7 +290,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicAsAsync()
         {
             IAsyncCache<int, int> lru = new ConcurrentLruBuilder<int, int>()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .AsAsyncCache()
                 .WithCapacity(3)
                 .Build();
@@ -304,7 +304,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             IAsyncCache<int, int> lru = new ConcurrentLruBuilder<int, int>()
                 .AsAsyncCache()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .WithCapacity(3)
                 .Build();
 
@@ -316,7 +316,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicWithScopedAsAsync()
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .AsScopedCache()
                 .AsAsyncCache()
                 .WithCapacity(3)
@@ -330,7 +330,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WithAtomicAsAsyncWithScoped()
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .AsAsyncCache()
                 .AsScopedCache()
                 .WithCapacity(3)
@@ -345,7 +345,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsScopedCache()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .AsAsyncCache()
                 .WithCapacity(3)
                 .Build();
@@ -360,7 +360,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsScopedCache()
                 .AsAsyncCache()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .WithCapacity(3)
                 .Build();
 
@@ -374,7 +374,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsAsyncCache()
                 .AsScopedCache()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .WithCapacity(3)
                 .Build();
 
@@ -387,7 +387,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             IScopedAsyncCache<int, Disposable> lru = new ConcurrentLruBuilder<int, Disposable>()
                 .AsAsyncCache()
-                .WithAtomicValueFactory()
+                .WithAtomicGetOrAdd()
                 .AsScopedCache()
                 .WithCapacity(3)
                 .Build();

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilderExtensions.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilderExtensions.cs
@@ -67,57 +67,61 @@ namespace BitFaster.Caching.Lru
         }
 
         /// <summary>
-        /// Execute the cache's GetOrAdd value factory atomically, such that it is applied at most once per key. Other threads
-        /// attempting to update the same key will be blocked until value factory completes.
+        /// Execute the cache's GetOrAdd method atomically, such that it is applied at most once per key. Other threads
+        /// attempting to update the same key will be blocked until value factory completes. Incurs a small performance
+        /// penalty.
         /// </summary>
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The ConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicConcurrentLruBuilder.</returns>
-        public static AtomicConcurrentLruBuilder<K, V> WithAtomicValueFactory<K, V>(this ConcurrentLruBuilder<K, V> builder)
+        public static AtomicConcurrentLruBuilder<K, V> WithAtomicGetOrAdd<K, V>(this ConcurrentLruBuilder<K, V> builder)
         {
             var convertBuilder = new ConcurrentLruBuilder<K, AtomicFactory<K, V>>(builder.info);
             return new AtomicConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
         /// <summary>
-        /// Execute the cache's ScopedGetOrAdd value factory atomically, such that it is applied at most once per key. Other threads
-        /// attempting to update the same key will be blocked until value factory completes.
+        /// Execute the cache's GetOrAdd method atomically, such that it is applied at most once per key. Other threads
+        /// attempting to update the same key will be blocked until value factory completes. Incurs a small performance
+        /// penalty.
         /// </summary>
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <typeparam name="W">The wrapped value type.</typeparam>
         /// <param name="builder">The ScopedConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicScopedConcurrentLruBuilder.</returns>
-        public static AtomicScopedConcurrentLruBuilder<K, V> WithAtomicValueFactory<K, V, W>(this ScopedConcurrentLruBuilder<K, V, W> builder) where V : IDisposable where W : IScoped<V>
+        public static AtomicScopedConcurrentLruBuilder<K, V> WithAtomicGetOrAdd<K, V, W>(this ScopedConcurrentLruBuilder<K, V, W> builder) where V : IDisposable where W : IScoped<V>
         {
             var convertBuilder = new ConcurrentLruBuilder<K, ScopedAtomicFactory<K, V>>(builder.info);
             return new AtomicScopedConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
         /// <summary>
-        /// Execute the cache's GetOrAddAsync value factory atomically, such that it is applied at most once per key. Other threads
-        /// attempting to update the same key will wait on the same value factory task.
+        /// Execute the cache's GetOrAdd method atomically, such that it is applied at most once per key. Other threads
+        /// attempting to update the same key will be blocked until value factory completes. Incurs a small performance
+        /// penalty.
         /// </summary>
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The AsyncConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicAsyncConcurrentLruBuilder.</returns>
-        public static AtomicAsyncConcurrentLruBuilder<K, V> WithAtomicValueFactory<K, V>(this AsyncConcurrentLruBuilder<K, V> builder)
+        public static AtomicAsyncConcurrentLruBuilder<K, V> WithAtomicGetOrAdd<K, V>(this AsyncConcurrentLruBuilder<K, V> builder)
         {
             var convertBuilder = new ConcurrentLruBuilder<K, AsyncAtomicFactory<K, V>>(builder.info);
             return new AtomicAsyncConcurrentLruBuilder<K, V>(convertBuilder);
         }
 
         /// <summary>
-        /// Execute the cache's ScopedGetOrAddAsync value factory atomically, such that it is applied at most once per key. Other threads
-        /// attempting to update the same key will wait on the same value factory task.
+        /// Execute the cache's GetOrAdd method atomically, such that it is applied at most once per key. Other threads
+        /// attempting to update the same key will be blocked until value factory completes. Incurs a small performance
+        /// penalty.
         /// </summary>
         /// <typeparam name="K">The type of keys in the cache.</typeparam>
         /// <typeparam name="V">The type of values in the cache.</typeparam>
         /// <param name="builder">The ScopedAsyncConcurrentLruBuilder to chain method calls onto.</param>
         /// <returns>An AtomicScopedAsyncConcurrentLruBuilder.</returns>
-        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithAtomicValueFactory<K, V>(this ScopedAsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
+        public static AtomicScopedAsyncConcurrentLruBuilder<K, V> WithAtomicGetOrAdd<K, V>(this ScopedAsyncConcurrentLruBuilder<K, V> builder) where V : IDisposable
         {
             var convertBuilder = new AsyncConcurrentLruBuilder<K, ScopedAsyncAtomicFactory<K, V>>(builder.info);
             return new AtomicScopedAsyncConcurrentLruBuilder<K, V>(convertBuilder);


### PR DESCRIPTION
Rename extension method to make it clear that GetOrAdd is atomic, not the value factory.

```cs
var lru = new ConcurrentLruBuilder<int, int>()
                .WithAtomicGetOrAdd()
                .WithCapacity(3)
                .Build();
```