### PR TITLE
package readme

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     permissions:
       actions: read
       contents: read

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -7,6 +7,7 @@
     <Product>BitFaster.Caching</Product>
     <Description>High performance, thread-safe in-memory caching primitives for .NET.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>2.0.0</Version>
     <Copyright>Copyright © Alex Peck $([System.DateTime]::Now.ToString(yyyy))</Copyright>
@@ -34,6 +35,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BitFaster.Caching/ReadMe.md
+++ b/BitFaster.Caching/ReadMe.md
@@ -27,3 +27,7 @@ var lfu = new ConcurrentLfu<string, SomeItem>(capacity);
 
 var value = lfu.GetOrAdd("key", (key) => new SomeItem(key));
 ```
+
+# Documentation
+
+Please refer to the [wiki](https://github.com/bitfaster/BitFaster.Caching/wiki) for full API documentation, and a complete analysis of hit rate vs cache size, latency and throughput.

--- a/BitFaster.Caching/ReadMe.md
+++ b/BitFaster.Caching/ReadMe.md
@@ -1,0 +1,29 @@
+# ⚡ BitFaster.Caching
+
+High performance, thread-safe in-memory caching primitives for .NET.
+
+## ConcurrentLru
+
+`ConcurrentLru` is a light weight drop in replacement for `ConcurrentDictionary`, but with bounded size enforced by the TU-Q pseudo LRU eviction policy. There are no background threads, no lock contention, lookups are fast and hit rate outperforms a pure LRU in all tested scenarios.
+
+Choose a capacity and use just like ConcurrentDictionary, but with bounded size:
+
+```csharp
+int capacity = 666;
+var lru = new ConcurrentLru<string, SomeItem>(capacity);
+
+var value = lru.GetOrAdd("key", (key) => new SomeItem(key));
+```
+
+## ConcurrentLfu
+
+`ConcurrentLfu` is a drop in replacement for `ConcurrentDictionary`, but with bounded size enforced by the [W-TinyLFU eviction policy](https://arxiv.org/pdf/1512.00727.pdf). `ConcurrentLfu` has near optimal hit rate. Reads and writes are buffered and replayed asynchronously to mitigate lock contention.
+
+Choose a capacity and use just like ConcurrentDictionary, but with bounded size:
+
+```csharp
+int capacity = 666;
+var lfu = new ConcurrentLfu<string, SomeItem>(capacity);
+
+var value = lfu.GetOrAdd("key", (key) => new SomeItem(key));
+```

--- a/BitFaster.Caching/ReadMe.md
+++ b/BitFaster.Caching/ReadMe.md
@@ -28,6 +28,6 @@ var lfu = new ConcurrentLfu<string, SomeItem>(capacity);
 var value = lfu.GetOrAdd("key", (key) => new SomeItem(key));
 ```
 
-# Documentation
+## Documentation
 
 Please refer to the [wiki](https://github.com/bitfaster/BitFaster.Caching/wiki) for full API documentation, and a complete analysis of hit rate vs cache size, latency and throughput.

--- a/BitFaster.Caching/ReadMe.md
+++ b/BitFaster.Caching/ReadMe.md
@@ -4,7 +4,7 @@ High performance, thread-safe in-memory caching primitives for .NET.
 
 ## ConcurrentLru
 
-`ConcurrentLru` is a light weight drop in replacement for `ConcurrentDictionary`, but with bounded size enforced by the TU-Q pseudo LRU eviction policy. There are no background threads, no lock contention, lookups are fast and hit rate outperforms a pure LRU in all tested scenarios.
+`ConcurrentLru` is a light weight drop in replacement for `ConcurrentDictionary`, but with bounded size enforced by the TU-Q eviction policy (similar to [2Q](https://www.vldb.org/conf/1994/P439.PDF)). There are no background threads, no lock contention, lookups are fast and hit rate outperforms a pure LRU in all tested scenarios.
 
 Choose a capacity and use just like ConcurrentDictionary, but with bounded size:
 


### PR DESCRIPTION
Switch CodeQL to run on windows since it fails to package the readme file on ubuntu for some reason.



```
Running dotnet build --no-incremental /p:UseSharedCompilation=false /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.sln
  MSBuild version 17.3.0+92e077650 for .NET
    Determining projects to restore...
    All projects are up-to-date for restore.
    BitFaster.Caching -> /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching/bin/Debug/netstandard2.0/BitFaster.Caching.dll
    BitFaster.Caching -> /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching/bin/Debug/netcoreapp3.1/BitFaster.Caching.dll
    BitFaster.Caching -> /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching/bin/Debug/net6.0/BitFaster.Caching.dll
    BitFaster.Caching.UnitTests -> /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching.UnitTests/bin/Debug/net6.0/BitFaster.Caching.UnitTests.dll
    BitFaster.Caching.Benchmarks -> /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching.Benchmarks/bin/Debug/net6.0/BitFaster.Caching.Benchmarks.dll
    BitFaster.Caching.HitRateAnalysis -> /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching.HitRateAnalysis/bin/Debug/net6.0/BitFaster.Caching.HitRateAnalysis.dll
    BitFaster.Caching.ThroughputAnalysis -> /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching.ThroughputAnalysis/bin/Debug/net6.0/BitFaster.Caching.ThroughputAnalysis.dll
    BitFaster.Caching.Benchmarks -> /home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching.Benchmarks/bin/Debug/net48/BitFaster.Caching.Benchmarks.exe
  /usr/share/dotnet/sdk/6.0.400/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(221,5): error NU5039: The readme file 'ReadMe.md' does not exist in the package. [/home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching.csproj]
  
  Build FAILED.
  
  /usr/share/dotnet/sdk/6.0.400/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(221,5): error NU5039: The readme file 'ReadMe.md' does not exist in the package. [/home/runner/work/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching/BitFaster.Caching.csproj]
      0 Warning(s)
      1 Error(s)
  
  Time Elapsed 00:01:26.78
  Exit code 1
  Attempting to build using MSBuild
```