### PR TITLE
update metric

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -233,7 +233,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var scheduler = new TestScheduler();
             cache = new ConcurrentLfu<int, int>(1, 20, scheduler);
 
-            cache.GetOrAdd(-1, k => k);
+            cache.GetOrAdd(1, k => k);
             scheduler.RunCount.Should().Be(1);
             cache.PendingMaintenance();
 
@@ -244,7 +244,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             cache.PendingMaintenance();
 
-            // TODO: how to verify this? There is no counter for updates.
+            cache.Metrics.Value.Updated.Should().Be(bufferSize);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -373,11 +373,31 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenKeyExistsTryUpdateIncrementsUpdateCount()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryUpdate(1, "2").Should().BeTrue();
+
+            lru.Metrics.Value.Updated.Should().Be(1);
+        }
+
+        [Fact]
         public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
             lru.TryUpdate(2, "3").Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenKeyDoesNotExistTryUpdateDoesNotIncrementCounter()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryUpdate(2, "3").Should().BeFalse();
+
+            lru.Metrics.Value.Updated.Should().Be(0);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -637,11 +637,31 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenKeyExistsTryUpdateIncrementsUpdateCount()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryUpdate(1, "2").Should().BeTrue();
+
+            lru.Metrics.Value.Updated.Should().Be(1);
+        }
+
+        [Fact]
         public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
             lru.TryUpdate(2, "3").Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenKeyDoesNotExistTryUpdateDoesNotIncrementCounter()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryUpdate(2, "3").Should().BeFalse();
+
+            lru.Metrics.Value.Updated.Should().Be(0);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/NoTelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/NoTelemetryPolicyTests.cs
@@ -36,6 +36,12 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void UpdatedIsZero()
+        {
+            counter.Updated.Should().Be(0);
+        }
+
+        [Fact]
         public void EvictedIsZero()
         {
             counter.Evicted.Should().Be(0);
@@ -51,6 +57,12 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void IncrementTotalCountIsNoOp()
         {
             counter.Invoking(c => c.IncrementMiss()).Should().NotThrow();
+        }
+
+        [Fact]
+        public void OnItemUpdatedIsNoOp()
+        {
+            counter.Invoking(c => c.OnItemUpdated(1, 2)).Should().NotThrow();
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
@@ -64,7 +64,15 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
-        public void WhenItemRemovedIsEvictedIncrementEvictedCount()
+        public void WhenItemUpdatedIncrementUpdatedCount()
+        {
+            telemetryPolicy.OnItemUpdated(1, 2);
+
+            telemetryPolicy.Updated.Should().Be(1);
+        }
+
+        [Fact]
+        public void WhenItemRemovedIncrementEvictedCount()
         {
             telemetryPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
 
@@ -72,7 +80,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
-        public void WhenItemRemovedIsRemovedDontIncrementEvictedCount()
+        public void WhenItemRemovedDontIncrementEvictedCount()
         {
             telemetryPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Removed);
 

--- a/BitFaster.Caching/ICacheMetrics.cs
+++ b/BitFaster.Caching/ICacheMetrics.cs
@@ -36,5 +36,10 @@ namespace BitFaster.Caching
         /// Gets the total number of evicted items.
         /// </summary>
         long Evicted { get; }
+
+        /// <summary>
+        /// Gets the total number of updated items.
+        /// </summary>
+        long Updated { get; }
     }
 }

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -464,13 +464,16 @@ namespace BitFaster.Caching.Lfu
                     else
                     {
                         this.windowLru.MoveToEnd(node);
+                        this.metrics.updatedCount++;
                     }
                     break;
                 case Position.Probation:
                     PromoteProbation(node);
+                    this.metrics.updatedCount++;
                     break;
                 case Position.Protected:
                     this.protectedLru.MoveToEnd(node);
+                    this.metrics.updatedCount++;
                     break;
             }
         }
@@ -592,6 +595,7 @@ namespace BitFaster.Caching.Lfu
         {
             public long requestHitCount;
             public long requestMissCount;
+            public long updatedCount;
             public long evictedCount;
 
             public double HitRatio => (double)requestHitCount / (double)Total;
@@ -601,6 +605,8 @@ namespace BitFaster.Caching.Lfu
             public long Hits => requestHitCount;
 
             public long Misses => requestMissCount;
+
+            public long Updated => updatedCount;
 
             public long Evicted => evictedCount;
         }

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -224,6 +224,7 @@ namespace BitFaster.Caching.Lru
             if (this.dictionary.TryGetValue(key, out var node))
             {
                 node.Value.Value = value;
+                Interlocked.Increment(ref this.metrics.updatedCount);
                 return true;
             }
 
@@ -238,6 +239,7 @@ namespace BitFaster.Caching.Lru
             if (this.dictionary.TryGetValue(key, out var existingNode))
             {
                 existingNode.Value.Value = value;
+                Interlocked.Increment(ref this.metrics.updatedCount);
                 return;
             }
 
@@ -377,6 +379,7 @@ namespace BitFaster.Caching.Lru
         {
             public long requestHitCount;
             public long requestTotalCount;
+            public long updatedCount;
             public long evictedCount;
 
             public double HitRatio => (double)requestHitCount / (double)requestTotalCount;
@@ -388,6 +391,8 @@ namespace BitFaster.Caching.Lru
             public long Misses => requestTotalCount - requestHitCount;
 
             public long Evicted => evictedCount;
+
+            public long Updated => updatedCount;
         }
     }
 }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -263,6 +263,7 @@ namespace BitFaster.Caching.Lru
                         V oldValue = existing.Value;
                         existing.Value = value;
                         this.itemPolicy.Update(existing);
+                        this.telemetryPolicy.OnItemUpdated(existing.Key, existing.Value);
                         Disposer<V>.Dispose(oldValue);
 
                         return true;
@@ -654,6 +655,8 @@ namespace BitFaster.Caching.Lru
             public long Misses => lru.telemetryPolicy.Misses;
 
             public long Evicted => lru.telemetryPolicy.Evicted;
+
+            public long Updated => lru.telemetryPolicy.Updated;
 
             public int Capacity => lru.Capacity;
 

--- a/BitFaster.Caching/Lru/ITelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/ITelemetryPolicy.cs
@@ -14,6 +14,8 @@ namespace BitFaster.Caching.Lru
 
         void OnItemRemoved(K key, V value, ItemRemovedReason reason);
 
+        void OnItemUpdated(K key, V value);
+
         void SetEventSource(object source);
     }
 }

--- a/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/NoTelemetryPolicy.cs
@@ -17,6 +17,8 @@ namespace BitFaster.Caching.Lru
 
         public long Misses => 0;
 
+        public long Updated => 0;
+
         public long Evicted => 0;
 
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
@@ -38,6 +40,11 @@ namespace BitFaster.Caching.Lru
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void OnItemRemoved(K key, V value, ItemRemovedReason reason)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnItemUpdated(K key, V value)
         {
         }
 

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -13,6 +13,7 @@ namespace BitFaster.Caching.Lru
         private long hitCount;
         private long missCount;
         private long evictedCount;
+        private long updatedCount;
         private object eventSource;
 
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
@@ -26,6 +27,8 @@ namespace BitFaster.Caching.Lru
         public long Misses => this.missCount;
 
         public long Evicted => this.evictedCount;
+
+        public long Updated => this.updatedCount;
 
         public void IncrementMiss()
         {
@@ -46,6 +49,11 @@ namespace BitFaster.Caching.Lru
 
             // passing 'this' as source boxes the struct, and is anyway the wrong object
             this.ItemRemoved?.Invoke(this.eventSource, new ItemRemovedEventArgs<K, V>(key, value, reason));
+        }
+
+        public void OnItemUpdated(K key, V value)
+        {
+            Interlocked.Increment(ref this.updatedCount);
         }
 
         public void SetEventSource(object source)


### PR DESCRIPTION
Add a cache metric for item update count.

|                   Method |            Runtime |       Mean |     Error |     StdDev | Ratio | Code Size | Allocated |
|------------------------- |------------------- |-----------:|----------:|-----------:|------:|----------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   7.886 ns | 0.0420 ns |  0.0351 ns |  1.00 |   1,523 B |         - |
|        FastConcurrentLru |           .NET 6.0 |   9.767 ns | 0.0634 ns |  0.0846 ns |  1.24 |   2,352 B |         - |
|            ConcurrentLru |           .NET 6.0 |  13.665 ns | 0.1322 ns |  0.1236 ns |  1.73 |   2,378 B |         - |
|            AtomicFastLru |           .NET 6.0 |  20.132 ns | 0.1051 ns |  0.0983 ns |  2.55 |     846 B |         - |
|       FastConcurrentTLru |           .NET 6.0 |  25.985 ns | 0.1771 ns |  0.1656 ns |  3.29 |   2,544 B |         - |
|           ConcurrentTLru |           .NET 6.0 |  30.040 ns | 0.2510 ns |  0.2225 ns |  3.81 |   2,619 B |         - |
|            ConcurrentLfu |           .NET 6.0 |  67.840 ns | 5.7485 ns | 16.9495 ns |  6.58 |   8,457 B |         - |
|               ClassicLru |           .NET 6.0 |  48.530 ns | 0.3970 ns |  0.3714 ns |  6.16 |   3,041 B |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 118.402 ns | 0.6894 ns |  0.6449 ns | 15.01 |      49 B |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  56.707 ns | 0.3290 ns |  0.2916 ns |  7.19 |      78 B |      24 B |
|                          |                    |            |           |            |       |           |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  13.790 ns | 0.0992 ns |  0.0879 ns |  1.00 |   4,207 B |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  14.544 ns | 0.1047 ns |  0.0979 ns |  1.05 |  15,182 B |         - |
|            ConcurrentLru | .NET Framework 4.8 |  16.762 ns | 0.1177 ns |  0.1101 ns |  1.22 |  15,212 B |         - |
|            AtomicFastLru | .NET Framework 4.8 |  37.702 ns | 0.1728 ns |  0.1532 ns |  2.73 |     358 B |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  47.849 ns | 0.1441 ns |  0.1125 ns |  3.47 |  15,358 B |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  45.839 ns | 0.1386 ns |  0.1158 ns |  3.32 |  15,403 B |         - |
|            ConcurrentLfu | .NET Framework 4.8 |  73.070 ns | 1.4727 ns |  1.8625 ns |  5.32 |  11,674 B |         - |
|               ClassicLru | .NET Framework 4.8 |  64.093 ns | 0.2857 ns |  0.2386 ns |  4.64 |   6,945 B |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 276.859 ns | 2.9298 ns |  2.5972 ns | 20.08 |      33 B |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 111.356 ns | 0.3487 ns |  0.3262 ns |  8.07 |      82 B |      24 B |