### PR TITLE
trim test

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -143,6 +143,9 @@ namespace BitFaster.Caching.Lfu
             // TODO: this is LRU order eviction, Caffeine is based on frequency
             lock (maintenanceLock)
             {
+                // flush all buffers
+                Maintenance();
+
                 // walk in lru order, get itemCount keys to evict
                 TakeCandidatesInLruOrder(this.probationLru, candidates, itemCount);
                 TakeCandidatesInLruOrder(this.protectedLru, candidates, itemCount);
@@ -470,6 +473,9 @@ namespace BitFaster.Caching.Lfu
                     node.list.Remove(node);
                 }
 
+                // if the write is in the buffer and is removed, it will come here twice
+                // once for the write and once for the removal. We cannot distinguish between these states
+                this.metrics.evictedCount++;
                 return;
             }
 


### PR DESCRIPTION
The test when items are in the buffer is inherently unstable because trim does not flush the buffer. It is possible to attempt to trim an empty cache when trim runs before the maintenance thread has started. Instead, make this deterministic and perform maintenance before trimming.

There remains a bug that evictions can be double counted - come back to that later.