### PR TITLE
undiag

### DIFF
--- a/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
@@ -11,7 +11,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     /// </summary>
     [SimpleJob(RuntimeMoniker.Net48)]
     [SimpleJob(RuntimeMoniker.Net60)]
-    [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+    // [DisassemblyDiagnoser(printSource: true, maxDepth: 5)] // Unstable
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Median", "RatioSD")]
     public class LruAsyncGet


### PR DESCRIPTION
Disable dissassembly for LruAsyncGet, since it fails almost 100% as follows:

```
// AfterAll
Unhandled exception. System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at BenchmarkDotNet.Disassemblers.SourceCodeProvider.ReadSourceLine(SourceFile file, Int32 line)
   at BenchmarkDotNet.Disassemblers.SourceCodeProvider.GetSource(ClrMethod method, ILToNativeMap map)+MoveNext()
   at BenchmarkDotNet.Disassemblers.ClrMdV2Disassembler.DisassembleMethod(MethodInfo methodInfo, State state, Settings settings)
   at BenchmarkDotNet.Disassemblers.ClrMdV2Disassembler.Disassemble(Settings settings, State state)
   at BenchmarkDotNet.Disassemblers.ClrMdV2Disassembler.AttachAndDisassemble(Settings settings)
   at BenchmarkDotNet.Diagnosers.DisassemblyDiagnoser.Handle(HostSignal signal, DiagnoserActionParameters parameters)
   at BenchmarkDotNet.Diagnosers.CompositeDiagnoser.Handle(HostSignal signal, DiagnoserActionParameters parameters)
   at BenchmarkDotNet.Loggers.SynchronousProcessOutputLoggerWithDiagnoser.ProcessInput()
   at BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliExecutor.Execute(BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, ILogger logger, ArtifactsPaths artifactsPaths, IDiagnoser diagnoser, String executableName, IResolver resolver, Int32 launchIndex, Boolean noAcknowledgments)
   at BenchmarkDotNet.Toolchains.DotNetCli.DotNetCliExecutor.Execute(ExecuteParameters executeParameters)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.RunExecute(ILogger logger, BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, IToolchain toolchain, BuildResult buildResult, IResolver resolver, IDiagnoser diagnoser, Int32 launchIndex)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.Execute(ILogger logger, BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, IToolchain toolchain, BuildResult buildResult, IResolver resolver)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.RunCore(BenchmarkCase benchmarkCase, BenchmarkId benchmarkId, ILogger logger, IResolver resolver, BuildResult buildResult)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run(BenchmarkRunInfo benchmarkRunInfo, Dictionary`2 buildResults, IResolver resolver, ILogger logger, List`1 artifactsToCleanup, String resultsFolderPath, String logFilePath, Int32 totalBenchmarkCount, StartedClock& runsChronometer, Int32& benchmarksToRunCount)
   at BenchmarkDotNet.Running.BenchmarkRunnerClean.Run(BenchmarkRunInfo[] benchmarkRunInfos)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.RunWithDirtyAssemblyResolveHelper(String[] args, IConfig config, Boolean askUserForInput)
   at BenchmarkDotNet.Running.BenchmarkSwitcher.Run(String[] args, IConfig config)
   at BitFaster.Caching.Benchmarks.Program.Main(String[] args) in D:\a\BitFaster.Caching\BitFaster.Caching\BitFaster.Caching.Benchmarks\Program.cs:line 9
Successfully reverted power plan (GUID: 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c FriendlyName: High performance)
// * Artifacts cleanup *
Unhandled exception. System.NotSupportedException: Unknown Acknowledgment: 
   at BenchmarkDotNet.Engines.ConsoleHost.SendSignal(HostSignal hostSignal)
   at BenchmarkDotNet.Engines.HostExtensions.AfterAll(IHost host)
   at BenchmarkDotNet.Autogenerated.UniqueProgramName.AfterAssemblyLoadingAttached(String[] args)
   at BenchmarkDotNet.Autogenerated.UniqueProgramName.Main(String[] args)
Error: Process completed with exit code 1.
```