### PR TITLE
correctness

### DIFF
--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -387,7 +387,7 @@ namespace BitFaster.Caching.Lru
 
             while (itemsRemoved < itemCount && trimWarmAttempts < maxAttempts)
             {
-                if (this.counter.cold > 0)
+                if (Volatile.Read(ref this.counter.cold) > 0)
                 {
                     if (TryRemoveCold(ItemRemovedReason.Trimmed) == (ItemDestination.Remove, 0))
                     {
@@ -468,7 +468,7 @@ namespace BitFaster.Caching.Lru
                 if (this.hotQueue.TryDequeue(out var item))
                 {
                     // always move to warm until it is full
-                    if (this.counter.warm < this.capacity.Warm)
+                    if (Volatile.Read(ref this.counter.warm) < this.capacity.Warm)
                     {
                         // If there is a race, we will potentially add multiple items to warm. Guard by cycling the queue.
                         int warmCount = this.Move(item, ItemDestination.Warm, ItemRemovedReason.Evicted);
@@ -540,7 +540,7 @@ namespace BitFaster.Caching.Lru
                 // When the warm queue is full, we allow an overflow of 1 item before redirecting warm items to cold.
                 // This only happens when hit rate is high, in which case we can consider all items relatively equal in
                 // terms of which was least recently used.
-                if (where == ItemDestination.Warm && this.counter.warm <= this.capacity.Warm)
+                if (where == ItemDestination.Warm && Volatile.Read(ref this.counter.warm) <= this.capacity.Warm)
                 {
                     return (ItemDestination.Warm, this.Move(item, where, removedReason));
                 }
@@ -575,7 +575,7 @@ namespace BitFaster.Caching.Lru
             {
                 var where = this.itemPolicy.RouteCold(item);
 
-                if (where == ItemDestination.Warm && this.counter.warm <= this.capacity.Warm)
+                if (where == ItemDestination.Warm && Volatile.Read(ref this.counter.warm) <= this.capacity.Warm)
                 {
                     return (ItemDestination.Warm, this.Move(item, where, removedReason));
                 }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -97,11 +97,11 @@ namespace BitFaster.Caching.Lru
 
         public CachePolicy Policy => CreatePolicy(this);
 
-        public int HotCount => this.counter.hot;
+        public int HotCount => Volatile.Read(ref this.counter.hot);
 
-        public int WarmCount => this.counter.warm;
+        public int WarmCount => Volatile.Read(ref this.counter.warm);
 
-        public int ColdCount => this.counter.cold;
+        public int ColdCount => Volatile.Read(ref this.counter.cold);
 
         /// <summary>
         /// Gets a collection containing the keys in the cache.
@@ -173,8 +173,7 @@ namespace BitFaster.Caching.Lru
                 if (this.dictionary.TryAdd(key, newItem))
                 {
                     this.hotQueue.Enqueue(newItem);
-                    Interlocked.Increment(ref counter.hot);
-                    Cycle();
+                    Cycle(Interlocked.Increment(ref counter.hot));
                     return newItem.Value;
                 }
 
@@ -199,8 +198,7 @@ namespace BitFaster.Caching.Lru
                 if (this.dictionary.TryAdd(key, newItem))
                 {
                     this.hotQueue.Enqueue(newItem);
-                    Interlocked.Increment(ref counter.hot);
-                    Cycle();
+                    Cycle(Interlocked.Increment(ref counter.hot));
                     return newItem.Value;
                 }
 
@@ -289,8 +287,7 @@ namespace BitFaster.Caching.Lru
                 if (this.dictionary.TryAdd(key, newItem))
                 {
                     this.hotQueue.Enqueue(newItem);
-                    Interlocked.Increment(ref counter.hot);
-                    Cycle();
+                    Cycle(Interlocked.Increment(ref counter.hot));
                     return;
                 }
 
@@ -392,7 +389,7 @@ namespace BitFaster.Caching.Lru
             {
                 if (this.counter.cold > 0)
                 {
-                    if (TryRemoveCold(ItemRemovedReason.Trimmed))
+                    if (TryRemoveCold(ItemRemovedReason.Trimmed) == (ItemDestination.Remove, 0))
                     {
                         itemsRemoved++;
                         trimWarmAttempts = 0;
@@ -410,17 +407,17 @@ namespace BitFaster.Caching.Lru
 
         private void TrimWarmOrHot()
         {
-            if (this.counter.warm > 0)
+            if (Volatile.Read(ref this.counter.warm) > 0)
             {
                 CycleWarmUnchecked(ItemRemovedReason.Trimmed);
             }
-            else if (this.counter.hot > 0)
+            else if (Volatile.Read(ref this.counter.hot) > 0)
             {
                 CycleHotUnchecked(ItemRemovedReason.Trimmed);
             }
         }
 
-        private void Cycle()
+        private void Cycle(int hotCount)
         {
             if (isWarm)
             {
@@ -428,28 +425,43 @@ namespace BitFaster.Caching.Lru
                 // This will prematurely free slots for the next caller. Each thread will still only cycle at most 5 items.
                 // Since TryDequeue is thread safe, only 1 thread can dequeue each item. Thus counts and queue state will always
                 // converge on correct over time.
-                CycleHot();
+                (var dest, var count) = CycleHot(hotCount);
 
                 // Multi-threaded stress tests show that due to races, the warm and cold count can increase beyond capacity when
                 // hit rate is very high. Double cycle results in stable count under all conditions. When contention is low, 
                 // secondary cycles have no effect.
-                CycleWarm();
-                CycleWarm();
-                CycleCold();
-                CycleCold();
+                if (dest == ItemDestination.Warm)
+                {
+                    (dest, count) = CycleWarm(count);
+
+                    if (dest == ItemDestination.Warm)
+                    {
+                        (dest, count) = CycleWarm(count);
+                    }
+                }
+
+                if (dest == ItemDestination.Cold)
+                {
+                    (dest, count) = CycleCold(count);
+
+                    if (dest == ItemDestination.Warm)
+                    {
+                        CycleCold(count);
+                    }
+                }
             }
             else
             {
                 // fill up the warm queue with new items until warm is full.
                 // else during warmup the cache will only use the hot + cold queues until any item is requested twice.
-                CycleDuringWarmup();
+                CycleDuringWarmup(hotCount);
             }
         }
 
-        private void CycleDuringWarmup()
+        private void CycleDuringWarmup(int hotCount)
         {
             // do nothing until hot is full
-            if (this.counter.hot > this.capacity.Hot)
+            if (hotCount > this.capacity.Hot)
             {
                 Interlocked.Decrement(ref this.counter.hot);
 
@@ -459,16 +471,16 @@ namespace BitFaster.Caching.Lru
                     if (this.counter.warm < this.capacity.Warm)
                     {
                         // If there is a race, we will potentially add multiple items to warm. Guard by cycling the queue.
-                        this.Move(item, ItemDestination.Warm, ItemRemovedReason.Evicted);
-                        CycleWarm();
+                        int warmCount = this.Move(item, ItemDestination.Warm, ItemRemovedReason.Evicted);
+                        CycleWarm(warmCount);
                     }
                     else
                     {
                         // Else mark isWarm and move items to cold.
                         // If there is a race, we will potentially add multiple items to cold. Guard by cycling the queue.
                         Volatile.Write(ref this.isWarm, true);
-                        this.Move(item, ItemDestination.Cold, ItemRemovedReason.Evicted);
-                        CycleCold();
+                        int coldCount = this.Move(item, ItemDestination.Cold, ItemRemovedReason.Evicted);
+                        CycleCold(coldCount);
                     }
                 }
                 else
@@ -478,40 +490,46 @@ namespace BitFaster.Caching.Lru
             }
         }
 
-        private void CycleHot()
+        private (ItemDestination, int) CycleHot(int hotCount)
         {
-            if (this.counter.hot > this.capacity.Hot)
+            if (hotCount > this.capacity.Hot)
             {
-                CycleHotUnchecked(ItemRemovedReason.Evicted);
+                return CycleHotUnchecked(ItemRemovedReason.Evicted);
             }
+
+            return (ItemDestination.Remove, 0);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void CycleHotUnchecked(ItemRemovedReason removedReason)
+        private (ItemDestination, int) CycleHotUnchecked(ItemRemovedReason removedReason)
         {
             Interlocked.Decrement(ref this.counter.hot);
 
             if (this.hotQueue.TryDequeue(out var item))
             {
                 var where = this.itemPolicy.RouteHot(item);
-                this.Move(item, where, removedReason);
+                //this.Move(item, where, removedReason);
+                return (where, this.Move(item, where, removedReason));
             }
             else
             {
                 Interlocked.Increment(ref this.counter.hot);
+                return (ItemDestination.Remove, 0);
             }
         }
 
-        private void CycleWarm()
+        private (ItemDestination, int) CycleWarm(int count)
         {
-            if (this.counter.warm > this.capacity.Warm)
+            if (count > this.capacity.Warm)
             {
-                CycleWarmUnchecked(ItemRemovedReason.Evicted);
+                return CycleWarmUnchecked(ItemRemovedReason.Evicted);
             }
+
+            return (ItemDestination.Remove, 0);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void CycleWarmUnchecked(ItemRemovedReason removedReason)
+        private (ItemDestination, int) CycleWarmUnchecked(ItemRemovedReason removedReason)
         {
             Interlocked.Decrement(ref this.counter.warm);
 
@@ -524,29 +542,32 @@ namespace BitFaster.Caching.Lru
                 // terms of which was least recently used.
                 if (where == ItemDestination.Warm && this.counter.warm <= this.capacity.Warm)
                 {
-                    this.Move(item, where, removedReason);
+                    return (ItemDestination.Warm, this.Move(item, where, removedReason));
                 }
                 else
                 {
-                    this.Move(item, ItemDestination.Cold, removedReason);
+                    return (ItemDestination.Cold, this.Move(item, ItemDestination.Cold, removedReason));
                 }
             }
             else
             {
                 Interlocked.Increment(ref this.counter.warm);
+                return (ItemDestination.Remove, 0);
             }
         }
 
-        private void CycleCold()
+        private (ItemDestination, int) CycleCold(int count)
         {
-            if (this.counter.cold > this.capacity.Cold)
+            if (count > this.capacity.Cold)
             {
-                TryRemoveCold(ItemRemovedReason.Evicted);
+                return TryRemoveCold(ItemRemovedReason.Evicted);
             }
+
+            return (ItemDestination.Remove, 0);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryRemoveCold(ItemRemovedReason removedReason)
+        private (ItemDestination, int) TryRemoveCold(ItemRemovedReason removedReason)
         {
             Interlocked.Decrement(ref this.counter.cold);
 
@@ -556,24 +577,22 @@ namespace BitFaster.Caching.Lru
 
                 if (where == ItemDestination.Warm && this.counter.warm <= this.capacity.Warm)
                 {
-                    this.Move(item, where, removedReason);
-                    return false;
+                    return (ItemDestination.Warm, this.Move(item, where, removedReason));
                 }
                 else
                 {
                     this.Move(item, ItemDestination.Remove, removedReason);
-                    return true;
+                    return (ItemDestination.Remove, 0);
                 }
             }
             else
             {
-                Interlocked.Increment(ref this.counter.cold);
-                return false;
-            }            
+                return (ItemDestination.Cold, Interlocked.Increment(ref this.counter.cold));
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Move(I item, ItemDestination where, ItemRemovedReason removedReason)
+        private int Move(I item, ItemDestination where, ItemRemovedReason removedReason)
         {
             item.WasAccessed = false;
 
@@ -581,12 +600,10 @@ namespace BitFaster.Caching.Lru
             {
                 case ItemDestination.Warm:
                     this.warmQueue.Enqueue(item);
-                    Interlocked.Increment(ref this.counter.warm);
-                    break;
+                    return Interlocked.Increment(ref this.counter.warm);
                 case ItemDestination.Cold:
                     this.coldQueue.Enqueue(item);
-                    Interlocked.Increment(ref this.counter.cold);
-                    break;
+                    return Interlocked.Increment(ref this.counter.cold);
                 case ItemDestination.Remove:
 
                     var kvp = new KeyValuePair<K, I>(item.Key, item);
@@ -606,6 +623,8 @@ namespace BitFaster.Caching.Lru
                     }
                     break;
             }
+
+            return 0;
         }
 
         /// <summary>Returns an enumerator that iterates through the cache.</summary>

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -508,7 +508,6 @@ namespace BitFaster.Caching.Lru
             if (this.hotQueue.TryDequeue(out var item))
             {
                 var where = this.itemPolicy.RouteHot(item);
-                //this.Move(item, where, removedReason);
                 return (where, this.Move(item, where, removedReason));
             }
             else


### PR DESCRIPTION
Improve correctness for ConcurrentLru: use the result of interlocked inc/dec and volatile reads for counter values. This eliminates races when propagating items across queues. Read/write throughput and LruCycleBench latency are unchanged.