### PR TITLE
fix eviction logic

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -544,60 +544,61 @@ namespace BitFaster.Caching.Lfu
         private void EvictFromMain(int candidates)
         {
             // var victimQueue = Position.Probation;
-            var victim = this.probationLru.First;
-            var candidate = this.probationLru.Last;
+            var victim = this.probationLru.First; // victims are LRU position in probation
+            var candidate = this.probationLru.Last; // candidates are MRU position, promoted from window
 
             while (this.windowLru.Count + this.probationLru.Count + this.protectedLru.Count > this.Capacity)
             {
-                // TODO: this logic is only reachable if entries have time expiry, and are removed early.
-                // Search the admission window for additional candidates
-                //if (candidates == 0)
-                //{
-                //    candidate = this.windowLru.First;
-                //}
+                {
+                    // TODO: this logic is only reachable if entries have time expiry, and are removed early.
+                    // Search the admission window for additional candidates
+                    //if (candidates == 0)
+                    //{
+                    //    candidate = this.windowLru.First;
+                    //}
 
-                //// Try evicting from the protected and window queues
-                //if (candidate == null && victim == null)
-                //{
+                    //// Try evicting from the protected and window queues
+                    //if (candidate == null && victim == null)
+                    //{
 
-                //    if (victimQueue == Position.Probation)
-                //    {
-                //        victim = this.protectedLru.First;
-                //        victimQueue = Position.Protected;
-                //        continue;
-                //    }
-                //    else if (victimQueue == Position.Protected)
-                //    {
-                //        victim = this.windowLru.First;
-                //        victimQueue = Position.Window;
-                //        continue;
-                //    }
+                    //    if (victimQueue == Position.Probation)
+                    //    {
+                    //        victim = this.protectedLru.First;
+                    //        victimQueue = Position.Protected;
+                    //        continue;
+                    //    }
+                    //    else if (victimQueue == Position.Protected)
+                    //    {
+                    //        victim = this.windowLru.First;
+                    //        victimQueue = Position.Window;
+                    //        continue;
+                    //    }
 
-                //    // The pending operations will adjust the size to reflect the correct weight
-                //    break;
-                //}
+                    //    // The pending operations will adjust the size to reflect the correct weight
+                    //    break;
+                    //}
 
-                // Evict immediately if only one of the entries is present
-                //if (victim == null)
-                //{
-                //    var previous = candidate.Previous;
-                //    var evictee = candidate;
-                //    candidate = previous;
+                    // Evict immediately if only one of the entries is present
+                    //if (victim == null)
+                    //{
+                    //    var previous = candidate.Previous;
+                    //    var evictee = candidate;
+                    //    candidate = previous;
 
-                //    Evict(evictee);
+                    //    Evict(evictee);
 
-                //    candidates--;
-                //    continue;
-                //}
-                //else if (candidate == null)
-                //{
-                //    var evictee = victim;
-                //    victim = victim.Previous;
+                    //    candidates--;
+                    //    continue;
+                    //}
+                    //else if (candidate == null)
+                    //{
+                    //    var evictee = victim;
+                    //    victim = victim.Previous;
 
-                //    Evict(evictee);
-                //    continue;
-                //}
-
+                    //    Evict(evictee);
+                    //    continue;
+                    //}
+                }
                 // Evict the entry with the lowest frequency
                 candidates--;
                 if (AdmitCandidate(candidate.Key, victim.Key))
@@ -606,6 +607,7 @@ namespace BitFaster.Caching.Lfu
 
                     // victim is initialized to first, and iterates forwards
                     victim = victim.Next;
+                    candidate = candidate.Previous;
 
                     Evict(evictee);
                 }


### PR DESCRIPTION
Missed a detail in the evictFromMain logic.

This slightly changes the Wikipedia hit rate result, it is slightly better for every cache size except 150 and 175:

| CacheSize |  ClassicLruHitRate | ConcurrentLruHitRate | ConcurrentLfuHitRate |
|-----------|--------------------|----------------------|----------------------|
|        25 | 12.339894258281078 |   30.750918726091133 |   29.036389257340637 |
|        50 | 21.441939220308402 |    38.53943261242653 |   37.330211691928824 |
|        75 |  27.84286871100062 |    42.52255799923583 |    41.40486350363181 |
|       100 |  32.25609649363885 |    45.09773154010279 |   44.030016903378254 |
|       125 |  35.30941454952625 |   47.217255293190156 |     45.7745936014676 |
|       150 | 37.484624347754924 |    48.69152956898225 |    47.66783663182043 |
|       175 |  39.10013286561485 |    49.93516599505441 |    48.61778619818706 |
|       200 |  40.35904822418645 |    50.83419470582313 |    49.79126485233431 |

previous result:

| CacheSize |  ClassicLruHitRate | ConcurrentLruHitRate | ConcurrentLfuHitRate |
|-----------|--------------------|----------------------|----------------------|
|        25 | 12.339894258281078 |   30.750918726091133 |   28.875597 |
|        50 | 21.441939220308402 |    38.53943261242653 |   37.36332051 |
|        75 |  27.84286871100062 |    42.52255799923583 |    41.39452592 |
|       100 |  32.25609649363885 |    45.09773154010279 |   43.61540974 |
|       125 |  35.30941454952625 |   47.217255293190156 |     45.29089676 |
|       150 | 37.484624347754924 |    48.69152956898225 |    47.77038298 |
|       175 |  39.10013286561485 |    49.93516599505441 |    48.79556322 |
|       200 |  40.35904822418645 |    50.83419470582313 |    49.24571866 |