### PR TITLE
2 pass

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -546,67 +546,15 @@ namespace BitFaster.Caching.Lfu
 
         private void EvictFromMain(LfuNode<K, V> candidate)
         {
-            // var victimQueue = Position.Probation;
             var victim = this.probationLru.First; // victims are LRU position in probation
-            //var candidate = this.probationLru.Last; // candidates are MRU position, promoted from window
 
-            // first pass: admin candidates
+            // first pass: admit candidates
             while (this.windowLru.Count + this.probationLru.Count + this.protectedLru.Count > this.Capacity)
             {
-                if (candidate == null)
+                // bail when we run out of options
+                if (candidate == null || victim == null || victim == candidate)
                 {
                     break;
-                }
-
-                {
-                    // TODO: this logic is only reachable if entries have time expiry, and are removed early.
-                    // Search the admission window for additional candidates
-                    //if (candidates == 0)
-                    //{
-                    //    candidate = this.windowLru.First;
-                    //}
-
-                    //// Try evicting from the protected and window queues
-                    //if (candidate == null && victim == null)
-                    //{
-
-                    //    if (victimQueue == Position.Probation)
-                    //    {
-                    //        victim = this.protectedLru.First;
-                    //        victimQueue = Position.Protected;
-                    //        continue;
-                    //    }
-                    //    else if (victimQueue == Position.Protected)
-                    //    {
-                    //        victim = this.windowLru.First;
-                    //        victimQueue = Position.Window;
-                    //        continue;
-                    //    }
-
-                    //    // The pending operations will adjust the size to reflect the correct weight
-                    //    break;
-                    //}
-
-                    // Evict immediately if only one of the entries is present
-                    //if (victim == null)
-                    //{
-                    //    var previous = candidate.Previous;
-                    //    var evictee = candidate;
-                    //    candidate = previous;
-
-                    //    Evict(evictee);
-
-                    //    candidates--;
-                    //    continue;
-                    //}
-                    //else if (candidate == null)
-                    //{
-                    //    var evictee = victim;
-                    //    victim = victim.Previous;
-
-                    //    Evict(evictee);
-                    //    continue;
-                    //}
                 }
 
                 // Evict the entry with the lowest frequency
@@ -631,7 +579,7 @@ namespace BitFaster.Caching.Lfu
                 }
             }
 
-            // 2nd pass: remove probation items in LRU order, remove lowest frequency
+            // 2nd pass: remove probation items in LRU order, evict lowest frequency
             while (this.windowLru.Count + this.probationLru.Count + this.protectedLru.Count > this.Capacity)
             {
                 victim = this.probationLru.First;


### PR DESCRIPTION
Try to process evicted items in two passes:

1. Admit candidates by comparing to victims in LRU order
2. If all candidates processed, compare LRU probation items and evict lowest frequency in LRU order

This gives slightly better hit rate for ARC OLTP, which benefits from Hill Climbing.

| CacheSize | Old | New |
|-----------|----------------------|----------------------|
|       250 |   24.727368196511495 |   24.878985281328454 |
|       500 |    33.69760814750395 |    33.72889421262491 |
|       750 |   37.114790323198186 |   37.457186770151345 |
|      1000 |    39.95033610641638 |    40.00721986118176 |
|      1250 |    42.33114002701978 |     42.2793976885505 |
|      1500 |    43.71144621476899 |   43.802788397901864 |
|      1750 |    45.01386541522406 |    45.05773154149506 |
|      2000 |   46.073434739565386 |    46.08907777212586 |