### PR TITLE
readme

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -35,7 +35,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="ReadMe.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuGet upload failed because the package did not contain README.md. This looks like a case sensitivity issue, and is likely why adding this file failed earlier for CodeQL on ubuntu.

Change the reference to match the casing of the file.