### PR TITLE
bounded

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -962,6 +962,22 @@ namespace BitFaster.Caching.UnitTests.Lru
             removedItems[1].Reason.Should().Be(ItemRemovedReason.Trimmed);
         }
 
+        [Fact]
+        public async Task WhenItemsAreScannedInParallelCapacityIsNotExceeded()
+        {
+            await Threaded.Run(4, () => {
+                for (int i = 0; i < 100000; i++)
+                {
+                    lru.GetOrAdd(i + 1, i =>i.ToString());
+                }
+            });
+
+            this.testOutputHelper.WriteLine($"{lru.HotCount} {lru.WarmCount} {lru.ColdCount}");
+
+            // allow +/- 1 variance for capacity
+            lru.Count.Should().BeCloseTo(9, 1);
+        }
+
         private void Warmup()
         {
             lru.GetOrAdd(-1, valueFactory.Create);


### PR DESCRIPTION
Make the cycle logic more robust to 'concurrent scanning'. There is now one fewer cycle attempt than the original logic (3 attempts at cold or warm, whereas previously there were 4 attempts, 2 warm + 2 cold).

This does not impact the latency in cycle bench or throughput.