### PR TITLE
Volatile.Read/Write

### DIFF
--- a/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
@@ -8,7 +8,6 @@ using System.Threading;
 
 namespace BitFaster.Caching.Buffers
 {
-#pragma warning disable CS0420 // A reference to a volatile field will not be treated as volatile
     /// <summary>
     /// Provides a multi-producer, multi-consumer thread-safe ring buffer. When the buffer is full,
     /// TryAdd fails and returns false. When the buffer is empty, TryTake fails and returns false.
@@ -66,7 +65,6 @@ namespace BitFaster.Caching.Buffers
                 while (true)
                 {
                     var headNow = Volatile.Read(ref headAndTail.Head);
-
                     var tailNow = Volatile.Read(ref headAndTail.Tail);
 
                     if (headNow == Volatile.Read(ref headAndTail.Head) &&
@@ -211,5 +209,4 @@ namespace BitFaster.Caching.Buffers
             public int SequenceNumber;
         }
     }
-#pragma warning restore CS0420 // A reference to a volatile field will not be treated as volatile
 }

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -73,7 +73,7 @@ namespace BitFaster.Caching.Buffers
         public BufferStatus TryAdd(T item)
         {
             int head = Volatile.Read(ref headAndTail.Head);
-            int tail = this.headAndTail.Tail;
+            int tail = Volatile.Read(ref headAndTail.Tail);
             int size = tail - head;
 
             if (size >= buffer.Length)
@@ -96,7 +96,7 @@ namespace BitFaster.Caching.Buffers
         public BufferStatus TryTake(out T item)
         {
             int head = Volatile.Read(ref headAndTail.Head);
-            int tail = this.headAndTail.Tail;
+            int tail = Volatile.Read(ref headAndTail.Tail);
             int size = tail - head;
 
             if (size == 0)
@@ -116,7 +116,7 @@ namespace BitFaster.Caching.Buffers
             }
 
             Volatile.Write(ref buffer[index], null);
-            Volatile.Write(ref this.headAndTail.Head, head);
+            Volatile.Write(ref this.headAndTail.Head, ++head);
             return BufferStatus.Success;
         }
 
@@ -124,7 +124,7 @@ namespace BitFaster.Caching.Buffers
         public int DrainTo(ArraySegment<T> output)
         {
             int head = Volatile.Read(ref headAndTail.Head);
-            int tail = this.headAndTail.Tail;
+            int tail = Volatile.Read(ref headAndTail.Tail);
             int size = tail - head;
 
             if (size == 0)

--- a/BitFaster.Caching/Buffers/PaddedHeadAndTail.cs
+++ b/BitFaster.Caching/Buffers/PaddedHeadAndTail.cs
@@ -11,7 +11,7 @@ namespace BitFaster.Caching.Buffers
     [StructLayout(LayoutKind.Explicit, Size = 3 * Padding.CACHE_LINE_SIZE)] // padding before/between/after fields
     internal struct PaddedHeadAndTail
     {
-        [FieldOffset(1 * Padding.CACHE_LINE_SIZE)] public volatile int Head;
-        [FieldOffset(2 * Padding.CACHE_LINE_SIZE)] public volatile int Tail;
+        [FieldOffset(1 * Padding.CACHE_LINE_SIZE)] public int Head;
+        [FieldOffset(2 * Padding.CACHE_LINE_SIZE)] public int Tail;
     }
 }


### PR DESCRIPTION
Mpsc buffer is unstable - many random test failures in previously stable tests. TryTake had a bug - not totally sure how the test could have passed previously

Go back to volatile static methods with full fence.

|                  Method |            Runtime |      Mean |     Error |    StdDev | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|----------:|------:|----------:|
|    ConcurrentDictionary |           .NET 6.0 |  7.824 ns | 0.1213 ns | 0.1075 ns |  1.00 |         - |
| ConcurrentLfuBackground |           .NET 6.0 | 36.620 ns | 1.0541 ns | 3.0750 ns |  4.50 |         - |
|  ConcurrentLfuForeround |           .NET 6.0 | 68.245 ns | 1.2233 ns | 1.1443 ns |  8.72 |         - |
| ConcurrentLfuThreadPool |           .NET 6.0 | 72.527 ns | 0.9874 ns | 0.9236 ns |  9.26 |         - |
|       ConcurrentLfuNull |           .NET 6.0 | 27.232 ns | 0.1447 ns | 0.1130 ns |  3.48 |         - |
|                         |                    |           |           |           |       |           |
|    ConcurrentDictionary | .NET Framework 4.8 | 14.963 ns | 0.2492 ns | 0.2331 ns |  1.00 |         - |
| ConcurrentLfuBackground | .NET Framework 4.8 | 73.517 ns | 1.4480 ns | 1.6675 ns |  4.92 |         - |
|  ConcurrentLfuForeround | .NET Framework 4.8 | 81.561 ns | 0.6495 ns | 0.6075 ns |  5.45 |         - |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 61.702 ns | 1.2046 ns | 1.1268 ns |  4.12 |         - |
|       ConcurrentLfuNull | .NET Framework 4.8 | 38.160 ns | 0.3684 ns | 0.3265 ns |  2.55 |         - |