### PR TITLE
cleanup

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -67,9 +67,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             }
 
             cache.PendingMaintenance();
+            LogLru();
 
-            cache.TryGet(1, out var value1).Should().BeTrue();
-            cache.TryGet(2, out var value2).Should().BeTrue();
             cache.Count.Should().Be(20);
         }
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -15,14 +15,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Scheduler;
-using static BitFaster.Caching.Lfu.LfuCapacityPartition;
 
 namespace BitFaster.Caching.Lfu
 {


### PR DESCRIPTION
Over specified test causes instability. Remove dupe using statement.