### PR TITLE
throwhelper

### DIFF
--- a/BitFaster.Caching.ThroughputAnalysis/Mode.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Mode.cs
@@ -5,10 +5,10 @@ namespace BitFaster.Caching.ThroughputAnalysis
     [Flags]
     public enum Mode
     {
-        Read = 0,
-        ReadWrite = 1,
-        Evict = 2,
-        Update = 4,
+        Read = 1,
+        ReadWrite = 2,
+        Evict = 4,
+        Update = 8,
         All = ~0,
     }
 }

--- a/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache == null)
             {
-                Ex.ThrowArgNull(nameof(cache));
+                Ex.ThrowArgNull(ExceptionArgument.cache);
             }
 
             this.cache = cache;

--- a/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache == null)
             {
-                throw new ArgumentNullException(nameof(cache));
+                Ex.ThrowArgNull(nameof(cache));
             }
 
             this.cache = cache;

--- a/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
@@ -24,7 +24,7 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache == null)
             {
-                throw new ArgumentNullException(nameof(cache));
+                Ex.ThrowArgNull(nameof(cache));
             }
 
             this.cache = cache;

--- a/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
@@ -24,7 +24,7 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache == null)
             {
-                Ex.ThrowArgNull(nameof(cache));
+                Ex.ThrowArgNull(ExceptionArgument.cache);
             }
 
             this.cache = cache;

--- a/BitFaster.Caching/Atomic/AtomicFactoryScopedAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryScopedAsyncCache.cs
@@ -26,7 +26,7 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache == null)
             {
-                Ex.ThrowArgNull(nameof(cache));
+                Ex.ThrowArgNull(ExceptionArgument.cache);
             }
 
             this.cache = cache;
@@ -87,7 +87,7 @@ namespace BitFaster.Caching.Atomic
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
                 {
-                    Ex.ThrowInvalidOp(ScopedCacheDefaults.RetryFailureMessage);
+                    Ex.ThrowScopedRetryFailure();
                 }
             }
         }

--- a/BitFaster.Caching/Atomic/AtomicFactoryScopedAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryScopedAsyncCache.cs
@@ -26,7 +26,7 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache == null)
             {
-                throw new ArgumentNullException(nameof(cache));
+                Ex.ThrowArgNull(nameof(cache));
             }
 
             this.cache = cache;
@@ -87,7 +87,7 @@ namespace BitFaster.Caching.Atomic
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
                 {
-                    throw new InvalidOperationException(ScopedCacheDefaults.RetryFailureMessage);
+                    Ex.ThrowInvalidOp(ScopedCacheDefaults.RetryFailureMessage);
                 }
             }
         }

--- a/BitFaster.Caching/Atomic/AtomicFactoryScopedCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryScopedCache.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache == null)
             {
-                Ex.ThrowArgNull(nameof(cache));
+                Ex.ThrowArgNull(ExceptionArgument.cache);
             }
 
             this.cache = cache;
@@ -85,7 +85,7 @@ namespace BitFaster.Caching.Atomic
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
                 {
-                    Ex.ThrowInvalidOp(ScopedCacheDefaults.RetryFailureMessage);
+                    Ex.ThrowScopedRetryFailure();
                 }
             }
         }

--- a/BitFaster.Caching/Atomic/AtomicFactoryScopedCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryScopedCache.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache == null)
             {
-                throw new ArgumentNullException(nameof(cache));
+                Ex.ThrowArgNull(nameof(cache));
             }
 
             this.cache = cache;
@@ -85,7 +85,7 @@ namespace BitFaster.Caching.Atomic
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
                 {
-                    throw new InvalidOperationException(ScopedCacheDefaults.RetryFailureMessage);
+                    Ex.ThrowInvalidOp(ScopedCacheDefaults.RetryFailureMessage);
                 }
             }
         }

--- a/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.Buffers
         {
             if (boundedLength < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(boundedLength));
+                Ex.ThrowArgOutOfRange(nameof(boundedLength));
             }
 
             // must be power of 2 to use & slotsMask instead of %

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.Buffers
         {
             if (boundedLength < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(boundedLength));
+                Ex.ThrowArgOutOfRange(nameof(boundedLength));
             }
 
             // must be power of 2 to use & slotsMask instead of %

--- a/BitFaster.Caching/Ex.cs
+++ b/BitFaster.Caching/Ex.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace BitFaster.Caching
+{
+    internal static class Ex
+    {
+        public static void ThrowArgNull(string paramName) => throw CreateArgumentNullException(paramName);
+
+        public static void ThrowArgOutOfRange(string paramName) => throw CreateArgumentOutOfRangeException(paramName);
+
+        public static void ThrowArgOutOfRange(string paramName, string message) => throw CreateArgumentOutOfRangeException(paramName, message);
+
+        public static void ThrowInvalidOp() => throw CreateInvalidOperationException();
+
+        public static void ThrowInvalidOp(string message) => throw CreateInvalidOperationException(message);
+
+        public static void ThrowDisposed(string objectName) => throw CreateObjectDisposedException(objectName);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentNullException CreateArgumentNullException(string paramName) => new ArgumentNullException(paramName);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException CreateArgumentOutOfRangeException(string paramName) => new ArgumentOutOfRangeException(paramName);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException CreateArgumentOutOfRangeException(string paramName, string message) => new ArgumentOutOfRangeException(paramName, message);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException CreateInvalidOperationException() => new InvalidOperationException();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException CreateInvalidOperationException(string message) => new InvalidOperationException(message);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ObjectDisposedException CreateObjectDisposedException(string message) => new ObjectDisposedException(message);
+    }
+}

--- a/BitFaster.Caching/Ex.cs
+++ b/BitFaster.Caching/Ex.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace BitFaster.Caching
 {
     internal static class Ex
     {
-        public static void ThrowArgNull(string paramName) => throw CreateArgumentNullException(paramName);
+        public static void ThrowArgNull(ExceptionArgument arg) => throw CreateArgumentNullException(arg);
 
         public static void ThrowArgOutOfRange(string paramName) => throw CreateArgumentOutOfRangeException(paramName);
 
@@ -15,10 +16,12 @@ namespace BitFaster.Caching
 
         public static void ThrowInvalidOp(string message) => throw CreateInvalidOperationException(message);
 
-        public static void ThrowDisposed(string objectName) => throw CreateObjectDisposedException(objectName);
+        public static void ThrowScopedRetryFailure() => throw CreateScopedRetryFailure();
+
+        public static void ThrowDisposed<T>() => throw CreateObjectDisposedException<T>();
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static ArgumentNullException CreateArgumentNullException(string paramName) => new ArgumentNullException(paramName);
+        private static ArgumentNullException CreateArgumentNullException(ExceptionArgument arg) => new ArgumentNullException(GetArgumentString(arg));
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArgumentOutOfRangeException CreateArgumentOutOfRangeException(string paramName) => new ArgumentOutOfRangeException(paramName);
@@ -33,6 +36,31 @@ namespace BitFaster.Caching
         private static InvalidOperationException CreateInvalidOperationException(string message) => new InvalidOperationException(message);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static ObjectDisposedException CreateObjectDisposedException(string message) => new ObjectDisposedException(message);
+        private static InvalidOperationException CreateScopedRetryFailure() => new InvalidOperationException(ScopedCacheDefaults.RetryFailureMessage);
+        
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ObjectDisposedException CreateObjectDisposedException<T>() => new ObjectDisposedException(nameof(T));
+
+        private static string GetArgumentString(ExceptionArgument argument)
+        {
+            switch (argument)
+            {
+                case ExceptionArgument.cache: return nameof(ExceptionArgument.cache);
+                case ExceptionArgument.comparer: return nameof(ExceptionArgument.comparer);
+                case ExceptionArgument.scoped: return nameof(ExceptionArgument.scoped);
+                case ExceptionArgument.capacity: return nameof(ExceptionArgument.capacity);
+                default:
+                    Debug.Fail("The ExceptionArgument value is not defined.");
+                    return string.Empty;
+            }
+        }
+    }
+
+    internal enum ExceptionArgument
+    {
+        cache,
+        comparer,
+        scoped,
+        capacity,
     }
 }

--- a/BitFaster.Caching/Ex.cs
+++ b/BitFaster.Caching/Ex.cs
@@ -49,6 +49,7 @@ namespace BitFaster.Caching
                 case ExceptionArgument.comparer: return nameof(ExceptionArgument.comparer);
                 case ExceptionArgument.scoped: return nameof(ExceptionArgument.scoped);
                 case ExceptionArgument.capacity: return nameof(ExceptionArgument.capacity);
+                case ExceptionArgument.node: return nameof(ExceptionArgument.node);
                 default:
                     Debug.Fail("The ExceptionArgument value is not defined.");
                     return string.Empty;
@@ -62,5 +63,6 @@ namespace BitFaster.Caching
         comparer,
         scoped,
         capacity,
+        node,
     }
 }

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -721,7 +721,8 @@ namespace BitFaster.Caching.Lfu
                     case ProcessingToRequired:
                         return false;
                     default:
-                        throw new InvalidOperationException();
+                        Ex.ThrowInvalidOp();
+                        return false; // not reachable
                 }
             }
 

--- a/BitFaster.Caching/Lfu/LfuCapacityPartition.cs
+++ b/BitFaster.Caching/Lfu/LfuCapacityPartition.cs
@@ -122,7 +122,7 @@ namespace BitFaster.Caching.Lfu
         {
             if (capacity < 3)
             {
-                throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than or equal to 3.");
+                Ex.ThrowArgOutOfRange(nameof(capacity), "Capacity must be greater than or equal to 3.");
             }
 
             int window = capacity - (int)(mainPercentage * capacity);

--- a/BitFaster.Caching/Lfu/LfuNodeList.cs
+++ b/BitFaster.Caching/Lfu/LfuNodeList.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace BitFaster.Caching.Lfu
 {
@@ -65,7 +66,7 @@ namespace BitFaster.Caching.Lfu
         public void RemoveFirst()
         {
 #if DEBUG
-            if (head == null) { throw new InvalidOperationException("List is empty."); }
+            if (head == null) { Ex.ThrowInvalidOp("List is empty."); }
 #endif
             InternalRemoveNode(head);
         }
@@ -124,12 +125,12 @@ namespace BitFaster.Caching.Lfu
         {
             if (node == null)
             {
-                throw new ArgumentNullException(nameof(node));
+                Ex.ThrowArgNull(nameof(node));
             }
 
             if (node.list != null)
             {
-                throw new InvalidOperationException("Node is already attached to a list.");
+                Ex.ThrowInvalidOp("Node is already attached to a list.");
             }
         }
 
@@ -138,12 +139,12 @@ namespace BitFaster.Caching.Lfu
         {
             if (node == null)
             {
-                throw new ArgumentNullException(nameof(node));
+                Ex.ThrowArgNull(nameof(node));
             }
 
             if (node.list != this)
             {
-                throw new InvalidOperationException("Node is already attached to a different list.");
+                Ex.ThrowInvalidOp("Node is already attached to a different list.");
             }
         }
 #endif
@@ -172,7 +173,7 @@ namespace BitFaster.Caching.Lfu
                 {
                     if (index == 0 || (index == list.Count + 1))
                     {
-                        throw new InvalidOperationException("Out of bounds");
+                        Ex.ThrowInvalidOp("Out of bounds");
                     }
 
                     return Current;

--- a/BitFaster.Caching/Lfu/LfuNodeList.cs
+++ b/BitFaster.Caching/Lfu/LfuNodeList.cs
@@ -125,7 +125,7 @@ namespace BitFaster.Caching.Lfu
         {
             if (node == null)
             {
-                Ex.ThrowArgNull(nameof(node));
+                Ex.ThrowArgNull(ExceptionArgument.node);
             }
 
             if (node.list != null)
@@ -139,7 +139,7 @@ namespace BitFaster.Caching.Lfu
         {
             if (node == null)
             {
-                Ex.ThrowArgNull(nameof(node));
+                Ex.ThrowArgNull(ExceptionArgument.node);
             }
 
             if (node.list != this)

--- a/BitFaster.Caching/Lru/CapacityPartitionExtensions.cs
+++ b/BitFaster.Caching/Lru/CapacityPartitionExtensions.cs
@@ -16,17 +16,17 @@ namespace BitFaster.Caching.Lru
         {
             if (capacity.Cold < 1)
             { 
-                throw new ArgumentOutOfRangeException(nameof(capacity.Cold));
+                Ex.ThrowArgOutOfRange(nameof(capacity.Cold));
             }
 
             if (capacity.Warm < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(capacity.Warm));
+                Ex.ThrowArgOutOfRange(nameof(capacity.Warm));
             }
 
             if (capacity.Hot < 1)
             {
-                throw new ArgumentOutOfRangeException(nameof(capacity.Hot));
+                Ex.ThrowArgOutOfRange(nameof(capacity.Hot));
             }
         }
     }

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -47,12 +47,12 @@ namespace BitFaster.Caching.Lru
         {
             if (capacity < 3)
             {
-                throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than or equal to 3.");
+                Ex.ThrowArgOutOfRange(nameof(capacity), "Capacity must be greater than or equal to 3.");
             }
 
             if (comparer == null)
             {
-                throw new ArgumentNullException(nameof(comparer));
+                Ex.ThrowArgNull(nameof(comparer));
             }
 
             this.capacity = capacity;
@@ -315,7 +315,7 @@ namespace BitFaster.Caching.Lru
         {
             if (itemCount < 1 || itemCount > this.capacity)
             {
-                throw new ArgumentOutOfRangeException(nameof(itemCount), "itemCount must be greater than or equal to one, and less than the capacity of the cache.");
+                Ex.ThrowArgOutOfRange(nameof(itemCount), "itemCount must be greater than or equal to one, and less than the capacity of the cache.");
             }
 
             for (int i = 0; i < itemCount; i++)

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -52,7 +52,7 @@ namespace BitFaster.Caching.Lru
 
             if (comparer == null)
             {
-                Ex.ThrowArgNull(nameof(comparer));
+                Ex.ThrowArgNull(ExceptionArgument.comparer);
             }
 
             this.capacity = capacity;

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -72,12 +72,12 @@ namespace BitFaster.Caching.Lru
         {
             if (capacity == null)
             {
-                throw new ArgumentNullException(nameof(capacity));
+                Ex.ThrowArgNull(nameof(capacity));
             }
 
             if (comparer == null)
             {
-                throw new ArgumentNullException(nameof(comparer));
+                Ex.ThrowArgNull(nameof(comparer));
             }
 
             capacity.Validate();
@@ -347,8 +347,8 @@ namespace BitFaster.Caching.Lru
             int capacity = this.Capacity;
 
             if (itemCount < 1 || itemCount > capacity)
-            { 
-                throw new ArgumentOutOfRangeException(nameof(itemCount), "itemCount must be greater than or equal to one, and less than the capacity of the cache.");
+            {
+                Ex.ThrowArgOutOfRange(nameof(itemCount), "itemCount must be greater than or equal to one, and less than the capacity of the cache.");
             }
 
             // clamp itemCount to number of items actually in the cache

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -72,12 +72,12 @@ namespace BitFaster.Caching.Lru
         {
             if (capacity == null)
             {
-                Ex.ThrowArgNull(nameof(capacity));
+                Ex.ThrowArgNull(ExceptionArgument.capacity);
             }
 
             if (comparer == null)
             {
-                Ex.ThrowArgNull(nameof(comparer));
+                Ex.ThrowArgNull(ExceptionArgument.comparer);
             }
 
             capacity.Validate();

--- a/BitFaster.Caching/Lru/EqualCapacityPartition.cs
+++ b/BitFaster.Caching/Lru/EqualCapacityPartition.cs
@@ -38,7 +38,7 @@ namespace BitFaster.Caching.Lru
         {
             if (capacity < 3)
             {
-                throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than or equal to 3.");
+                Ex.ThrowArgOutOfRange(nameof(capacity), "Capacity must be greater than or equal to 3.");
             }
 
             int hotCapacity = capacity / 3;

--- a/BitFaster.Caching/Lru/FavorWarmPartition.cs
+++ b/BitFaster.Caching/Lru/FavorWarmPartition.cs
@@ -55,12 +55,12 @@ namespace BitFaster.Caching.Lru
         {
             if (capacity < 3)
             {
-                throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be greater than or equal to 3.");
+                Ex.ThrowArgOutOfRange(nameof(capacity), "Capacity must be greater than or equal to 3.");
             }
 
             if (warmRatio <= 0.0 || warmRatio >= 1.0)
             {
-                throw new ArgumentOutOfRangeException(nameof(warmRatio), "warmRatio must be between 0.0 and 1.0");
+                Ex.ThrowArgOutOfRange(nameof(warmRatio), "warmRatio must be between 0.0 and 1.0");
             }
 
             int warm2 = (int)(capacity * warmRatio);

--- a/BitFaster.Caching/Lru/LruDebugView.cs
+++ b/BitFaster.Caching/Lru/LruDebugView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
@@ -13,7 +14,7 @@ namespace BitFaster.Caching.Lru
         {
             if (cache is null)
             {
-                throw new ArgumentNullException(nameof(cache));
+                Ex.ThrowArgNull(nameof(cache));
             }
 
             this.cache = cache;

--- a/BitFaster.Caching/Lru/LruDebugView.cs
+++ b/BitFaster.Caching/Lru/LruDebugView.cs
@@ -14,7 +14,7 @@ namespace BitFaster.Caching.Lru
         {
             if (cache is null)
             {
-                Ex.ThrowArgNull(nameof(cache));
+                Ex.ThrowArgNull(ExceptionArgument.cache);
             }
 
             this.cache = cache;

--- a/BitFaster.Caching/Scoped.cs
+++ b/BitFaster.Caching/Scoped.cs
@@ -70,7 +70,7 @@ namespace BitFaster.Caching
         {
             if (!TryCreateLifetime(out var lifetime))
             {
-                Ex.ThrowDisposed(nameof(T));
+                Ex.ThrowDisposed<T>();
             }
 
             return lifetime;
@@ -127,7 +127,7 @@ namespace BitFaster.Caching
             {
                 if (scoped is null)
                 {
-                    Ex.ThrowArgNull(nameof(scoped));
+                    Ex.ThrowArgNull(ExceptionArgument.scoped);
                 }
 
                 this.scoped = scoped;

--- a/BitFaster.Caching/Scoped.cs
+++ b/BitFaster.Caching/Scoped.cs
@@ -70,7 +70,7 @@ namespace BitFaster.Caching
         {
             if (!TryCreateLifetime(out var lifetime))
             {
-                throw new ObjectDisposedException($"{nameof(T)} is disposed.");
+                Ex.ThrowDisposed(nameof(T));
             }
 
             return lifetime;
@@ -127,7 +127,7 @@ namespace BitFaster.Caching
             {
                 if (scoped is null)
                 {
-                    throw new ArgumentNullException(nameof(scoped));
+                    Ex.ThrowArgNull(nameof(scoped));
                 }
 
                 this.scoped = scoped;

--- a/BitFaster.Caching/ScopedAsyncCache.cs
+++ b/BitFaster.Caching/ScopedAsyncCache.cs
@@ -28,7 +28,7 @@ namespace BitFaster.Caching
         {
             if (cache == null)
             {
-                Ex.ThrowArgNull(nameof(cache));
+                Ex.ThrowArgNull(ExceptionArgument.cache);
             }
 
             this.cache = cache;
@@ -79,7 +79,7 @@ namespace BitFaster.Caching
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
                 {
-                    Ex.ThrowInvalidOp(ScopedCacheDefaults.RetryFailureMessage);
+                    Ex.ThrowScopedRetryFailure();
                 }
             }
         }

--- a/BitFaster.Caching/ScopedAsyncCache.cs
+++ b/BitFaster.Caching/ScopedAsyncCache.cs
@@ -28,7 +28,7 @@ namespace BitFaster.Caching
         {
             if (cache == null)
             {
-                throw new ArgumentNullException(nameof(cache));
+                Ex.ThrowArgNull(nameof(cache));
             }
 
             this.cache = cache;
@@ -79,7 +79,7 @@ namespace BitFaster.Caching
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
                 {
-                    throw new InvalidOperationException(ScopedCacheDefaults.RetryFailureMessage);
+                    Ex.ThrowInvalidOp(ScopedCacheDefaults.RetryFailureMessage);
                 }
             }
         }

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -26,7 +26,7 @@ namespace BitFaster.Caching
         {
             if (cache == null)
             {
-                throw new ArgumentNullException(nameof(cache));
+                Ex.ThrowArgNull(nameof(cache));
             }
 
             this.cache = cache;
@@ -77,7 +77,7 @@ namespace BitFaster.Caching
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
                 {
-                    throw new InvalidOperationException(ScopedCacheDefaults.RetryFailureMessage);
+                    Ex.ThrowInvalidOp(ScopedCacheDefaults.RetryFailureMessage);
                 }
             }
         }

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -26,7 +26,7 @@ namespace BitFaster.Caching
         {
             if (cache == null)
             {
-                Ex.ThrowArgNull(nameof(cache));
+                Ex.ThrowArgNull(ExceptionArgument.cache);
             }
 
             this.cache = cache;
@@ -77,7 +77,7 @@ namespace BitFaster.Caching
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
                 {
-                    Ex.ThrowInvalidOp(ScopedCacheDefaults.RetryFailureMessage);
+                    Ex.ThrowScopedRetryFailure();
                 }
             }
         }


### PR DESCRIPTION
Implement a throw helper using the pattern used in the base library, e.g. https://github.com/stephentoub/corefx/blob/master/src/System.Linq/src/System/Linq/ThrowHelper.cs

This has a measurable benefit for DrainStatus.ShouldDrain(). [This article](https://dunnhq.com/posts/2022/throw-helper/) gives more details explaining why.

Before:
|                  Method |            Runtime |      Mean |     Error |    StdDev | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|----------:|------:|----------:|
| ConcurrentLfuBackground |           .NET 6.0 | 36.620 ns | 1.0541 ns | 3.0750 ns |  4.50 |         - |

After:

|                  Method |            Runtime |      Mean |     Error |    StdDev | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|----------:|------:|----------:|
| ConcurrentLfuBackground |           .NET 6.0 | 30.676 ns | 0.6457 ns | 0.7436 ns |  4.32 |         - |

