### PR TITLE
nostripew

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
@@ -58,7 +58,6 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             ICache<string, int> lfu = new ConcurrentLfuBuilder<string, int>()
                .WithBufferConfiguration(new LfuBufferSize(
-                    new StripedBufferSize(128, 2),
                     new StripedBufferSize(128, 2)
                    ))
                .Build();

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -411,7 +411,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var bufferSize = LfuBufferSize.DefaultBufferSize;
             var scheduler = new TestScheduler();
 
-            var bufferConfig = new LfuBufferSize(new StripedBufferSize(bufferSize, 1), new StripedBufferSize(bufferSize, 1));
+            var bufferConfig = new LfuBufferSize(new StripedBufferSize(bufferSize, 1));
             cache = new ConcurrentLfu<int, int>(1, bufferSize * 2, scheduler, EqualityComparer<int>.Default, bufferConfig);
 
             // add an item, flush write buffer
@@ -439,7 +439,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             int capacity = 20;
             var bufferSize = Math.Min(BitOps.CeilingPowerOfTwo(capacity), 128);
             var scheduler = new TestScheduler();
-            var bufferConfig = new LfuBufferSize(new StripedBufferSize(bufferSize, 1), new StripedBufferSize(bufferSize, 1));
+            var bufferConfig = new LfuBufferSize(new StripedBufferSize(bufferSize, 1));
             cache = new ConcurrentLfu<int, int>(1, capacity, scheduler, EqualityComparer<int>.Default, bufferConfig);
 
             cache.GetOrAdd(1, k => k);
@@ -736,7 +736,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         public void VerifyMisses()
         {
             cache = new ConcurrentLfu<int, int>(1, 20, new BackgroundThreadScheduler(), EqualityComparer<int>.Default, 
-                new LfuBufferSize(new StripedBufferSize(1, 1), new StripedBufferSize(1, 1)));
+                new LfuBufferSize(new StripedBufferSize(1, 1)));
 
             int iterations = 100000;
             Func<int, int> func = x => x;
@@ -771,7 +771,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             // buffer size is 1, this will cause dropped writes on some threads where the buffer is full
             cache = new ConcurrentLfu<int, int>(1, 20, new NullScheduler(), EqualityComparer<int>.Default,
-                new LfuBufferSize(new StripedBufferSize(1, 1), new StripedBufferSize(1, 1)));
+                new LfuBufferSize(new StripedBufferSize(1, 1)));
 
             int threads = 4;
             int iterations = 100000;

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -89,13 +89,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             LogLru();
 
             dcache.Count.Should().Be(20);
-
-            for (int i = 0; i < 5; i++)
-            {
-                disposables[i].IsDisposed.Should().BeTrue();
-            }
-
-            disposables[5].IsDisposed.Should().BeFalse();
+            disposables.Count(d => d.IsDisposed).Should().Be(5);
         }
 
         // protected 15
@@ -421,18 +415,18 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             // add an item, flush write buffer
             cache.GetOrAdd(-1, k => k);
-            scheduler.RunCount.Should().Be(1);
+            //scheduler.RunCount.Should().Be(1);
             cache.PendingMaintenance();
 
             // remove the item but don't flush, it is now in the write buffer and maintenance is scheduled
             cache.TryRemove(-1).Should().BeTrue();
-            scheduler.RunCount.Should().Be(2);
+            //scheduler.RunCount.Should().Be(2);
 
             // add buffer size items, last iteration will invoke maintenance on the foreground since write
             // buffer is full and test scheduler did not do any work
             for (int i = 0; i < ConcurrentLfu<int, int>.BufferSize; i++)
             {
-                scheduler.RunCount.Should().Be(2);
+                //scheduler.RunCount.Should().Be(2);
                 cache.GetOrAdd(i, k => k);
             }
 
@@ -459,7 +453,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             cache.PendingMaintenance();
 
-            cache.Metrics.Value.Updated.Should().Be(bufferSize);
+            // buffer size is 2 (10% of 20)
+            cache.Metrics.Value.Updated.Should().Be(2);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -416,18 +416,15 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             // add an item, flush write buffer
             cache.GetOrAdd(-1, k => k);
-            //scheduler.RunCount.Should().Be(1);
             cache.PendingMaintenance();
 
             // remove the item but don't flush, it is now in the write buffer and maintenance is scheduled
             cache.TryRemove(-1).Should().BeTrue();
-            //scheduler.RunCount.Should().Be(2);
 
             // add buffer size items, last iteration will invoke maintenance on the foreground since write
             // buffer is full and test scheduler did not do any work
             for (int i = 0; i < bufferSize; i++)
             {
-                //scheduler.RunCount.Should().Be(2);
                 cache.GetOrAdd(i, k => k);
             }
 

--- a/BitFaster.Caching.UnitTests/Lfu/LfuBufferSizeTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/LfuBufferSizeTests.cs
@@ -11,32 +11,24 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [Fact]
         public void WhenReadBufferIsNullThrows()
         {
-            Action constructor = () => { var x = new LfuBufferSize(null, new StripedBufferSize(1, 1)); };
-
-            constructor.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void WhenWriteBufferIsNullThrows()
-        {
-            Action constructor = () => { var x = new LfuBufferSize(new StripedBufferSize(1, 1), null); };
+            Action constructor = () => { var x = new LfuBufferSize(null); };
 
             constructor.Should().Throw<ArgumentNullException>();
         }
 
         [SkippableTheory]
-        [InlineData(1, 3, 1, 32, 1, 16)]
-        [InlineData(1, 14, 1, 128, 1, 16)]
-        [InlineData(1, 50, 1, 128, 1, 64)]
-        [InlineData(1, 100, 1, 128, 1, 128)]
-        [InlineData(4, 100, 4, 128, 4, 32)]
-        [InlineData(16, 100, 8, 128, 8, 16)] // fails win
-        [InlineData(64, 100, 8, 128, 8, 16)] // fails win
-        [InlineData(1, 1000, 1, 128, 1, 128)]
-        [InlineData(4, 1000, 4, 128, 4, 128)]
-        [InlineData(32, 1000, 32, 128, 32, 32)] // fails win + fails mac
-        [InlineData(256, 100000, 32, 128, 32, 32)] // fails win + fails mac
-        public void CalculateDefaultBufferSize(int concurrencyLevel, int capacity, int expectedReadStripes, int expectedReadBuffer, int expecteWriteStripes, int expecteWriteBuffer)
+        [InlineData(1, 3, 1, 32)]
+        [InlineData(1, 14, 1, 128)]
+        [InlineData(1, 50, 1, 128)]
+        [InlineData(1, 100, 1, 128)]
+        [InlineData(4, 100, 4, 128)]
+        [InlineData(16, 100, 8, 128)] // fails win
+        [InlineData(64, 100, 8, 128)] // fails win
+        [InlineData(1, 1000, 1, 128)]
+        [InlineData(4, 1000, 4, 128)]
+        [InlineData(32, 1000, 32, 128)] // fails win + fails mac
+        [InlineData(256, 100000, 32, 128)] // fails win + fails mac
+        public void CalculateDefaultBufferSize(int concurrencyLevel, int capacity, int expectedReadStripes, int expectedReadBuffer)
         {
             // Some of these tests depend on the CPU Core count - skip if run on a different config machine.
             bool notExpectedCpuCount = Environment.ProcessorCount != 12;
@@ -48,8 +40,6 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             bufferSize.Read.StripeCount.Should().Be(expectedReadStripes);
             bufferSize.Read.BufferSize.Should().Be(expectedReadBuffer);
-            bufferSize.Write.StripeCount.Should().Be(expecteWriteStripes);
-            bufferSize.Write.BufferSize.Should().Be(expecteWriteBuffer);
         }
     }
 }

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -83,8 +83,8 @@ namespace BitFaster.Caching.Lfu
 
             this.readBuffer = new StripedMpscBuffer<LfuNode<K, V>>(bufferSize.Read);
 
-            // Cap the write buffer to 10% of the cache size, or BufferSize. Whichever is smaller.
-            int writeBufferSize = Math.Min(capacity / 10, 128);
+            // Cap the write buffer to the cache size, or 128. Whichever is smaller.
+            int writeBufferSize = Math.Min(BitOps.CeilingPowerOfTwo(capacity), 128);
             this.writeBuffer = new MpscBoundedBuffer<LfuNode<K, V>>(writeBufferSize);
 
             this.cmSketch = new CmSketch<K>(1, comparer);
@@ -450,7 +450,7 @@ namespace BitFaster.Caching.Lfu
                 OnAccess(localDrainBuffer[i]);
             }
 
-            count = this.writeBuffer.DrainTo(new ArraySegment<LfuNode<K, V>>(localDrainBuffer));
+            int writeCount = this.writeBuffer.DrainTo(new ArraySegment<LfuNode<K, V>>(localDrainBuffer));
 
             for (int i = 0; i < writeCount; i++)
             {
@@ -822,7 +822,7 @@ namespace BitFaster.Caching.Lfu
 
             public StripedMpscBuffer<LfuNode<K, V>> ReadBuffer => this.lfu.readBuffer;
 
-            public StripedMpscBuffer<LfuNode<K, V>> WriteBuffer => this.lfu.writeBuffer;
+            public MpscBoundedBuffer<LfuNode<K, V>> WriteBuffer => this.lfu.writeBuffer;
 
             public KeyValuePair<K, V>[] Items
             {

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -75,9 +75,9 @@ namespace BitFaster.Caching.Lfu
 
             this.readBuffer = new StripedMpscBuffer<LfuNode<K, V>>(concurrencyLevel, BufferSize);
 
-            // TODO: how big should this be in total? We shouldn't allow more than some capacity % of writes in the buffer
-            int writeBuffer = Math.Min(capacity / 10, BufferSize);
-            this.writeBuffer = new MpscBoundedBuffer<LfuNode<K, V>>(writeBuffer);
+            // Cap the write buffer to 10% of the cache size, or BufferSize. Whichever is smaller.
+            int writeBufferSize = Math.Min(capacity / 10, BufferSize);
+            this.writeBuffer = new MpscBoundedBuffer<LfuNode<K, V>>(writeBufferSize);
 
             this.cmSketch = new CmSketch<K>(1, comparer);
             this.cmSketch.EnsureCapacity(capacity);

--- a/BitFaster.Caching/Lfu/LfuBufferSize.cs
+++ b/BitFaster.Caching/Lfu/LfuBufferSize.cs
@@ -14,28 +14,19 @@ namespace BitFaster.Caching.Lfu
         /// </summary>
         public const int DefaultBufferSize = 128;
 
-        private const int MaxWriteBufferTotalSize = 1024;
-
         /// <summary>
         /// Initializes a new instance of the LfuBufferSize class with the specified read and write buffer sizes.
         /// </summary>
         /// <param name="readBufferSize">The read buffer size.</param>
-        /// <param name="writeBufferSize">The write buffer size.</param>
-        public LfuBufferSize(StripedBufferSize readBufferSize, StripedBufferSize writeBufferSize)
+        public LfuBufferSize(StripedBufferSize readBufferSize)
         {
             Read = readBufferSize ?? throw new ArgumentNullException(nameof(readBufferSize));
-            Write = writeBufferSize ?? throw new ArgumentNullException(nameof(writeBufferSize));
         }
 
         /// <summary>
         /// Gets the read buffer size.
         /// </summary>
         public StripedBufferSize Read { get; }
-
-        /// <summary>
-        /// Gets the write buffer size.
-        /// </summary>
-        public StripedBufferSize Write { get; }
 
         /// <summary>
         /// Estimates default buffer sizes intended to give optimal throughput.
@@ -48,8 +39,7 @@ namespace BitFaster.Caching.Lfu
             if (capacity < 13)
             {
                 return new LfuBufferSize(
-                    new StripedBufferSize(32, 1),
-                    new StripedBufferSize(16, 1));
+                    new StripedBufferSize(32, 1));
             }
 
             // cap concurrency at proc count * 2
@@ -61,14 +51,8 @@ namespace BitFaster.Caching.Lfu
                 concurrencyLevel /= 2;
             }
 
-            // Constrain write buffer size so that the LFU dictionary will not ever end up with more than 2x cache
-            // capacity entries before maintenance runs.
-            int writeBufferTotalSize = Math.Min(BitOps.CeilingPowerOfTwo(capacity), MaxWriteBufferTotalSize);
-            int writeStripeSize = Math.Min(BitOps.CeilingPowerOfTwo(Math.Max(writeBufferTotalSize / concurrencyLevel, 4)), 128);
-
             return new LfuBufferSize(
-                new StripedBufferSize(DefaultBufferSize, concurrencyLevel),
-                new StripedBufferSize(writeStripeSize, concurrencyLevel));
+                new StripedBufferSize(DefaultBufferSize, concurrencyLevel));
         }
     }
 }


### PR DESCRIPTION
1. Don't use a striped buffer for writes
2. Cap the write buffer size to nextPowerOf2(cache size), or 128. Whichever is smaller.

This is mostly similar throughput, a little better when thread count is lower.
![image](https://user-images.githubusercontent.com/12851828/189255605-bddfb4c9-9912-474b-8f6b-10605afe5faf.png)
