### PR TITLE
rawbuffer

### DIFF
--- a/BitFaster.Caching.UnitTests/Buffers/BoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/BoundedBufferTests.cs
@@ -38,19 +38,19 @@ namespace BitFaster.Caching.UnitTests.Buffers
         public void WhenBufferHasOneItemCountIsOne()
         {
             // head < tail
-            buffer.TryAdd(1);
+            buffer.TryAddRaw(1);
             buffer.Count.Should().Be(1);
         }
 
         [Fact]
         public void WhenBufferHas15ItemCountIs15()
         {
-            buffer.TryAdd(0).Should().Be(BufferStatus.Success);
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Success);
+            buffer.TryAddRaw(0).Should().Be(BufferStatus.Success);
+            buffer.TryTakeRaw(out var _).Should().Be(BufferStatus.Success);
 
             for (var i = 0; i < 15; i++)
             {
-                buffer.TryAdd(0).Should().Be(BufferStatus.Success);
+                buffer.TryAddRaw(0).Should().Be(BufferStatus.Success);
             }
 
             // head = 1, tail = 0 : head > tail
@@ -62,38 +62,38 @@ namespace BitFaster.Caching.UnitTests.Buffers
         {
             for (var i = 0; i < 16; i++)
             {
-                buffer.TryAdd(i).Should().Be(BufferStatus.Success);
+                buffer.TryAddRaw(i).Should().Be(BufferStatus.Success);
             }
 
-            buffer.TryAdd(666).Should().Be(BufferStatus.Full);
+            buffer.TryAddRaw(666).Should().Be(BufferStatus.Full);
         }
 
         [Fact]
         public void WhenBufferIsEmptyTryTakeIsFalse()
         {
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Empty);
+            buffer.TryTakeRaw(out var _).Should().Be(BufferStatus.Empty);
         }
 
         [Fact]
         public void WhenItemAddedItCanBeTaken()
         {
-            buffer.TryAdd(123).Should().Be(BufferStatus.Success);
-            buffer.TryTake(out var item).Should().Be(BufferStatus.Success);
+            buffer.TryAddRaw(123).Should().Be(BufferStatus.Success);
+            buffer.TryTakeRaw(out var item).Should().Be(BufferStatus.Success);
             item.Should().Be(123);
         }
 
         [Fact]
         public void WhenItemsAreAddedClearRemovesItems()
         {
-            buffer.TryAdd(1);
-            buffer.TryAdd(2);
+            buffer.TryAddRaw(1);
+            buffer.TryAddRaw(2);
 
             buffer.Count.Should().Be(2);
 
             buffer.Clear();
 
             buffer.Count.Should().Be(0);
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Empty);
+            buffer.TryTakeRaw(out var _).Should().Be(BufferStatus.Empty);
         }
     }
 }

--- a/BitFaster.Caching/Buffers/BoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/BoundedBuffer.cs
@@ -118,7 +118,7 @@ namespace BitFaster.Caching.Buffers
             {
                 switch (TryAddRaw(item))
                 {
-                    case BufferStatus.Empty:
+                    case BufferStatus.Full:
                         return false;
                     case BufferStatus.Success:
                         return true;

--- a/BitFaster.Caching/Buffers/StripedBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedBuffer.cs
@@ -44,7 +44,7 @@ namespace BitFaster.Caching.Buffers
 
                 while (count < outputBuffer.Length & status != BufferStatus.Empty)
                 {
-                    status = buffers[i].TryTake(out var item);
+                    status = buffers[i].TryTakeRaw(out var item);
 
                     if (status == BufferStatus.Success)
                     {
@@ -89,7 +89,7 @@ namespace BitFaster.Caching.Buffers
 
             for (var i = 0; i < MaxAttempts; i++)
             {
-                result = buffers[h & mask].TryAdd(item);
+                result = buffers[h & mask].TryAddRaw(item);
 
                 if (result == BufferStatus.Success)
                 {


### PR DESCRIPTION
Provide API for both TryAdd/Take with spin loop or TryAddRaw/TakeRaw which exposes buffer status.

This makes it easier to write the background scheduler code, which should always retry on contention.