### PR TITLE
mpsc buffer

### DIFF
--- a/BitFaster.Caching.ThroughputAnalysis/Program.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Program.cs
@@ -82,7 +82,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
                 for (int i = 0; i < warmup + runs; i++)
                 {
-                    results[i] = MeasureThroughput(new ConcurrentLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
+                    results[i] = MeasureThroughput(new FastConcurrentLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
                 }
                 avg = AverageLast(results, runs) / 1000000;
                 Console.WriteLine($"ConcurrLru ({tc}) {avg} million ops/sec");

--- a/BitFaster.Caching.ThroughputAnalysis/Program.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Program.cs
@@ -72,21 +72,21 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 const int runs = 6;
                 double[] results = new double[warmup + runs];
 
-                //for (int i = 0; i < warmup + runs; i++)
-                //{
-                //    results[i] = MeasureThroughput(new ClassicLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
-                //}
-                //double avg = AverageLast(results, runs) / 1000000;
-                //Console.WriteLine($"ClassicLru ({tc}) {avg} million ops/sec");
-                //classicLru[tc.ToString()] = avg.ToString();
+                for (int i = 0; i < warmup + runs; i++)
+                {
+                    results[i] = MeasureThroughput(new ClassicLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
+                }
+                double avg = AverageLast(results, runs) / 1000000;
+                Console.WriteLine($"ClassicLru ({tc}) {avg} million ops/sec");
+                classicLru[tc.ToString()] = avg.ToString();
 
-                //for (int i = 0; i < warmup + runs; i++)
-                //{
-                //    results[i] = MeasureThroughput(new ConcurrentLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
-                //}
-                //avg = AverageLast(results, runs) / 1000000;
-                //Console.WriteLine($"ConcurrLru ({tc}) {avg} million ops/sec");
-                //concurrentLru[tc.ToString()] = avg.ToString();
+                for (int i = 0; i < warmup + runs; i++)
+                {
+                    results[i] = MeasureThroughput(new ConcurrentLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
+                }
+                avg = AverageLast(results, runs) / 1000000;
+                Console.WriteLine($"ConcurrLru ({tc}) {avg} million ops/sec");
+                concurrentLru[tc.ToString()] = avg.ToString();
 
                 for (int i = 0; i < warmup + runs; i++)
                 {
@@ -94,7 +94,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     results[i] = MeasureThroughput(new ConcurrentLfu<int, int>(concurrencyLevel: tc, capacity: capacity, scheduler: scheduler), tc);
                     scheduler.Dispose();
                 }
-                var avg = AverageLast(results, runs) / 1000000;
+                avg = AverageLast(results, runs) / 1000000;
                 Console.WriteLine($"ConcurrLfu ({tc}) {avg} million ops/sec");
                 concurrentLfu[tc.ToString()] = avg.ToString();
             }

--- a/BitFaster.Caching.ThroughputAnalysis/Program.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Program.cs
@@ -72,21 +72,21 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 const int runs = 6;
                 double[] results = new double[warmup + runs];
 
-                for (int i = 0; i < warmup + runs; i++)
-                {
-                    results[i] = MeasureThroughput(new ClassicLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
-                }
-                double avg = AverageLast(results, runs) / 1000000;
-                Console.WriteLine($"ClassicLru ({tc}) {avg} million ops/sec");
-                classicLru[tc.ToString()] = avg.ToString();
+                //for (int i = 0; i < warmup + runs; i++)
+                //{
+                //    results[i] = MeasureThroughput(new ClassicLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
+                //}
+                //double avg = AverageLast(results, runs) / 1000000;
+                //Console.WriteLine($"ClassicLru ({tc}) {avg} million ops/sec");
+                //classicLru[tc.ToString()] = avg.ToString();
 
-                for (int i = 0; i < warmup + runs; i++)
-                {
-                    results[i] = MeasureThroughput(new ConcurrentLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
-                }
-                avg = AverageLast(results, runs) / 1000000;
-                Console.WriteLine($"ConcurrLru ({tc}) {avg} million ops/sec");
-                concurrentLru[tc.ToString()] = avg.ToString();
+                //for (int i = 0; i < warmup + runs; i++)
+                //{
+                //    results[i] = MeasureThroughput(new ConcurrentLru<int, int>(tc, capacity, EqualityComparer<int>.Default), tc);
+                //}
+                //avg = AverageLast(results, runs) / 1000000;
+                //Console.WriteLine($"ConcurrLru ({tc}) {avg} million ops/sec");
+                //concurrentLru[tc.ToString()] = avg.ToString();
 
                 for (int i = 0; i < warmup + runs; i++)
                 {
@@ -94,7 +94,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     results[i] = MeasureThroughput(new ConcurrentLfu<int, int>(concurrencyLevel: tc, capacity: capacity, scheduler: scheduler), tc);
                     scheduler.Dispose();
                 }
-                avg = AverageLast(results, runs) / 1000000;
+                var avg = AverageLast(results, runs) / 1000000;
                 Console.WriteLine($"ConcurrLfu ({tc}) {avg} million ops/sec");
                 concurrentLfu[tc.ToString()] = avg.ToString();
             }

--- a/BitFaster.Caching.UnitTests/Buffers/MpmcBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpmcBoundedBufferTests.cs
@@ -10,14 +10,14 @@ using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Buffers
 {
-    public class BoundedBufferTests
+    public class MpmcBoundedBufferTests
     {
-        private readonly BoundedBuffer<int> buffer = new BoundedBuffer<int>(10);
+        private readonly MpmcBoundedBuffer<int> buffer = new MpmcBoundedBuffer<int>(10);
 
         [Fact]
         public void WhenSizeIsLessThan1CtorThrows()
         {
-            Action constructor = () => { var x = new BoundedBuffer<int>(-1); };
+            Action constructor = () => { var x = new MpmcBoundedBuffer<int>(-1); };
 
             constructor.Should().Throw<ArgumentOutOfRangeException>();
         }

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -177,9 +177,16 @@ namespace BitFaster.Caching.UnitTests.Buffers
             int drainCalls = 0;
             int maxDrains = 2048;
 
+            var spinner = new SpinWait();
+
             while (drained < 1024)
             {
                 drained += buffer.DrainTo(drainBuffer);
+
+                if (drained == 0)
+                {
+                    spinner.SpinOnce();
+                }
 
                 drainCalls++.Should().BeLessThan(maxDrains);
             }

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -155,7 +155,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             });
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task WhileBufferIsFilledItemsCanBeTaken()
         {
             var buffer = new MpscBoundedBuffer<string>(1024);
@@ -174,30 +174,18 @@ namespace BitFaster.Caching.UnitTests.Buffers
 
             int taken = 0;
 
-            int takeCalls = 0;
-            int maxTakes = 2048;
-
-            var spinner = new SpinWait();
-
             while (taken < 1024)
             {
                 if (buffer.TryTake(out var _) == BufferStatus.Success) 
                 {
                     taken++;
                 }
-
-                if (taken == 0)
-                {
-                    spinner.SpinOnce();
-                }
-
-                takeCalls++.Should().BeLessThan(maxTakes);
             }
 
             await fill;
         }
 
-        [Fact]
+        [Fact(Timeout = 5000)]
         public async Task WhileBufferIsFilledBufferCanBeDrained()
         {
             var buffer = new MpscBoundedBuffer<string>(1024);
@@ -217,21 +205,9 @@ namespace BitFaster.Caching.UnitTests.Buffers
             int drained = 0;
             var drainBuffer = new ArraySegment<string>(new string[1024]);
 
-            int drainCalls = 0;
-            int maxDrains = 2048;
-
-            var spinner = new SpinWait();
-
             while (drained < 1024)
             {
                 drained += buffer.DrainTo(drainBuffer);
-
-                if (drained == 0)
-                {
-                    spinner.SpinOnce();
-                }
-
-                drainCalls++.Should().BeLessThan(maxDrains);
             }
 
             await fill;

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -186,7 +186,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
                     taken++;
                 }
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && taken == 0)
+                if (taken == 0)
                 {
                     spinner.SpinOnce();
                 }
@@ -226,7 +226,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             {
                 drained += buffer.DrainTo(drainBuffer);
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && drained == 0)
+                if (drained == 0)
                 {
                     spinner.SpinOnce();
                 }

--- a/BitFaster.Caching.UnitTests/Buffers/StripedMpscBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/StripedMpscBufferTests.cs
@@ -9,11 +9,11 @@ using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Buffers
 {
-    public class StripedBufferTests
+    public class StripedMpscBufferTests
     {
         const int bufferSize = 16;
         const int stripeCount = 2;
-        private readonly StripedMpmcBuffer<int> buffer = new StripedMpmcBuffer<int>(stripeCount, bufferSize);
+        private readonly StripedMpscBuffer<string> buffer = new StripedMpscBuffer<string>(stripeCount, bufferSize);
 
         [Fact]
         public void WhenBufferIsFullTryAddReturnsFull()
@@ -22,17 +22,17 @@ namespace BitFaster.Caching.UnitTests.Buffers
             {
                 for (var j = 0; j < bufferSize; j++)
                 {
-                    buffer.TryAdd(1).Should().Be(BufferStatus.Success);
+                    buffer.TryAdd(1.ToString()).Should().Be(BufferStatus.Success);
                 }
             }
 
-            buffer.TryAdd(1).Should().Be(BufferStatus.Full);
+            buffer.TryAdd("1").Should().Be(BufferStatus.Full);
         }
 
         [Fact]
         public void WhenBufferIsEmptyDrainReturnsZero()
         {
-            var array = new int[bufferSize];
+            var array = new string[bufferSize];
             buffer.DrainTo(array).Should().Be(0);
         }
 
@@ -43,11 +43,11 @@ namespace BitFaster.Caching.UnitTests.Buffers
             {
                 for (var j = 0; j < bufferSize; j++)
                 {
-                    buffer.TryAdd(1);
+                    buffer.TryAdd("1");
                 }
             }
 
-            var array = new int[bufferSize * stripeCount];
+            var array = new string[bufferSize * stripeCount];
             buffer.DrainTo(array).Should().Be(stripeCount * bufferSize);
         }
 
@@ -58,12 +58,27 @@ namespace BitFaster.Caching.UnitTests.Buffers
             {
                 for (var j = 0; j < bufferSize; j++)
                 {
-                    buffer.TryAdd(1);
+                    buffer.TryAdd("1");
                 }
             }
 
-            var array = new int[bufferSize];
+            var array = new string[bufferSize];
             buffer.DrainTo(array).Should().Be(bufferSize);
+        }
+
+        [Fact]
+        public void WhenDrainBufferIsSmallerThanStripedBufferDrainReturnsBufferItemCount2()
+        {
+            for (var i = 0; i < stripeCount; i++)
+            {
+                for (var j = 0; j < bufferSize; j++)
+                {
+                    buffer.TryAdd("1");
+                }
+            }
+
+            var array = new string[bufferSize+4];
+            buffer.DrainTo(array).Should().Be(bufferSize+4);
         }
 
         [Fact]
@@ -71,10 +86,10 @@ namespace BitFaster.Caching.UnitTests.Buffers
         {
             for (var j = 0; j < bufferSize; j++)
             {
-                buffer.TryAdd(1);
+                buffer.TryAdd("1");
             }
 
-            var array = new int[bufferSize * stripeCount];
+            var array = new string[bufferSize * stripeCount];
             buffer.DrainTo(array).Should().Be(bufferSize);
         }
 
@@ -85,13 +100,13 @@ namespace BitFaster.Caching.UnitTests.Buffers
             {
                 for (var j = 0; j < bufferSize; j++)
                 {
-                    buffer.TryAdd(1);
+                    buffer.TryAdd("1");
                 }
             }
 
             buffer.Clear();
 
-            var array = new int[bufferSize * stripeCount];
+            var array = new string[bufferSize * stripeCount];
             buffer.DrainTo(array).Should().Be(0);
         }
     }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -640,15 +640,13 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 cache.GetOrAdd(i, k => k);
             }
 
-            // since trim does not flush, with background scheduler it is possible that Trim runs before maintenance.
-            // in this case, the LRU lists are all empty and trim will have no effect
-
-            cache.Trim(10);
+            // Trim implicitly performs maintenance
+            cache.Trim(5);
 
             cache.PendingMaintenance();
 
             // The trim takes effect before all the writes are replayed by the maintenance thread.
-            cache.Metrics.Value.Evicted.Should().Be(5);
+            cache.Metrics.Value.Evicted.Should().Be(10);
             cache.Count.Should().Be(15);
 
             this.output.WriteLine($"Count {cache.Count}");

--- a/BitFaster.Caching.UnitTests/Threaded.cs
+++ b/BitFaster.Caching.UnitTests/Threaded.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public class Threaded
+    {
+        public static async Task Run(int threadCount, Action action)
+        {
+            var tasks = new Task[threadCount];
+            ManualResetEvent mre = new ManualResetEvent(false);
+
+            for (int i = 0; i < threadCount; i++)
+            {
+                tasks[i] = Task.Run(() =>
+                {
+                    mre.WaitOne();
+                    action();
+                });
+            }
+
+            mre.Set();
+
+            await Task.WhenAll(tasks);
+        }
+    }
+}

--- a/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
@@ -16,13 +16,13 @@ namespace BitFaster.Caching.Buffers
     /// Based on the Segment internal class from ConcurrentQueue
     /// https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentQueueSegment.cs
     /// </remarks>
-    public class BoundedBuffer<T>
+    public class MpmcBoundedBuffer<T>
     {
         private Slot[] slots;
         private readonly int slotsMask;
         private PaddedHeadAndTail headAndTail; // mutable struct, don't mark readonly
 
-        public BoundedBuffer(int boundedLength)
+        public MpmcBoundedBuffer(int boundedLength)
         {
             if (boundedLength < 0)
             {
@@ -208,13 +208,5 @@ namespace BitFaster.Caching.Buffers
             /// <summary>The sequence number for this slot, used to synchronize between enqueuers and dequeuers.</summary>
             public int SequenceNumber;
         }
-    }
-
-    [DebuggerDisplay("Head = {Head}, Tail = {Tail}")]
-    [StructLayout(LayoutKind.Explicit, Size = 3 * Padding.CACHE_LINE_SIZE)] // padding before/between/after fields
-    internal struct PaddedHeadAndTail
-    {
-        [FieldOffset(1 * Padding.CACHE_LINE_SIZE)] public int Head;
-        [FieldOffset(2 * Padding.CACHE_LINE_SIZE)] public int Tail;
     }
 }

--- a/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
@@ -8,6 +8,7 @@ using System.Threading;
 
 namespace BitFaster.Caching.Buffers
 {
+#pragma warning disable CS0420 // A reference to a volatile field will not be treated as volatile
     /// <summary>
     /// Provides a multi-producer, multi-consumer thread-safe ring buffer. When the buffer is full,
     /// TryAdd fails and returns false. When the buffer is empty, TryTake fails and returns false.
@@ -65,6 +66,7 @@ namespace BitFaster.Caching.Buffers
                 while (true)
                 {
                     var headNow = Volatile.Read(ref headAndTail.Head);
+
                     var tailNow = Volatile.Read(ref headAndTail.Tail);
 
                     if (headNow == Volatile.Read(ref headAndTail.Head) &&
@@ -209,4 +211,5 @@ namespace BitFaster.Caching.Buffers
             public int SequenceNumber;
         }
     }
+#pragma warning restore CS0420 // A reference to a volatile field will not be treated as volatile
 }

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.Buffers
+{
+    /// <summary>
+    /// A multiple producer single consumer buffer.
+    /// </summary>
+    public class MpscBoundedBuffer<T> where T : class
+    {
+        private T[] buffer;
+        private readonly int mask;
+        private PaddedHeadAndTail headAndTail; // mutable struct, don't mark readonly
+
+        public MpscBoundedBuffer(int boundedLength)
+        {
+            if (boundedLength < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(boundedLength));
+            }
+
+            // must be power of 2 to use & slotsMask instead of %
+            boundedLength = BitOps.CeilingPowerOfTwo(boundedLength);
+
+            buffer = new T[boundedLength];
+            mask = boundedLength - 1;
+        }
+
+        public int Capacity => buffer.Length;
+
+        public int Count
+        {
+            get
+            {
+                var spinner = new SpinWait();
+                while (true)
+                {
+                    var headNow = Volatile.Read(ref headAndTail.Head);
+                    var tailNow = Volatile.Read(ref headAndTail.Tail);
+
+                    if (headNow == Volatile.Read(ref headAndTail.Head) &&
+                        tailNow == Volatile.Read(ref headAndTail.Tail))
+                    {
+                        return GetCount(headNow, tailNow);
+                    }
+
+                    spinner.SpinOnce();
+                }
+            }
+        }
+
+        private int GetCount(int head, int tail)
+        {
+            if (head != tail)
+            {
+                head &= mask;
+                tail &= mask;
+
+                return head < tail ? tail - head : buffer.Length - head + tail;
+            }
+            return 0;
+        }
+
+        // thread safe
+        public BufferStatus TryAdd(T item)
+        {
+            int head = this.headAndTail.Head;
+            int tail = Volatile.Read(ref this.headAndTail.Tail);
+            int size = tail - head;
+
+            if (size >= buffer.Length)
+            {
+                return BufferStatus.Full;
+            }
+
+            if (Interlocked.CompareExchange(ref this.headAndTail.Tail, tail + 1, tail) == tail)
+            {
+                int index = (int)(tail & mask);
+                Volatile.Write(ref buffer[index], item);
+
+                return BufferStatus.Success;
+            }
+
+            return BufferStatus.Contended;
+        }
+
+        // thread safe for try take + multiple try add
+        public BufferStatus TryTake(out T item)
+        {
+            int head = this.headAndTail.Head;
+            int tail = Volatile.Read(ref this.headAndTail.Tail);
+            int size = tail - head;
+
+            if (size == 0)
+            {
+                item = default;
+                return BufferStatus.Empty;
+            }
+
+            int index = head & mask;
+
+            item = Volatile.Read(ref buffer[index]);
+
+            if (item == null)
+            {
+                // not published yet
+                return BufferStatus.Contended;
+            }
+
+            Volatile.Write(ref buffer[index], null);
+            Volatile.Write(ref this.headAndTail.Head, head + 1);
+            return BufferStatus.Success;
+        }
+
+        // thread safe for single drain + multiple try add
+        public int DrainTo(ArraySegment<T> output)
+        {
+            int head = this.headAndTail.Head;
+            int tail = Volatile.Read(ref this.headAndTail.Tail);
+            int size = tail - head;
+
+            if (size == 0)
+            {
+                return 0;
+            }
+
+            int outCount = 0;
+
+            do
+            {
+                int index = head & mask;
+
+                T item = Volatile.Read(ref buffer[index]);
+
+                if (item == null)
+                {
+                    // not published yet
+                    break;
+                }
+
+                Volatile.Write(ref buffer[index], null);
+                output.Array[output.Offset + outCount++] = item;
+                head++;
+            }
+            while (head != tail && outCount < output.Count);
+
+            Volatile.Write(ref this.headAndTail.Head, head);
+
+            return outCount;
+        }
+
+        // Not thread safe
+        public void Clear()
+        {
+            buffer = new T[buffer.Length];
+            headAndTail = new PaddedHeadAndTail();
+        }
+    }
+}

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -7,8 +7,13 @@ using System.Threading.Tasks;
 namespace BitFaster.Caching.Buffers
 {
     /// <summary>
-    /// A multiple producer single consumer buffer.
+    /// Provides a multi-producer, single-consumer thread-safe ring buffer. When the buffer is full,
+    /// TryAdd fails and returns false. When the buffer is empty, TryTake fails and returns false.
     /// </summary>
+    /// <remarks>
+    /// Based on BoundedBuffer by Ben Manes.
+    /// https://github.com/ben-manes/caffeine/blob/master/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedBuffer.java
+    /// </remarks>
     public class MpscBoundedBuffer<T> where T : class
     {
         private T[] buffer;
@@ -87,7 +92,7 @@ namespace BitFaster.Caching.Buffers
             return BufferStatus.Contended;
         }
 
-        // thread safe for try take + multiple try add
+        // thread safe for single try take/drain + multiple try add
         public BufferStatus TryTake(out T item)
         {
             int head = this.headAndTail.Head;
@@ -115,7 +120,7 @@ namespace BitFaster.Caching.Buffers
             return BufferStatus.Success;
         }
 
-        // thread safe for single drain + multiple try add
+        // thread safe for single try take/drain + multiple try add
         public int DrainTo(ArraySegment<T> output)
         {
             int head = this.headAndTail.Head;

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -43,11 +43,11 @@ namespace BitFaster.Caching.Buffers
                 var spinner = new SpinWait();
                 while (true)
                 {
-                    var headNow = Volatile.Read(ref headAndTail.Head);
-                    var tailNow = Volatile.Read(ref headAndTail.Tail);
+                    var headNow = headAndTail.Head;
+                    var tailNow = headAndTail.Tail;
 
-                    if (headNow == Volatile.Read(ref headAndTail.Head) &&
-                        tailNow == Volatile.Read(ref headAndTail.Tail))
+                    if (headNow == headAndTail.Head &&
+                        tailNow == headAndTail.Tail)
                     {
                         return GetCount(headNow, tailNow);
                     }
@@ -73,7 +73,7 @@ namespace BitFaster.Caching.Buffers
         public BufferStatus TryAdd(T item)
         {
             int head = this.headAndTail.Head;
-            int tail = Volatile.Read(ref this.headAndTail.Tail);
+            int tail = this.headAndTail.Tail;
             int size = tail - head;
 
             if (size >= buffer.Length)
@@ -96,7 +96,7 @@ namespace BitFaster.Caching.Buffers
         public BufferStatus TryTake(out T item)
         {
             int head = this.headAndTail.Head;
-            int tail = Volatile.Read(ref this.headAndTail.Tail);
+            int tail = this.headAndTail.Tail;
             int size = tail - head;
 
             if (size == 0)
@@ -116,7 +116,7 @@ namespace BitFaster.Caching.Buffers
             }
 
             Volatile.Write(ref buffer[index], null);
-            Volatile.Write(ref this.headAndTail.Head, head + 1);
+            this.headAndTail.Head++;
             return BufferStatus.Success;
         }
 
@@ -124,7 +124,7 @@ namespace BitFaster.Caching.Buffers
         public int DrainTo(ArraySegment<T> output)
         {
             int head = this.headAndTail.Head;
-            int tail = Volatile.Read(ref this.headAndTail.Tail);
+            int tail = this.headAndTail.Tail;
             int size = tail - head;
 
             if (size == 0)
@@ -152,7 +152,7 @@ namespace BitFaster.Caching.Buffers
             }
             while (head != tail && outCount < output.Count);
 
-            Volatile.Write(ref this.headAndTail.Head, head);
+            this.headAndTail.Head = head;
 
             return outCount;
         }

--- a/BitFaster.Caching/Buffers/PaddedHeadAndTail.cs
+++ b/BitFaster.Caching/Buffers/PaddedHeadAndTail.cs
@@ -11,7 +11,7 @@ namespace BitFaster.Caching.Buffers
     [StructLayout(LayoutKind.Explicit, Size = 3 * Padding.CACHE_LINE_SIZE)] // padding before/between/after fields
     internal struct PaddedHeadAndTail
     {
-        [FieldOffset(1 * Padding.CACHE_LINE_SIZE)] public int Head;
-        [FieldOffset(2 * Padding.CACHE_LINE_SIZE)] public int Tail;
+        [FieldOffset(1 * Padding.CACHE_LINE_SIZE)] public volatile int Head;
+        [FieldOffset(2 * Padding.CACHE_LINE_SIZE)] public volatile int Tail;
     }
 }

--- a/BitFaster.Caching/Buffers/PaddedHeadAndTail.cs
+++ b/BitFaster.Caching/Buffers/PaddedHeadAndTail.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace BitFaster.Caching.Buffers
+{
+    [DebuggerDisplay("Head = {Head}, Tail = {Tail}")]
+    [StructLayout(LayoutKind.Explicit, Size = 3 * Padding.CACHE_LINE_SIZE)] // padding before/between/after fields
+    internal struct PaddedHeadAndTail
+    {
+        [FieldOffset(1 * Padding.CACHE_LINE_SIZE)] public int Head;
+        [FieldOffset(2 * Padding.CACHE_LINE_SIZE)] public int Tail;
+    }
+}

--- a/BitFaster.Caching/Buffers/StripedMpmcBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpmcBuffer.cs
@@ -17,20 +17,20 @@ namespace BitFaster.Caching.Buffers
     /// rehashed to select a different buffer to retry up to 3 times. Using this approach
     /// writes scale linearly with number of concurrent threads.
     /// </summary>
-    public class StripedBuffer<T>
+    public class StripedMpmcBuffer<T>
     {
         const int MaxAttempts = 3;
 
-        private BoundedBuffer<T>[] buffers;
+        private MpmcBoundedBuffer<T>[] buffers;
 
-        public StripedBuffer(int stripeCount, int bufferSize)
+        public StripedMpmcBuffer(int stripeCount, int bufferSize)
         {
             stripeCount = BitOps.CeilingPowerOfTwo(stripeCount);
-            buffers = new BoundedBuffer<T>[stripeCount];
+            buffers = new MpmcBoundedBuffer<T>[stripeCount];
 
             for (var i = 0; i < stripeCount; i++)
             {
-                buffers[i] = new BoundedBuffer<T>(bufferSize);
+                buffers[i] = new MpmcBoundedBuffer<T>(bufferSize);
             }
         }
 

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+#if !NETSTANDARD2_0
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace BitFaster.Caching.Buffers
+{
+    /// <summary>
+    /// Provides a striped bounded buffer. Add operations use thread ID to index into
+    /// the underlying array of buffers, and if TryAdd is contended the thread ID is 
+    /// rehashed to select a different buffer to retry up to 3 times. Using this approach
+    /// writes scale linearly with number of concurrent threads.
+    /// </summary>
+    public class StripedMpscBuffer<T> where T : class
+    {
+        const int MaxAttempts = 3;
+
+        private MpscBoundedBuffer<T>[] buffers;
+
+        public StripedMpscBuffer(int stripeCount, int bufferSize)
+        {
+            stripeCount = BitOps.CeilingPowerOfTwo(stripeCount);
+            buffers = new MpscBoundedBuffer<T>[stripeCount];
+
+            for (var i = 0; i < stripeCount; i++)
+            {
+                buffers[i] = new MpscBoundedBuffer<T>(bufferSize);
+            }
+        }
+
+        public int DrainTo(T[] outputBuffer)
+        {
+            var count = 0;
+
+            for (var i = 0; i < buffers.Length; i++)
+            {
+                if (count == outputBuffer.Length)
+                {
+                    break;
+                }
+
+                var segment = new ArraySegment<T>(outputBuffer, count, outputBuffer.Length - count);
+                count += buffers[i].DrainTo(segment);
+            }
+
+            return count;
+        }
+
+        public BufferStatus TryAdd(T item)
+        {
+            // Is using Sse42.Crc32 faster?
+            //#if NETSTANDARD2_0
+            //            ulong z = Mix64((ulong)Environment.CurrentManagedThreadId);
+            //            int inc = (int)(z >> 32) | 1;
+            //            int h = (int)z;
+            //#else
+            //            int inc, h;
+
+            //            // https://rigtorp.se/notes/hashing/
+            //            if (Sse42.IsSupported)
+            //            {
+            //                h = inc = (int)Sse42.Crc32(486187739, (uint)Environment.CurrentManagedThreadId);
+            //            }
+            //            else
+            //            {
+            //                ulong z = Mix64((ulong)Environment.CurrentManagedThreadId);
+            //                inc = (int)(z >> 32) | 1;
+            //                h = (int)z;
+            //            }
+            //#endif
+
+            var z = Mix64((ulong)Environment.CurrentManagedThreadId);
+            var inc = (int)(z >> 32) | 1;
+            var h = (int)z;
+
+            var mask = buffers.Length - 1;
+
+            var result = BufferStatus.Empty;
+
+            for (var i = 0; i < MaxAttempts; i++)
+            {
+                result = buffers[h & mask].TryAdd(item);
+
+                if (result == BufferStatus.Success)
+                {
+                    break;
+                }
+
+                h += inc;
+            }
+
+            return result;
+        }
+
+        public void Clear()
+        {
+            for (var i = 0; i < buffers.Length; i++)
+            {
+                buffers[i].Clear();
+            }
+        }
+
+        // Computes Stafford variant 13 of 64-bit mix function.
+        // http://zimbry.blogspot.com/2011/09/better-bit-mixing-improving-on.html
+        private static ulong Mix64(ulong z)
+        {
+            z = (z ^ z >> 30) * 0xbf58476d1ce4e5b9L;
+            z = (z ^ z >> 27) * 0x94d049bb133111ebL;
+            return z ^ z >> 31;
+        }
+    }
+}

--- a/BitFaster.Caching/Scheduler/BackgroundThreadScheduler.cs
+++ b/BitFaster.Caching/Scheduler/BackgroundThreadScheduler.cs
@@ -23,7 +23,7 @@ namespace BitFaster.Caching.Scheduler
         private int count;
         private readonly CancellationTokenSource cts = new CancellationTokenSource();
         private readonly SemaphoreSlim semaphore = new SemaphoreSlim(0, MaxBacklog);
-        private readonly BoundedBuffer<Action> work = new BoundedBuffer<Action>(MaxBacklog);
+        private readonly MpmcBoundedBuffer<Action> work = new MpmcBoundedBuffer<Action>(MaxBacklog);
 
         private Optional<Exception> lastException = Optional<Exception>.None();
 


### PR DESCRIPTION
A simplified multiple producer single consumer buffer, and striped version based on Caffeine BoundedBuffer. The drain to array method is more efficient. Latency is better for both background and foreground.

https://github.com/bitfaster/BitFaster.Caching/pull/197/commits/e34a2696b06e4c678c9ef787b75648e06e2e31ec - not sure how representative this run is - due to variability, it did _a lot_ of reps on ConcurrentLfuBackground on .NET6.
|                  Method |            Runtime |      Mean |     Error |    StdDev | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|----------:|------:|----------:|
|    ConcurrentDictionary |           .NET 6.0 |  7.745 ns | 0.0335 ns | 0.0313 ns |  1.00 |         - |
| ConcurrentLfuBackground |           .NET 6.0 | 40.975 ns | 1.6332 ns | 4.7641 ns |  5.66 |         - |
|  ConcurrentLfuForeround |           .NET 6.0 | 67.327 ns | 0.4557 ns | 0.4262 ns |  8.69 |         - |
| ConcurrentLfuThreadPool |           .NET 6.0 | 70.637 ns | 0.6907 ns | 0.6461 ns |  9.12 |         - |
|       ConcurrentLfuNull |           .NET 6.0 | 26.625 ns | 0.1291 ns | 0.1144 ns |  3.44 |         - |
|                         |                    |           |           |           |       |           |
|    ConcurrentDictionary | .NET Framework 4.8 | 14.294 ns | 0.0911 ns | 0.0807 ns |  1.00 |         - |
| ConcurrentLfuBackground | .NET Framework 4.8 | 76.374 ns | 1.5344 ns | 1.7054 ns |  5.33 |         - |
|  ConcurrentLfuForeround | .NET Framework 4.8 | 79.986 ns | 0.8199 ns | 0.7669 ns |  5.59 |         - |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 76.536 ns | 0.8888 ns | 0.8314 ns |  5.35 |         - |
|       ConcurrentLfuNull | .NET Framework 4.8 | 41.019 ns | 1.8125 ns | 5.3441 ns |  3.11 |         - |

https://github.com/bitfaster/BitFaster.Caching/pull/197/commits/8515cd05fc4c24c4174fb87c9d5268be67702b6f - switch to volatile head and tail. Also many reps on ConcurrentLfuBackground - high error.

|                  Method |            Runtime |      Mean |     Error |    StdDev | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|----------:|------:|----------:|
|    ConcurrentDictionary |           .NET 6.0 |  7.771 ns | 0.0446 ns | 0.0417 ns |  1.00 |         - |
| ConcurrentLfuBackground |           .NET 6.0 | 37.830 ns | 1.2401 ns | 3.6370 ns |  5.08 |         - |
|  ConcurrentLfuForeround |           .NET 6.0 | 67.874 ns | 0.1870 ns | 0.1562 ns |  8.73 |         - |
| ConcurrentLfuThreadPool |           .NET 6.0 | 52.346 ns | 1.0792 ns | 1.3253 ns |  6.74 |         - |
|       ConcurrentLfuNull |           .NET 6.0 | 25.323 ns | 0.0947 ns | 0.0840 ns |  3.26 |         - |
|                         |                    |           |           |           |       |           |
|    ConcurrentDictionary | .NET Framework 4.8 | 14.231 ns | 0.0805 ns | 0.0753 ns |  1.00 |         - |
| ConcurrentLfuBackground | .NET Framework 4.8 | 75.578 ns | 1.2353 ns | 1.1555 ns |  5.31 |         - |
|  ConcurrentLfuForeround | .NET Framework 4.8 | 79.652 ns | 0.2798 ns | 0.2617 ns |  5.60 |         - |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 58.151 ns | 0.7469 ns | 0.6621 ns |  4.08 |         - |
|       ConcurrentLfuNull | .NET Framework 4.8 | 36.992 ns | 0.2244 ns | 0.2099 ns |  2.60 |         - |

main

|                  Method |            Runtime |      Mean |     Error |     StdDev | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|-----------:|------:|----------:|
|    ConcurrentDictionary |           .NET 6.0 |  7.530 ns | 0.0405 ns |  0.0359 ns |  1.00 |         - |
| ConcurrentLfuBackground |           .NET 6.0 | 51.408 ns | 3.5763 ns | 10.5449 ns |  8.26 |         - |
|  ConcurrentLfuForeround |           .NET 6.0 | 77.045 ns | 1.5122 ns |  1.9663 ns | 10.39 |         - |
| ConcurrentLfuThreadPool |           .NET 6.0 | 77.638 ns | 1.2778 ns |  1.1953 ns | 10.30 |         - |
|       ConcurrentLfuNull |           .NET 6.0 | 28.605 ns | 0.4603 ns |  0.4305 ns |  3.80 |         - |
|                         |                    |           |           |            |       |           |
|    ConcurrentDictionary | .NET Framework 4.8 | 16.090 ns | 0.0512 ns |  0.0427 ns |  1.00 |         - |
| ConcurrentLfuBackground | .NET Framework 4.8 | 78.216 ns | 1.0883 ns |  1.0180 ns |  4.86 |         - |
|  ConcurrentLfuForeround | .NET Framework 4.8 | 83.023 ns | 0.3906 ns |  0.3462 ns |  5.16 |         - |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 64.026 ns | 0.4500 ns |  0.3989 ns |  3.98 |         - |
|       ConcurrentLfuNull | .NET Framework 4.8 | 37.467 ns | 0.1786 ns |  0.1583 ns |  2.33 |         - |


Throughput is not obviously better one way or another (this is a very rudimentary test, new zipf each time influences results):

![image](https://user-images.githubusercontent.com/12851828/186993455-25079756-ea03-4446-bfc8-5adbb40d449a.png)
