### PR TITLE
nopool

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -56,9 +56,7 @@ namespace BitFaster.Caching.Lfu
 
         private readonly IScheduler scheduler;
 
-#if NETSTANDARD2_0
         private readonly LfuNode<K, V>[] drainBuffer;
-#endif
 
         /// <summary>
         /// Initializes a new instance of the ConcurrentLfu class with the specified capacity.
@@ -97,9 +95,7 @@ namespace BitFaster.Caching.Lfu
 
             this.scheduler = scheduler;
 
-#if NETSTANDARD2_0
             this.drainBuffer = new LfuNode<K, V>[this.readBuffer.Capacity];
-#endif
         }
 
         ///<inheritdoc/>
@@ -689,18 +685,11 @@ namespace BitFaster.Caching.Lfu
 
         private LfuNode<K, V>[] RentDrainBuffer()
         {
-#if !NETSTANDARD2_0
-            return ArrayPool<LfuNode<K, V>>.Shared.Rent(this.readBuffer.Capacity);
-#else
             return drainBuffer;
-#endif
         }
 
         private void ReturnDrainBuffer(LfuNode<K, V>[] localDrainBuffer)
         {
-#if !NETSTANDARD2_0
-            ArrayPool<LfuNode<K, V>>.Shared.Return(localDrainBuffer);
-#endif
         }
 
         [DebuggerDisplay("{Format(),nq}")]


### PR DESCRIPTION
Remove use of array pooling, approx 12% better throughput. Now very close to 6 million ops/sec.

![image](https://user-images.githubusercontent.com/12851828/189261516-4ac93799-80d1-4d71-9e79-8acf28910e3b.png)


|                  Method |            Runtime |      Mean |     Error |    StdDev | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|----------:|------:|----------:|
|    ConcurrentDictionary |           .NET 6.0 |  7.362 ns | 0.0334 ns | 0.0297 ns |  1.00 |         - |
| ConcurrentLfuBackground |           .NET 6.0 | 36.728 ns | 0.9014 ns | 2.6436 ns |  4.82 |         - |
|  ConcurrentLfuForeround |           .NET 6.0 | 67.891 ns | 0.3150 ns | 0.2947 ns |  9.23 |         - |
| ConcurrentLfuThreadPool |           .NET 6.0 | 53.836 ns | 0.7426 ns | 0.6946 ns |  7.31 |         - |
|       ConcurrentLfuNull |           .NET 6.0 | 27.233 ns | 0.0743 ns | 0.0695 ns |  3.70 |         - |
|                         |                    |           |           |           |       |           |
|    ConcurrentDictionary | .NET Framework 4.8 | 13.889 ns | 0.1314 ns | 0.1026 ns |  1.00 |         - |
| ConcurrentLfuBackground | .NET Framework 4.8 | 64.676 ns | 1.3003 ns | 1.8229 ns |  4.64 |         - |
|  ConcurrentLfuForeround | .NET Framework 4.8 | 78.924 ns | 0.7792 ns | 0.7288 ns |  5.69 |         - |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 44.644 ns | 0.9221 ns | 1.5407 ns |  3.24 |         - |
|       ConcurrentLfuNull | .NET Framework 4.8 | 37.809 ns | 0.0954 ns | 0.0846 ns |  2.72 |         - |
