### PR TITLE
pad counters

### DIFF
--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -40,9 +40,10 @@ namespace BitFaster.Caching.Lru
         private readonly ConcurrentQueue<I> coldQueue;
 
         // maintain count outside ConcurrentQueue, since ConcurrentQueue.Count holds a global lock
-        private int hotCount;
-        private int warmCount;
-        private int coldCount;
+        //private int hotCount;
+        //private int warmCount;
+        //private int coldCount;
+        PaddedQueueCount counter;
 
         private readonly ICapacityPartition capacity;
 
@@ -100,11 +101,11 @@ namespace BitFaster.Caching.Lru
 
         public CachePolicy Policy => CreatePolicy(this);
 
-        public int HotCount => this.hotCount;
+        public int HotCount => this.counter.hot;
 
-        public int WarmCount => this.warmCount;
+        public int WarmCount => this.counter.warm;
 
-        public int ColdCount => this.coldCount;
+        public int ColdCount => this.counter.cold;
 
         /// <summary>
         /// Gets a collection containing the keys in the cache.
@@ -176,7 +177,7 @@ namespace BitFaster.Caching.Lru
                 if (this.dictionary.TryAdd(key, newItem))
                 {
                     this.hotQueue.Enqueue(newItem);
-                    Interlocked.Increment(ref hotCount);
+                    Interlocked.Increment(ref counter.hot);
                     Cycle();
                     return newItem.Value;
                 }
@@ -202,7 +203,7 @@ namespace BitFaster.Caching.Lru
                 if (this.dictionary.TryAdd(key, newItem))
                 {
                     this.hotQueue.Enqueue(newItem);
-                    Interlocked.Increment(ref hotCount);
+                    Interlocked.Increment(ref counter.hot);
                     Cycle();
                     return newItem.Value;
                 }
@@ -292,7 +293,7 @@ namespace BitFaster.Caching.Lru
                 if (this.dictionary.TryAdd(key, newItem))
                 {
                     this.hotQueue.Enqueue(newItem);
-                    Interlocked.Increment(ref hotCount);
+                    Interlocked.Increment(ref counter.hot);
                     Cycle();
                     return;
                 }
@@ -377,9 +378,9 @@ namespace BitFaster.Caching.Lru
                 }
             }
 
-            RemoveDiscardableItems(coldQueue, ref this.coldCount);
-            RemoveDiscardableItems(warmQueue, ref this.warmCount);
-            RemoveDiscardableItems(hotQueue, ref this.hotCount);
+            RemoveDiscardableItems(coldQueue, ref this.counter.cold);
+            RemoveDiscardableItems(warmQueue, ref this.counter.warm);
+            RemoveDiscardableItems(hotQueue, ref this.counter.hot);
 
             return itemsRemoved;
         }
@@ -393,7 +394,7 @@ namespace BitFaster.Caching.Lru
 
             while (itemsRemoved < itemCount && trimWarmAttempts < maxAttempts)
             {
-                if (this.coldCount > 0)
+                if (this.counter.cold > 0)
                 {
                     if (TryRemoveCold(ItemRemovedReason.Trimmed))
                     {
@@ -413,11 +414,11 @@ namespace BitFaster.Caching.Lru
 
         private void TrimWarmOrHot()
         {
-            if (this.warmCount > 0)
+            if (this.counter.warm > 0)
             {
                 CycleWarmUnchecked(ItemRemovedReason.Trimmed);
             }
-            else if (this.hotCount > 0)
+            else if (this.counter.hot > 0)
             {
                 CycleHotUnchecked(ItemRemovedReason.Trimmed);
             }
@@ -452,14 +453,14 @@ namespace BitFaster.Caching.Lru
         private void CycleDuringWarmup()
         {
             // do nothing until hot is full
-            if (this.hotCount > this.capacity.Hot)
+            if (this.counter.hot > this.capacity.Hot)
             {
-                Interlocked.Decrement(ref this.hotCount);
+                Interlocked.Decrement(ref this.counter.hot);
 
                 if (this.hotQueue.TryDequeue(out var item))
                 {
                     // always move to warm until it is full
-                    if (this.warmCount < this.capacity.Warm)
+                    if (this.counter.warm < this.capacity.Warm)
                     {
                         // If there is a race, we will potentially add multiple items to warm. Guard by cycling the queue.
                         this.Move(item, ItemDestination.Warm, ItemRemovedReason.Evicted);
@@ -476,14 +477,14 @@ namespace BitFaster.Caching.Lru
                 }
                 else
                 {
-                    Interlocked.Increment(ref this.hotCount);
+                    Interlocked.Increment(ref this.counter.hot);
                 }
             }
         }
 
         private void CycleHot()
         {
-            if (this.hotCount > this.capacity.Hot)
+            if (this.counter.hot > this.capacity.Hot)
             {
                 CycleHotUnchecked(ItemRemovedReason.Evicted);
             }
@@ -492,7 +493,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CycleHotUnchecked(ItemRemovedReason removedReason)
         {
-            Interlocked.Decrement(ref this.hotCount);
+            Interlocked.Decrement(ref this.counter.hot);
 
             if (this.hotQueue.TryDequeue(out var item))
             {
@@ -501,13 +502,13 @@ namespace BitFaster.Caching.Lru
             }
             else
             {
-                Interlocked.Increment(ref this.hotCount);
+                Interlocked.Increment(ref this.counter.hot);
             }
         }
 
         private void CycleWarm()
         {
-            if (this.warmCount > this.capacity.Warm)
+            if (this.counter.warm > this.capacity.Warm)
             {
                 CycleWarmUnchecked(ItemRemovedReason.Evicted);
             }
@@ -516,7 +517,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CycleWarmUnchecked(ItemRemovedReason removedReason)
         {
-            Interlocked.Decrement(ref this.warmCount);
+            Interlocked.Decrement(ref this.counter.warm);
 
             if (this.warmQueue.TryDequeue(out var item))
             {
@@ -525,7 +526,7 @@ namespace BitFaster.Caching.Lru
                 // When the warm queue is full, we allow an overflow of 1 item before redirecting warm items to cold.
                 // This only happens when hit rate is high, in which case we can consider all items relatively equal in
                 // terms of which was least recently used.
-                if (where == ItemDestination.Warm && this.warmCount <= this.capacity.Warm)
+                if (where == ItemDestination.Warm && this.counter.warm <= this.capacity.Warm)
                 {
                     this.Move(item, where, removedReason);
                 }
@@ -536,13 +537,13 @@ namespace BitFaster.Caching.Lru
             }
             else
             {
-                Interlocked.Increment(ref this.warmCount);
+                Interlocked.Increment(ref this.counter.warm);
             }
         }
 
         private void CycleCold()
         {
-            if (this.coldCount > this.capacity.Cold)
+            if (this.counter.cold > this.capacity.Cold)
             {
                 TryRemoveCold(ItemRemovedReason.Evicted);
             }
@@ -551,13 +552,13 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool TryRemoveCold(ItemRemovedReason removedReason)
         {
-            Interlocked.Decrement(ref this.coldCount);
+            Interlocked.Decrement(ref this.counter.cold);
 
             if (this.coldQueue.TryDequeue(out var item))
             {
                 var where = this.itemPolicy.RouteCold(item);
 
-                if (where == ItemDestination.Warm && this.warmCount <= this.capacity.Warm)
+                if (where == ItemDestination.Warm && this.counter.warm <= this.capacity.Warm)
                 {
                     this.Move(item, where, removedReason);
                     return false;
@@ -570,7 +571,7 @@ namespace BitFaster.Caching.Lru
             }
             else
             {
-                Interlocked.Increment(ref this.coldCount);
+                Interlocked.Increment(ref this.counter.cold);
                 return false;
             }            
         }
@@ -584,11 +585,11 @@ namespace BitFaster.Caching.Lru
             {
                 case ItemDestination.Warm:
                     this.warmQueue.Enqueue(item);
-                    Interlocked.Increment(ref this.warmCount);
+                    Interlocked.Increment(ref this.counter.warm);
                     break;
                 case ItemDestination.Cold:
                     this.coldQueue.Enqueue(item);
-                    Interlocked.Increment(ref this.coldCount);
+                    Interlocked.Increment(ref this.counter.cold);
                     break;
                 case ItemDestination.Remove:
 

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -4,7 +4,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -40,10 +39,7 @@ namespace BitFaster.Caching.Lru
         private readonly ConcurrentQueue<I> coldQueue;
 
         // maintain count outside ConcurrentQueue, since ConcurrentQueue.Count holds a global lock
-        //private int hotCount;
-        //private int warmCount;
-        //private int coldCount;
-        PaddedQueueCount counter;
+        private PaddedQueueCount counter;
 
         private readonly ICapacityPartition capacity;
 

--- a/BitFaster.Caching/Lru/PaddedQueueCount.cs
+++ b/BitFaster.Caching/Lru/PaddedQueueCount.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace BitFaster.Caching.Lru
+{
+    [DebuggerDisplay("Hot = {hot}, Warm = {warm}, Cold = {cold}")]
+    [StructLayout(LayoutKind.Explicit, Size = 4 * Padding.CACHE_LINE_SIZE)] // padding before/between/after fields
+    internal struct PaddedQueueCount
+    {
+        [FieldOffset(1 * Padding.CACHE_LINE_SIZE)] public int hot;
+        [FieldOffset(2 * Padding.CACHE_LINE_SIZE)] public int warm;
+        [FieldOffset(3 * Padding.CACHE_LINE_SIZE)] public int cold;
+    }
+}

--- a/BitFaster.Caching/Padding.cs
+++ b/BitFaster.Caching/Padding.cs
@@ -4,7 +4,6 @@ using System.Text;
 
 namespace BitFaster.Caching
 {
-    // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/Internal/Padding.cs
     internal class Padding
     {
 #if TARGET_ARM64 || TARGET_LOONGARCH64


### PR DESCRIPTION
## Throughput read + write

![image](https://user-images.githubusercontent.com/12851828/187096828-8e3bda4f-f3f6-440a-9234-ee37c9205435.png)


## this PR https://github.com/bitfaster/BitFaster.Caching/pull/217/commits/c7f02580254475bfe72bb3b8f56fefa538356d8c

|                   Method |            Runtime |       Mean |     Error |    StdDev | Ratio | Code Size | Allocated |
|------------------------- |------------------- |-----------:|----------:|----------:|------:|----------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   7.764 ns | 0.0867 ns | 0.0768 ns |  1.00 |   1,523 B |         - |
|        FastConcurrentLru |           .NET 6.0 |   9.684 ns | 0.1058 ns | 0.0938 ns |  1.25 |   2,363 B |         - |
|            ConcurrentLru |           .NET 6.0 |  13.738 ns | 0.1324 ns | 0.1174 ns |  1.77 |   2,395 B |         - |
|            AtomicFastLru |           .NET 6.0 |  20.212 ns | 0.1765 ns | 0.1651 ns |  2.60 |     846 B |         - |
|       FastConcurrentTLru |           .NET 6.0 |  26.661 ns | 0.2663 ns | 0.2223 ns |  3.43 |   2,558 B |         - |
|           ConcurrentTLru |           .NET 6.0 |  30.306 ns | 0.4455 ns | 0.3949 ns |  3.90 |   2,642 B |         - |
|            ConcurrentLfu |           .NET 6.0 |  38.101 ns | 1.0887 ns | 3.1757 ns |  5.01 |   9,029 B |         - |
|               ClassicLru |           .NET 6.0 |  48.334 ns | 0.2584 ns | 0.2158 ns |  6.22 |   3,041 B |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 110.535 ns | 0.6087 ns | 0.5396 ns | 14.24 |      49 B |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  53.883 ns | 0.2561 ns | 0.2271 ns |  6.94 |      78 B |      24 B |
|                          |                    |            |           |           |       |           |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  13.772 ns | 0.1128 ns | 0.1055 ns |  1.00 |   4,207 B |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  14.357 ns | 0.1389 ns | 0.1299 ns |  1.04 |  15,185 B |         - |
|            ConcurrentLru | .NET Framework 4.8 |  16.637 ns | 0.1612 ns | 0.1508 ns |  1.21 |  15,221 B |         - |
|            AtomicFastLru | .NET Framework 4.8 |  37.866 ns | 0.2175 ns | 0.2034 ns |  2.75 |     358 B |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  44.029 ns | 0.3181 ns | 0.2975 ns |  3.20 |  15,370 B |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  45.750 ns | 0.1400 ns | 0.1241 ns |  3.32 |  15,424 B |         - |
|            ConcurrentLfu | .NET Framework 4.8 |  74.009 ns | 1.4897 ns | 1.5298 ns |  5.38 |  13,180 B |         - |
|               ClassicLru | .NET Framework 4.8 |  60.843 ns | 0.3509 ns | 0.3110 ns |  4.42 |   6,945 B |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 282.825 ns | 2.1865 ns | 2.0452 ns | 20.54 |      33 B |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 112.098 ns | 0.5218 ns | 0.4626 ns |  8.14 |      82 B |      24 B |

## main https://github.com/bitfaster/BitFaster.Caching/commit/164b9b180d0c39d48f392dc960c11dab0c8bdeeb

|                   Method |            Runtime |       Mean |     Error |    StdDev | Ratio | Code Size | Allocated |
|------------------------- |------------------- |-----------:|----------:|----------:|------:|----------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   7.686 ns | 0.0995 ns | 0.0831 ns |  1.00 |   1,523 B |         - |
|        FastConcurrentLru |           .NET 6.0 |   9.582 ns | 0.1121 ns | 0.0936 ns |  1.25 |   2,352 B |         - |
|            ConcurrentLru |           .NET 6.0 |  13.701 ns | 0.1257 ns | 0.1114 ns |  1.78 |   2,378 B |         - |
|            AtomicFastLru |           .NET 6.0 |  20.552 ns | 0.1972 ns | 0.1647 ns |  2.67 |     846 B |         - |
|       FastConcurrentTLru |           .NET 6.0 |  26.809 ns | 0.3714 ns | 0.3474 ns |  3.48 |   2,544 B |         - |
|           ConcurrentTLru |           .NET 6.0 |  30.149 ns | 0.3113 ns | 0.2600 ns |  3.92 |   2,619 B |         - |
|            ConcurrentLfu |           .NET 6.0 |  38.921 ns | 1.5546 ns | 4.5837 ns |  4.95 |   9,029 B |         - |
|               ClassicLru |           .NET 6.0 |  48.872 ns | 0.2385 ns | 0.1991 ns |  6.36 |   3,041 B |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 113.920 ns | 0.5219 ns | 0.4626 ns | 14.82 |      49 B |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  54.488 ns | 0.3213 ns | 0.2683 ns |  7.09 |      78 B |      24 B |
|                          |                    |            |           |           |       |           |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  14.355 ns | 0.1377 ns | 0.1149 ns |  1.00 |   4,207 B |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  14.492 ns | 0.2321 ns | 0.2171 ns |  1.01 |  15,182 B |         - |
|            ConcurrentLru | .NET Framework 4.8 |  17.227 ns | 0.2065 ns | 0.1932 ns |  1.20 |  15,212 B |         - |
|            AtomicFastLru | .NET Framework 4.8 |  38.195 ns | 0.4646 ns | 0.4119 ns |  2.66 |     358 B |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  44.854 ns | 0.3043 ns | 0.2847 ns |  3.12 |  15,358 B |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  46.633 ns | 0.3628 ns | 0.3216 ns |  3.25 |  15,403 B |         - |
|            ConcurrentLfu | .NET Framework 4.8 |  70.499 ns | 1.4008 ns | 1.8700 ns |  4.92 |  13,180 B |         - |
|               ClassicLru | .NET Framework 4.8 |  61.930 ns | 1.0632 ns | 0.9945 ns |  4.32 |   6,945 B |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 290.582 ns | 3.9381 ns | 3.2885 ns | 20.24 |      33 B |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 116.358 ns | 2.3375 ns | 3.6393 ns |  8.22 |      82 B |      24 B |

