### PR TITLE
don't drop writes

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -286,7 +286,8 @@ namespace BitFaster.Caching.Lfu
 
             lock (this.maintenanceLock)
             {
-                Maintenance();
+                // if the write was dropped from the buffer, explicitly pass it to maintenance
+                Maintenance(node);
             }
         }
 
@@ -378,7 +379,7 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
-        private bool Maintenance()
+        private bool Maintenance(LfuNode<K, V> droppedWrite = null)
         {
             this.drainStatus.Set(DrainStatus.ProcessingToIdle);
 
@@ -415,6 +416,11 @@ namespace BitFaster.Caching.Lfu
             for (int i = 0; i < count; i++)
             {
                 OnWrite(localDrainBuffer[i]);
+            }
+
+            if (droppedWrite != null)
+            {
+                OnWrite(droppedWrite);
             }
 
 #if !NETSTANDARD2_0


### PR DESCRIPTION
When the write buffer is full or contended beyond number of retries, maintenance is run as part of the write. However, the written node was dropped.

This is causing test instability where sometimes written items are not present.