### PR TITLE
size buff

### DIFF
--- a/BitFaster.Caching.UnitTests/Buffers/StripedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/StripedBufferTests.cs
@@ -16,6 +16,12 @@ namespace BitFaster.Caching.UnitTests.Buffers
         private readonly StripedMpmcBuffer<int> buffer = new StripedMpmcBuffer<int>(stripeCount, bufferSize);
 
         [Fact]
+        public void CapacityReturnsCapacity()
+        {
+            buffer.Capacity.Should().Be(32);
+        }
+
+        [Fact]
         public void WhenBufferIsFullTryAddReturnsFull()
         {
             for (var i = 0; i < stripeCount; i++)

--- a/BitFaster.Caching.UnitTests/Buffers/StripedMpscBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/StripedMpscBufferTests.cs
@@ -16,6 +16,12 @@ namespace BitFaster.Caching.UnitTests.Buffers
         private readonly StripedMpscBuffer<string> buffer = new StripedMpscBuffer<string>(stripeCount, bufferSize);
 
         [Fact]
+        public void CapacityReturnsCapacity()
+        {
+            buffer.Capacity.Should().Be(32);
+        }
+
+        [Fact]
         public void WhenBufferIsFullTryAddReturnsFull()
         {
             for (var i = 0; i < stripeCount; i++)

--- a/BitFaster.Caching/Buffers/StripedMpmcBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpmcBuffer.cs
@@ -34,6 +34,8 @@ namespace BitFaster.Caching.Buffers
             }
         }
 
+        public int Capacity => buffers.Length * buffers[0].Capacity;
+
         public int DrainTo(T[] outputBuffer)
         {
             var count = 0;

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -32,6 +32,8 @@ namespace BitFaster.Caching.Buffers
             }
         }
 
+        public int Capacity => buffers.Length * buffers[0].Capacity;
+
         public int DrainTo(T[] outputBuffer)
         {
             var count = 0;


### PR DESCRIPTION
Size the drain buffer based on the read buffer (which is always equal or bigger than the write buffer). Cache hit benchmark is substantially faster. Since MpscStripedBuffer/MpscBoundedBuffer DrainTo walks the array to a snapshot of tail, it will always be able to walk every stripe of the stiped buffer.

https://github.com/bitfaster/BitFaster.Caching/pull/205/commits/89898da51ae2ddf258708c21e1037902772fca76 - size == read buffer capacity
|                  Method |            Runtime |      Mean |     Error |    StdDev | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|----------:|------:|----------:|
|    ConcurrentDictionary |           .NET 6.0 |  7.756 ns | 0.1021 ns | 0.0905 ns |  1.00 |         - |
| ConcurrentLfuBackground |           .NET 6.0 | 33.026 ns | 0.6707 ns | 1.6826 ns |  4.11 |         - |
|  ConcurrentLfuForeround |           .NET 6.0 | 68.649 ns | 0.5166 ns | 0.4579 ns |  8.85 |         - |
| ConcurrentLfuThreadPool |           .NET 6.0 | 33.074 ns | 0.3246 ns | 0.2878 ns |  4.27 |         - |
|       ConcurrentLfuNull |           .NET 6.0 | 26.992 ns | 0.1149 ns | 0.1075 ns |  3.48 |         - |
|                         |                    |           |           |           |       |           |
|    ConcurrentDictionary | .NET Framework 4.8 | 15.023 ns | 0.2074 ns | 0.1940 ns |  1.00 |         - |
| ConcurrentLfuBackground | .NET Framework 4.8 | 73.286 ns | 1.3263 ns | 1.8155 ns |  4.88 |         - |
|  ConcurrentLfuForeround | .NET Framework 4.8 | 80.838 ns | 0.6848 ns | 0.6071 ns |  5.38 |         - |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 61.448 ns | 1.0670 ns | 0.9458 ns |  4.09 |         - |
|       ConcurrentLfuNull | .NET Framework 4.8 | 37.709 ns | 0.4390 ns | 0.4106 ns |  2.51 |         - |