### PR TITLE
fix tests

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -152,6 +152,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
             LogLru();
 
             cache.GetOrAdd(16, k => k);
+            cache.GetOrAdd(16, k => k);
+            cache.GetOrAdd(16, k => k);
+            cache.PendingMaintenance();
 
             for (int i = 25; i < 50; i++)
             {
@@ -176,8 +179,6 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [Fact]
         public void WritePromotesProbation()
         {
-            cache = new ConcurrentLfu<int, int>(1, 20, new BackgroundThreadScheduler());
-
             cache.GetOrAdd(1, k => k);
             cache.GetOrAdd(1, k => k);
             cache.GetOrAdd(2, k => k);

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -161,26 +161,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
-        public void LoopIt()
-        {
-            for (int i = 0; i < 10000; i++)
-            {
-                this.output.WriteLine($"iteration {i}");
-                cache = new ConcurrentLfu<int, int>(1, 20, new BackgroundThreadScheduler());
-                ReadPromotesProbation();
-            }
-        }
-
-
-
-        //[Fact]
         public void ReadPromotesProbation()
         {
-            //cache.GetOrAdd(1, k => k);
-            //cache.GetOrAdd(1, k => k);
-            //cache.GetOrAdd(2, k => k);
-            //cache.GetOrAdd(2, k => k);
-
             for (int i = 0; i < 20; i++)
             {
                 cache.GetOrAdd(i, k => k);

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -161,26 +161,39 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
+        public void LoopIt()
+        {
+            for (int i = 0; i < 10000; i++)
+            {
+                this.output.WriteLine($"iteration {i}");
+                cache = new ConcurrentLfu<int, int>(1, 20, new BackgroundThreadScheduler());
+                ReadPromotesProbation();
+            }
+        }
+
+
+
+        //[Fact]
         public void ReadPromotesProbation()
         {
-            cache.GetOrAdd(1, k => k);
-            cache.GetOrAdd(1, k => k);
-            cache.GetOrAdd(2, k => k);
-            cache.GetOrAdd(2, k => k);
+            //cache.GetOrAdd(1, k => k);
+            //cache.GetOrAdd(1, k => k);
+            //cache.GetOrAdd(2, k => k);
+            //cache.GetOrAdd(2, k => k);
 
-            for (int i = 0; i < 25; i++)
+            for (int i = 0; i < 20; i++)
             {
                 cache.GetOrAdd(i, k => k);
             }
 
-            // W [24] Protected [] Probation [1,2,0,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]
+            // W [19] Protected [] Probation [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]
             cache.PendingMaintenance();
             LogLru();
 
-            cache.GetOrAdd(16, k => k);
-            cache.GetOrAdd(16, k => k);
+            // W [19] Protected [16] Probation [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,17,18]
             cache.GetOrAdd(16, k => k);
             cache.PendingMaintenance();
+            LogLru();
 
             for (int i = 25; i < 50; i++)
             {
@@ -188,7 +201,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 cache.GetOrAdd(i, k => k);
             }
 
-            // W [49] Protected [16] Probation [1,2,0,3,4,5,6,7,8,9,10,11,12,13,14,15,17,18]
+            // W [49] Protected [16] Probation [25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42]
             cache.PendingMaintenance();
             LogLru();
 
@@ -205,23 +218,17 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [Fact]
         public void WritePromotesProbation()
         {
-            cache.GetOrAdd(1, k => k);
-            cache.GetOrAdd(1, k => k);
-            cache.GetOrAdd(2, k => k);
-            cache.GetOrAdd(2, k => k);
-
-            for (int i = 0; i < 25; i++)
+            for (int i = 0; i < 20; i++)
             {
                 cache.GetOrAdd(i, k => k);
             }
 
-            //  W [24] Protected [] Probation [2,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23]
+            //  W [19] Protected [] Probation [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18]
             cache.PendingMaintenance();
             LogLru();
 
             // W [24] Protected [16] Probation [2,6,7,8,9,10,11,12,13,14,15,17,18,19,20,21,22,23]
-            cache.AddOrUpdate(16, -16);
-            cache.AddOrUpdate(16, -16);
+            cache.TryUpdate(16, -16).Should().BeTrue();
             cache.PendingMaintenance();
             LogLru();
 


### PR DESCRIPTION
By overfilling the cache, items are evicted via maintenance at the beginning of the test.

The result of this appears to be a non-deterministic result. Depending on how full the read buffer is, whether any items are dropped and when maintenance starts to run, there can be different items in the cache when it completes.