### PR TITLE
macos time

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using System.Runtime.InteropServices;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
@@ -17,6 +18,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         private ValueFactory valueFactory = new ValueFactory();
 
         private List<ItemRemovedEventArgs<int, int>> removedItems = new List<ItemRemovedEventArgs<int, int>>();
+
+        // on MacOS time measurement seems to be less stable, give longer pause
+        private int ttlWaitMlutiplier = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 8 : 2;
 
         private void OnLruItemRemoved(object sender, ItemRemovedEventArgs<int, int> e)
         {
@@ -77,7 +81,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            await Task.Delay(timeToLive * 2);
+            await Task.Delay(timeToLive * ttlWaitMlutiplier);
 
             lru.TryGet(1, out var value).Should().BeFalse();
         }
@@ -87,7 +91,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            await Task.Delay(timeToLive * 2);
+            await Task.Delay(timeToLive * ttlWaitMlutiplier);
 
             lru.TryUpdate(1, "3");
 
@@ -153,7 +157,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(8, "8");
             lru.AddOrUpdate(9, "9");
 
-            await Task.Delay(timeToLive * 2);
+            await Task.Delay(timeToLive * ttlWaitMlutiplier);
 
             lru.Policy.ExpireAfterWrite.Value.TrimExpired();
 
@@ -171,7 +175,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(5, "5");
             lru.AddOrUpdate(6, "6");
 
-            await Task.Delay(timeToLive * 4);
+            await Task.Delay(timeToLive * ttlWaitMlutiplier);
 
             lru.GetOrAdd(1, valueFactory.Create);
             lru.GetOrAdd(2, valueFactory.Create);
@@ -189,7 +193,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(2, "2");
             lru.AddOrUpdate(3, "3");
 
-            await Task.Delay(timeToLive * 2);
+            await Task.Delay(timeToLive * ttlWaitMlutiplier);
 
             lru.Trim(1);
 


### PR DESCRIPTION
TLru tests on MacOS are less table - increase delay on that platform.