### PR TITLE
perf

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -227,13 +227,13 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void CanExpireIsFalse()
         {
-            this.lru.CanExpire.Should().BeFalse();
+            this.lru.Policy.ExpireAfterWrite.CanExpire.Should().BeFalse();
         }
 
         [Fact]
         public void TimeToLiveIsInfinite()
         {
-            this.lru.TimeToLive.Should().Be(NoneTimePolicy.Infinite);
+            this.lru.Policy.ExpireAfterWrite.TimeToLive.Should().Be(NoneTimePolicy.Infinite);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -55,13 +55,13 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void CanExpireIsTrue()
         {
-            this.lru.CanExpire.Should().BeTrue();
+            this.lru.Policy.ExpireAfterWrite.CanExpire.Should().BeTrue();
         }
 
         [Fact]
         public void TimeToLiveIsCtorArg()
         {
-            this.lru.TimeToLive.Should().Be(timeToLive);
+            this.lru.Policy.ExpireAfterWrite.TimeToLive.Should().Be(timeToLive);
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             await Task.Delay(timeToLive * 2);
 
-            lru.TrimExpired();
+            lru.Policy.ExpireAfterWrite.TrimExpired();
 
             lru.Count.Should().Be(0);
         }
@@ -177,7 +177,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(2, valueFactory.Create);
             lru.GetOrAdd(3, valueFactory.Create);
 
-            lru.TrimExpired();
+            lru.Policy.ExpireAfterWrite.TrimExpired();
 
             lru.Count.Should().Be(3);
         }

--- a/BitFaster.Caching.UnitTests/Lru/FastConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/FastConcurrentTLruTests.cs
@@ -49,7 +49,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             await Task.Delay(ttl * 2);
 
-            lru.TrimExpired();
+            lru.Policy.ExpireAfterWrite.TrimExpired();
 
             lru.Count.Should().Be(0);
         }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -53,9 +53,6 @@ namespace BitFaster.Caching.Lru
         // if mutate methods are called. Therefore, field must be mutable to maintain count.
         protected T telemetryPolicy;
 
-        //private readonly CachePolicy policy;
-        //private readonly Proxy proxy;
-
         public ConcurrentLruCore(
             int concurrencyLevel,
             ICapacityPartition capacity,
@@ -86,9 +83,6 @@ namespace BitFaster.Caching.Lru
             this.itemPolicy = itemPolicy;
             this.telemetryPolicy = telemetryPolicy;
             this.telemetryPolicy.SetEventSource(this);
-
-            //this.proxy = new Proxy(this);
-            //this.policy = new CachePolicy(this.proxy, this.proxy);
         }
 
         // No lock count: https://arbel.net/2013/02/03/best-practices-for-using-concurrentdictionary/
@@ -105,9 +99,6 @@ namespace BitFaster.Caching.Lru
         public ICacheEvents<K, V> Events => new Proxy(this);
 
         public CachePolicy Policy => CreatePolicy(this);
-
-    private static CachePolicy CreatePolicy(ConcurrentLruCore<K, V, I, P, T> lru)
-        { var p = new Proxy(lru); return new CachePolicy(p, p); }
 
         public int HotCount => this.hotCount;
 
@@ -623,6 +614,12 @@ namespace BitFaster.Caching.Lru
         IEnumerator IEnumerable.GetEnumerator()
         {
             return ((ConcurrentLruCore<K, V, I, P, T>)this).GetEnumerator();
+        }
+
+        private static CachePolicy CreatePolicy(ConcurrentLruCore<K, V, I, P, T> lru)
+        { 
+            var p = new Proxy(lru); 
+            return new CachePolicy(p, p); 
         }
 
         // To get JIT optimizations, policies must be structs.

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -53,7 +53,8 @@ namespace BitFaster.Caching.Lru
         // if mutate methods are called. Therefore, field must be mutable to maintain count.
         protected T telemetryPolicy;
 
-        private readonly CachePolicy policy;
+        //private readonly CachePolicy policy;
+        //private readonly Proxy proxy;
 
         public ConcurrentLruCore(
             int concurrencyLevel,
@@ -86,8 +87,8 @@ namespace BitFaster.Caching.Lru
             this.telemetryPolicy = telemetryPolicy;
             this.telemetryPolicy.SetEventSource(this);
 
-            var p = new Proxy(this);
-            this.policy = new CachePolicy(p, p);
+            //this.proxy = new Proxy(this);
+            //this.policy = new CachePolicy(this.proxy, this.proxy);
         }
 
         // No lock count: https://arbel.net/2013/02/03/best-practices-for-using-concurrentdictionary/
@@ -103,6 +104,11 @@ namespace BitFaster.Caching.Lru
         ///<inheritdoc/>
         public ICacheEvents<K, V> Events => new Proxy(this);
 
+        public CachePolicy Policy => CreatePolicy(this);
+
+    private static CachePolicy CreatePolicy(ConcurrentLruCore<K, V, I, P, T> lru)
+        { var p = new Proxy(lru); return new CachePolicy(p, p); }
+
         public int HotCount => this.hotCount;
 
         public int WarmCount => this.warmCount;
@@ -113,12 +119,6 @@ namespace BitFaster.Caching.Lru
         /// Gets a collection containing the keys in the cache.
         /// </summary>
         public ICollection<K> Keys => this.dictionary.Keys;
-
-        public CachePolicy Policy => this.policy;
-
-       // public bool CanExpire => this.itemPolicy.CanDiscard();
-
-       // public TimeSpan TimeToLive => this.itemPolicy.TimeToLive;
 
         /// <summary>Returns an enumerator that iterates through the cache.</summary>
         /// <returns>An enumerator for the cache.</returns>

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -342,6 +342,13 @@ namespace BitFaster.Caching.Lru
             TrimLiveItems(itemsRemoved, itemCount, capacity);
         }
 
+        private void TrimExpired()
+        {
+            if (this.itemPolicy.CanDiscard())
+            {
+                this.TrimAllDiscardedItems();
+            }
+        }
 
         protected int TrimAllDiscardedItems()
         {
@@ -669,10 +676,7 @@ namespace BitFaster.Caching.Lru
 
             public void TrimExpired()
             {
-                if (lru.itemPolicy.CanDiscard())
-                {
-                    lru.TrimAllDiscardedItems();
-                }
+                lru.TrimExpired();
             }
         }
     }


### PR DESCRIPTION
Inheriting from IBoundedPolicy/ITimePolicy comes with some overhead, so use proxy. Caching an instance of proxy inside lru core also results in the same penalty.

Before:
|                   Method |            Runtime |       Mean |     Error | Ratio | Code Size | Allocated |
|------------------------- |------------------- |-----------:|----------:|------:|----------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   7.368 ns | 0.0568 ns |  1.00 |   1,523 B |         - |
|        FastConcurrentLru |           .NET 6.0 |  10.248 ns | 0.2043 ns |  1.39 |   2,352 B |         - |
|            ConcurrentLru |           .NET 6.0 |  13.693 ns | 0.1725 ns |  1.86 |   2,378 B |         - |
|            AtomicFastLru |           .NET 6.0 |  19.988 ns | 0.1546 ns |  2.71 |     846 B |         - |
|       FastConcurrentTLru |           .NET 6.0 |  26.544 ns | 0.3709 ns |  3.61 |   2,544 B |         - |
|           ConcurrentTLru |           .NET 6.0 |  32.986 ns | 0.3864 ns |  4.48 |   2,619 B |         - |
|               ClassicLru |           .NET 6.0 |  48.563 ns | 0.3721 ns |  6.60 |   3,041 B |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 121.734 ns | 2.3760 ns | 16.60 |      49 B |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  53.987 ns | 0.4352 ns |  7.33 |      78 B |      24 B |
|                          |                    |            |           |       |           |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  14.333 ns | 0.2964 ns |  1.00 |   4,207 B |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  15.140 ns | 0.2779 ns |  1.06 |  15,182 B |         - |
|            ConcurrentLru | .NET Framework 4.8 |  17.627 ns | 0.3523 ns |  1.23 |  15,212 B |         - |
|            AtomicFastLru | .NET Framework 4.8 |  39.460 ns | 0.7806 ns |  2.76 |     358 B |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  45.415 ns | 0.5684 ns |  3.17 |  15,358 B |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  47.494 ns | 0.7391 ns |  3.31 |  15,403 B |         - |
|               ClassicLru | .NET Framework 4.8 |  61.447 ns | 0.8935 ns |  4.28 |   6,945 B |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 282.429 ns | 3.1541 ns | 19.72 |      33 B |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 114.503 ns | 1.4632 ns |  7.99 |      82 B |      24 B |

After:

|                   Method |            Runtime |       Mean |     Error | Ratio | Code Size | Allocated |
|------------------------- |------------------- |-----------:|----------:|------:|----------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   8.132 ns | 0.1803 ns |  1.00 |   1,523 B |         - |
|        FastConcurrentLru |           .NET 6.0 |  10.059 ns | 0.0674 ns |  1.24 |   2,352 B |         - |
|            ConcurrentLru |           .NET 6.0 |  13.665 ns | 0.0694 ns |  1.68 |   2,378 B |         - |
|            AtomicFastLru |           .NET 6.0 |  19.910 ns | 0.3562 ns |  2.45 |     846 B |         - |
|       FastConcurrentTLru |           .NET 6.0 |  25.743 ns | 0.2754 ns |  3.17 |   2,544 B |         - |
|           ConcurrentTLru |           .NET 6.0 |  29.895 ns | 0.0757 ns |  3.68 |   2,619 B |         - |
|               ClassicLru |           .NET 6.0 |  48.791 ns | 0.8167 ns |  6.01 |   3,041 B |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 117.031 ns | 1.9028 ns | 14.44 |      49 B |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  54.898 ns | 1.0983 ns |  6.77 |      78 B |      24 B |
|                          |                    |            |           |       |           |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  13.810 ns | 0.1752 ns |  1.00 |   4,207 B |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  15.032 ns | 0.3198 ns |  1.09 |  15,182 B |         - |
|            ConcurrentLru | .NET Framework 4.8 |  17.699 ns | 0.3127 ns |  1.28 |  15,212 B |         - |
|            AtomicFastLru | .NET Framework 4.8 |  40.034 ns | 0.3762 ns |  2.90 |     358 B |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  45.270 ns | 0.1457 ns |  3.28 |  15,358 B |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  46.651 ns | 0.7994 ns |  3.38 |  15,403 B |         - |
|               ClassicLru | .NET Framework 4.8 |  61.811 ns | 0.8297 ns |  4.47 |   6,945 B |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 277.511 ns | 1.1883 ns | 20.08 |      33 B |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 113.441 ns | 1.1372 ns |  8.21 |      82 B |      24 B |