### PR TITLE
lock contention

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -758,7 +758,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         public async Task ThreadedVerifyMisses()
         {
             // buffer size is 1, this will cause dropped writes on some threads where the buffer is full
-            cache = new ConcurrentLfu<int, int>(1, 20, new BackgroundThreadScheduler(), EqualityComparer<int>.Default,
+            cache = new ConcurrentLfu<int, int>(1, 20, new NullScheduler(), EqualityComparer<int>.Default,
                 new LfuBufferSize(new StripedBufferSize(1, 1), new StripedBufferSize(1, 1)));
 
             int threads = 4;

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -213,6 +213,16 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.PendingMaintenance();
             LogLru();
 
+            for (int i = 25; i < 50; i++)
+            {
+                cache.GetOrAdd(i, k => k);
+                cache.GetOrAdd(i, k => k);
+            }
+
+            //  W [49] Protected [16] Probation [2,6,7,8,9,10,11,12,13,14,15,17,18,19,20,21,22,23]
+            cache.PendingMaintenance();
+            LogLru();
+
             cache.Trim(18);
 
             // W [49] Protected [16] Probation []

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -176,16 +176,6 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.PendingMaintenance();
             LogLru();
 
-            for (int i = 25; i < 50; i++)
-            {
-                cache.GetOrAdd(i, k => k);
-                cache.GetOrAdd(i, k => k);
-            }
-
-            // W [49] Protected [16] Probation [25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42]
-            cache.PendingMaintenance();
-            LogLru();
-
             cache.Trim(18);
 
             // W [49] Protected [16] Probation []
@@ -210,16 +200,6 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             // W [24] Protected [16] Probation [2,6,7,8,9,10,11,12,13,14,15,17,18,19,20,21,22,23]
             cache.TryUpdate(16, -16).Should().BeTrue();
-            cache.PendingMaintenance();
-            LogLru();
-
-            for (int i = 25; i < 50; i++)
-            {
-                cache.GetOrAdd(i, k => k);
-                cache.GetOrAdd(i, k => k);
-            }
-
-            //  W [49] Protected [16] Probation [2,6,7,8,9,10,11,12,13,14,15,17,18,19,20,21,22,23]
             cache.PendingMaintenance();
             LogLru();
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -754,6 +754,32 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.Metrics.Value.Misses.Should().Be(iterations);
         }
 
+        [Fact]
+        public async Task ThreadedVerifyMisses()
+        {
+            int threads = 4;
+            int iterations = 100000;
+
+            await Threaded.Run(threads, i => 
+            {
+                Func<int, int> func = x => x;
+
+                int start = i * iterations;
+
+                for (int j = start; j < start + iterations; j++)
+                {
+                    cache.GetOrAdd(j, func);
+                }
+            });
+
+            var samplePercent = this.cache.Metrics.Value.Misses / (double)iterations / threads * 100;
+
+            this.output.WriteLine($"Cache misses {this.cache.Metrics.Value.Misses} (sampled {samplePercent}%)");
+            this.output.WriteLine($"Maintenance ops {this.cache.Scheduler.RunCount}");
+
+            cache.Metrics.Value.Misses.Should().Be(iterations * threads);
+        }
+
         private void VerifyHits(int iterations, int minSamples)
         {
             Func<int, int> func = x => x;

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -792,7 +792,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             this.output.WriteLine($"Maintenance ops {this.cache.Scheduler.RunCount}");
 
             cache.Metrics.Value.Misses.Should().Be(iterations * threads);
-            cache.Count.Should().Be(20);
+            cache.Count.Should().BeCloseTo(20, 1);
         }
 
         private void VerifyHits(int iterations, int minSamples)

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -723,7 +723,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [Fact]
         public void VerifyMisses()
         {
-            cache = new ConcurrentLfu<int, int>(1, 20, new ForegroundScheduler(), EqualityComparer<int>.Default, 
+            cache = new ConcurrentLfu<int, int>(1, 20, new BackgroundThreadScheduler(), EqualityComparer<int>.Default, 
                 new LfuBufferSize(new StripedBufferSize(1, 1), new StripedBufferSize(1, 1)));
 
             int iterations = 100000;

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -723,6 +723,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [Fact]
         public void VerifyMisses()
         {
+            cache = new ConcurrentLfu<int, int>(1, 20, new ForegroundScheduler(), EqualityComparer<int>.Default, 
+                new LfuBufferSize(new StripedBufferSize(1, 1), new StripedBufferSize(1, 1)));
+
             int iterations = 100000;
             Func<int, int> func = x => x;
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -176,6 +176,16 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.PendingMaintenance();
             LogLru();
 
+            for (int i = 25; i < 50; i++)
+            {
+                cache.GetOrAdd(i, k => k);
+                cache.GetOrAdd(i, k => k);
+            }
+
+            // W [49] Protected [16] Probation [25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42]
+            cache.PendingMaintenance();
+            LogLru();
+
             cache.Trim(18);
 
             // W [49] Protected [16] Probation []

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -757,6 +757,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [Fact]
         public async Task ThreadedVerifyMisses()
         {
+            // buffer size is 1, this will cause dropped writes on some threads where the buffer is full
+            cache = new ConcurrentLfu<int, int>(1, 20, new BackgroundThreadScheduler(), EqualityComparer<int>.Default,
+                new LfuBufferSize(new StripedBufferSize(1, 1), new StripedBufferSize(1, 1)));
+
             int threads = 4;
             int iterations = 100000;
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -782,6 +782,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             this.output.WriteLine($"Maintenance ops {this.cache.Scheduler.RunCount}");
 
             cache.Metrics.Value.Misses.Should().Be(iterations * threads);
+            cache.Count.Should().Be(20);
         }
 
         private void VerifyHits(int iterations, int minSamples)

--- a/BitFaster.Caching.UnitTests/Threaded.cs
+++ b/BitFaster.Caching.UnitTests/Threaded.cs
@@ -12,22 +12,6 @@ namespace BitFaster.Caching.UnitTests
         public static Task Run(int threadCount, Action action)
         {
             return Run(threadCount, i => action());
-
-            //var tasks = new Task[threadCount];
-            //ManualResetEvent mre = new ManualResetEvent(false);
-
-            //for (int i = 0; i < threadCount; i++)
-            //{
-            //    tasks[i] = Task.Run(() =>
-            //    {
-            //        mre.WaitOne();
-            //        action();
-            //    });
-            //}
-
-            //mre.Set();
-
-            //await Task.WhenAll(tasks);
         }
 
         public static async Task Run(int threadCount, Action<int> action)

--- a/BitFaster.Caching.UnitTests/Threaded.cs
+++ b/BitFaster.Caching.UnitTests/Threaded.cs
@@ -9,17 +9,39 @@ namespace BitFaster.Caching.UnitTests
 {
     public class Threaded
     {
-        public static async Task Run(int threadCount, Action action)
+        public static Task Run(int threadCount, Action action)
+        {
+            return Run(threadCount, i => action());
+
+            //var tasks = new Task[threadCount];
+            //ManualResetEvent mre = new ManualResetEvent(false);
+
+            //for (int i = 0; i < threadCount; i++)
+            //{
+            //    tasks[i] = Task.Run(() =>
+            //    {
+            //        mre.WaitOne();
+            //        action();
+            //    });
+            //}
+
+            //mre.Set();
+
+            //await Task.WhenAll(tasks);
+        }
+
+        public static async Task Run(int threadCount, Action<int> action)
         {
             var tasks = new Task[threadCount];
             ManualResetEvent mre = new ManualResetEvent(false);
 
             for (int i = 0; i < threadCount; i++)
             {
+                int run = i; 
                 tasks[i] = Task.Run(() =>
                 {
                     mre.WaitOne();
-                    action();
+                    action(run);
                 });
             }
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -283,7 +283,7 @@ namespace BitFaster.Caching.Lfu
                 {
                     status = writeBuffer.TryAdd(node);
 
-                    if (status != BufferStatus.Success)
+                    if (status == BufferStatus.Success)
                     {
                         return;
                     }

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -409,7 +409,7 @@ namespace BitFaster.Caching.Lfu
                 OnWrite(localDrainBuffer[i]);
             }
 
-            // we are done only when both buffers were empty
+            // we are done only when both buffers are empty
             var done = readCount == 0 & writeCount == 0;
 
             if (droppedWrite != null)

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -329,6 +329,7 @@ namespace BitFaster.Caching.Lfu
 
                     if (status == BufferStatus.Success)
                     {
+                        ScheduleAfterWrite();
                         return;
                     }
                 }

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -621,7 +621,7 @@ namespace BitFaster.Caching.Lfu
 
                     // victim is initialized to first, and iterates forwards
                     victim = victim.Next;
-                    //candidate = candidate.Next;
+                    candidate = candidate.Next;
 
                     Evict(evictee);
                 }


### PR DESCRIPTION
In the Read+Write scenario, the bottleneck is lock contention while attempting to enter the maintenance lock.

![image](https://user-images.githubusercontent.com/12851828/188290428-2c51c698-f521-4b7d-a93a-ab9bf77904a4.png)

Breakdown of time in maintenance:

![image](https://user-images.githubusercontent.com/12851828/188337924-09f7b4bb-ed08-44ac-8716-273c1a39ffae.png)


Fix:

1. Try to exit the lock early if maintenance has just run and it is possible to add to the write buffer. This reduces wait time for a queue of writes when in a lock convoy.
2. When maintenance is running on the background thread, keep track of whether the write buffer was fully drained, and if not run maintenance again. This has the effect of maintenance constantly running in the background when the buffers are populated. 
3. Remove the spin wait, which is just slowing things down (throughput is measurably lower).


This is an approx 10% throughput gain for the Read+Write scenario.

![image](https://user-images.githubusercontent.com/12851828/188763494-f8b09575-78b0-4f2d-9ba9-e721174d31a4.png)

