### PR TITLE
debug

### DIFF
--- a/BitFaster.Caching.UnitTests/Buffers/StripedMpscBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/StripedMpscBufferTests.cs
@@ -22,6 +22,22 @@ namespace BitFaster.Caching.UnitTests.Buffers
         }
 
         [Fact]
+        public void CountReturnsCount()
+        {
+            buffer.Count.Should().Be(0);
+
+            for (var i = 0; i < stripeCount; i++)
+            {
+                for (var j = 0; j < bufferSize; j++)
+                {
+                    buffer.TryAdd(1.ToString()).Should().Be(BufferStatus.Success);
+                }
+            }
+
+            buffer.Count.Should().Be(buffer.Capacity);
+        }
+
+        [Fact]
         public void WhenBufferIsFullTryAddReturnsFull()
         {
             for (var i = 0; i < stripeCount; i++)

--- a/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Atomic
 {
+    [DebuggerDisplay("Count = {Count}")]
     public sealed class AtomicFactoryAsyncCache<K, V> : IAsyncCache<K, V>
     {
         private readonly ICache<K, AsyncAtomicFactory<K, V>> cache;

--- a/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace BitFaster.Caching.Atomic
 {
+    [DebuggerDisplay("Count = {Count}")]
     public sealed class AtomicFactoryCache<K, V> : ICache<K, V>
     {
         private readonly ICache<K, AtomicFactory<K, V>> cache;

--- a/BitFaster.Caching/Atomic/AtomicFactoryScopedAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryScopedAsyncCache.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Atomic
 {
+    [DebuggerDisplay("Count = {Count}")]
     public sealed class AtomicFactoryScopedAsyncCache<K, V> : IScopedAsyncCache<K, V> where V : IDisposable
     {
         private readonly ICache<K, ScopedAsyncAtomicFactory<K, V>> cache;

--- a/BitFaster.Caching/Atomic/AtomicFactoryScopedCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryScopedCache.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Atomic
 {
+    [DebuggerDisplay("Count = {Count}")]
     public sealed class AtomicFactoryScopedCache<K, V> : IScopedCache<K, V> where V : IDisposable
     {
         private readonly ICache<K, ScopedAtomicFactory<K, V>> cache;

--- a/BitFaster.Caching/Atomic/ScopedAsyncAtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/ScopedAsyncAtomicFactory.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Atomic
 {
+    [DebuggerDisplay("IsValueCreated={initializer == null}, Value={ScopeIfCreated}")]
     public sealed class ScopedAsyncAtomicFactory<K, V> : IScoped<V>, IDisposable where V : IDisposable
     {
         private Scoped<V> scope;

--- a/BitFaster.Caching/Atomic/ScopedAtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/ScopedAtomicFactory.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Atomic
 {
@@ -12,6 +8,7 @@ namespace BitFaster.Caching.Atomic
     // 1. Exactly once disposal.
     // 2. Exactly once invocation of value factory (synchronized create).
     // 3. Resolve race between create dispose init, if disposed is called before value is created, scoped value is disposed for life.
+    [DebuggerDisplay("IsValueCreated={initializer == null}, Value={ScopeIfCreated}")]
     public sealed class ScopedAtomicFactory<K, V> : IScoped<V>, IDisposable where V : IDisposable
     {
         private Scoped<V> scope;

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +15,7 @@ namespace BitFaster.Caching.Buffers
     /// Based on BoundedBuffer by Ben Manes.
     /// https://github.com/ben-manes/caffeine/blob/master/caffeine/src/main/java/com/github/benmanes/caffeine/cache/BoundedBuffer.java
     /// </remarks>
+    [DebuggerDisplay("Count = {Count}/{Capacity}")]
     public class MpscBoundedBuffer<T> where T : class
     {
         private T[] buffer;

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Threading;
 
@@ -15,6 +17,7 @@ namespace BitFaster.Caching.Buffers
     /// rehashed to select a different buffer to retry up to 3 times. Using this approach
     /// writes scale linearly with number of concurrent threads.
     /// </summary>
+    [DebuggerDisplay("Count = {Count}/{Capacity}")]
     public class StripedMpscBuffer<T> where T : class
     {
         const int MaxAttempts = 3;
@@ -31,6 +34,8 @@ namespace BitFaster.Caching.Buffers
                 buffers[i] = new MpscBoundedBuffer<T>(bufferSize);
             }
         }
+
+        public int Count => buffers.Sum(b => b.Count);
 
         public int Capacity => buffers.Length * buffers[0].Capacity;
 

--- a/BitFaster.Caching/Lfu/LfuCapacityPartition.cs
+++ b/BitFaster.Caching/Lfu/LfuCapacityPartition.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 
 namespace BitFaster.Caching.Lfu
 {
+    [DebuggerDisplay("{Capacity} ({Window}/{Protected}/{Probation})")]
     public class LfuCapacityPartition
     {
         private readonly int max;

--- a/BitFaster.Caching/Lru/ConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLru.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace BitFaster.Caching.Lru
 {
     ///<inheritdoc/>
+    [DebuggerTypeProxy(typeof(LruDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}/{Capacity}")]
     public sealed class ConcurrentLru<K, V> : ConcurrentLruCore<K, V, LruItem<K, V>, LruPolicy<K, V>, TelemetryPolicy<K, V>>
     {
         /// <summary>

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -660,6 +661,7 @@ namespace BitFaster.Caching.Lru
         // it becomes immutable. However, this object is then somewhere else on the 
         // heap, which slows down the policies with hit counter logic in benchmarks. Likely
         // this approach keeps the structs data members in the same CPU cache line as the LRU.
+        [DebuggerDisplay("Hit = {Hits}, Miss = {Misses}, Upd = {Updated}, Evict = {Evicted}")]
         private class Proxy : ICacheMetrics, ICacheEvents<K, V>, IBoundedPolicy, ITimePolicy
         {
             private readonly ConcurrentLruCore<K, V, I, P, T> lru;

--- a/BitFaster.Caching/Lru/ConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentTLru.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace BitFaster.Caching.Lru
 {
     ///<inheritdoc/>
+    [DebuggerTypeProxy(typeof(LruDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}/{Capacity}")]
     public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, TelemetryPolicy<K, V>>
     {
         /// <summary>

--- a/BitFaster.Caching/Lru/EqualCapacityPartition.cs
+++ b/BitFaster.Caching/Lru/EqualCapacityPartition.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -9,6 +10,7 @@ namespace BitFaster.Caching.Lru
     /// <summary>
     /// A simple partitioning scheme to put an approximately equal number of items in each queue.
     /// </summary>
+    [DebuggerDisplay("{Hot}/{Warm}/{Cold}")]
     public class EqualCapacityPartition : ICapacityPartition
     {
         private readonly int hotCapacity;

--- a/BitFaster.Caching/Lru/FastConcurrentLru.cs
+++ b/BitFaster.Caching/Lru/FastConcurrentLru.cs
@@ -1,10 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace BitFaster.Caching.Lru
 {
     ///<inheritdoc/>
+    [DebuggerTypeProxy(typeof(LruDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}/{Capacity}")]
     public sealed class FastConcurrentLru<K, V> : ConcurrentLruCore<K, V, LruItem<K, V>, LruPolicy<K, V>, NoTelemetryPolicy<K, V>>
     {
         /// <summary>

--- a/BitFaster.Caching/Lru/FastConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/FastConcurrentTLru.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Diagnostics;
 
 namespace BitFaster.Caching.Lru
 {
     ///<inheritdoc/>
+    [DebuggerTypeProxy(typeof(LruDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}/{Capacity}")]
     public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, NoTelemetryPolicy<K, V>>
     {
         /// <summary>

--- a/BitFaster.Caching/Lru/FavorWarmPartition.cs
+++ b/BitFaster.Caching/Lru/FavorWarmPartition.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace BitFaster.Caching.Lru
 {
@@ -10,6 +7,7 @@ namespace BitFaster.Caching.Lru
     /// A capacity partitioning scheme that favors frequently accessed items by allocating 80% 
     /// capacity to the warm queue.
     /// </summary>
+    [DebuggerDisplay("{Hot}/{Warm}/{Cold}")]
     public class FavorWarmPartition : ICapacityPartition
     {
         private readonly int hotCapacity;

--- a/BitFaster.Caching/Lru/LruDebugView.cs
+++ b/BitFaster.Caching/Lru/LruDebugView.cs
@@ -33,5 +33,7 @@ namespace BitFaster.Caching.Lru
                 return items;
             }
         }
+
+        public ICacheMetrics Metrics => cache.Metrics.Value;
     }
 }

--- a/BitFaster.Caching/Lru/LruDebugView.cs
+++ b/BitFaster.Caching/Lru/LruDebugView.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace BitFaster.Caching.Lru
+{
+    [ExcludeFromCodeCoverage]
+    internal class LruDebugView<K, V>
+    {
+        private readonly ICache<K, V> cache;
+
+        public LruDebugView(ICache<K, V> cache)
+        {
+            if (cache is null)
+            {
+                throw new ArgumentNullException(nameof(cache));
+            }
+
+            this.cache = cache;
+        }
+
+        public KeyValuePair<K, V>[] Items
+        {
+            get
+            {
+                var items = new KeyValuePair<K, V>[cache.Count];
+
+                var index = 0;
+                foreach (var kvp in cache)
+                {
+                    items[index++] = kvp;
+                }
+                return items;
+            }
+        }
+    }
+}

--- a/BitFaster.Caching/Lru/TelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/TelemetryPolicy.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using BitFaster.Caching.Concurrent;
 
 namespace BitFaster.Caching.Lru
 {
+    [DebuggerDisplay("Hit = {Hits}, Miss = {Misses}, Upd = {Updated}, Evict = {Evicted}")]
     public struct TelemetryPolicy<K, V> : ITelemetryPolicy<K, V>
     {
         private LongAdder hitCount;

--- a/BitFaster.Caching/Lru/TlruLongTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruLongTicksPolicy.cs
@@ -15,6 +15,7 @@ namespace BitFaster.Caching.Lru
     /// <remarks>
     /// This class measures time using stopwatch.
     /// </remarks>
+    [DebuggerDisplay("TTL = {TimeToLive,nq})")]
     public readonly struct TLruLongTicksPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
     {
         // On some platforms (e.g. MacOS), stopwatch and timespan have different resolution

--- a/BitFaster.Caching/Optional.cs
+++ b/BitFaster.Caching/Optional.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Diagnostics;
 
 namespace BitFaster.Caching
 {
     /// <summary>
     /// Represents an optional value.
     /// </summary>
+    [DebuggerDisplay("{Value}")]
     public class Optional<T> 
     {
         private readonly T value;

--- a/BitFaster.Caching/ScopedAsyncCache.cs
+++ b/BitFaster.Caching/ScopedAsyncCache.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,6 +14,7 @@ namespace BitFaster.Caching
     /// </summary>
     /// <typeparam name="K">The type of keys in the cache.</typeparam>
     /// <typeparam name="V">The type of values in the cache.</typeparam>
+    [DebuggerDisplay("Count = {Count}")]
     public sealed class ScopedAsyncCache<K, V> : IScopedAsyncCache<K, V> where V : IDisposable
     {
         private readonly IAsyncCache<K, Scoped<V>> cache;

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using System.Diagnostics;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
@@ -15,6 +13,7 @@ namespace BitFaster.Caching
     /// </summary>
     /// <typeparam name="K">The type of keys in the cache.</typeparam>
     /// <typeparam name="V">The type of values in the cache.</typeparam>
+    [DebuggerDisplay("Count = {Count}")]
     public sealed class ScopedCache<K, V> : IScopedCache<K, V> where V : IDisposable
     {
         private readonly ICache<K, Scoped<V>> cache;


### PR DESCRIPTION
Provide `DebuggerDisplay` and `DebuggerTypeProxy` annotations for `ConcurrentLru`,  `ConcurrentLfu`, `Scoped` and `Optional`.

Reduce the amount of data shown, so that it is more suited to a programmer using the cache in their program rather than debugging the cache itself (which presumably is not the primary use case):

![image](https://user-images.githubusercontent.com/12851828/187569655-e6be9f2b-84fc-497e-a840-c286828e1859.png)

vs

![image](https://user-images.githubusercontent.com/12851828/187569833-bdcb6ed0-082c-48dd-9357-4fd64570a59c.png)

