### PR TITLE
col

### DIFF
--- a/BitFaster.Caching.Benchmarks/DisposerBench.cs
+++ b/BitFaster.Caching.Benchmarks/DisposerBench.cs
@@ -11,7 +11,7 @@ namespace BitFaster.Caching.Benchmarks
     [SimpleJob(RuntimeMoniker.Net60)]
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
     [MemoryDiagnoser(displayGenColumns: false)]
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DisposerBench
     {
         [Benchmark(Baseline = true)]

--- a/BitFaster.Caching.Benchmarks/Lfu/LfuJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/LfuJustGetOrAdd.cs
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.Benchmarks
     [MemoryDiagnoser(displayGenColumns: false)]
     // [HardwareCounters(HardwareCounter.LlcMisses, HardwareCounter.CacheMisses)] // Requires Admin https://adamsitnik.com/Hardware-Counters-Diagnoser/
     // [ThreadingDiagnoser] // Requires .NET Core
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LfuJustGetOrAdd
     {
         private static readonly ConcurrentDictionary<int, int> dictionary = new ConcurrentDictionary<int, int>(8, 9, EqualityComparer<int>.Default);

--- a/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
@@ -13,7 +13,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     [SimpleJob(RuntimeMoniker.Net60)]
     // [DisassemblyDiagnoser(printSource: true, maxDepth: 5)] // Unstable
     [MemoryDiagnoser(displayGenColumns: false)]
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruAsyncGet
     {
         // if the cache value is a value type, value task has no effect - so use string to repro.

--- a/BitFaster.Caching.Benchmarks/Lru/LruCycleBench.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruCycleBench.cs
@@ -26,7 +26,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     [SimpleJob(RuntimeMoniker.Net60)]
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
     [MemoryDiagnoser(displayGenColumns: false)]
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruCycleBench
     {
         private static readonly ClassicLru<int, int> classicLru = new ClassicLru<int, int>(8, 9, EqualityComparer<int>.Default);

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -34,7 +34,7 @@ namespace BitFaster.Caching.Benchmarks
     [MemoryDiagnoser(displayGenColumns: false)]
     // [HardwareCounters(HardwareCounter.LlcMisses, HardwareCounter.CacheMisses)] // Requires Admin https://adamsitnik.com/Hardware-Counters-Diagnoser/
     // [ThreadingDiagnoser] // Requires .NET Core
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruJustGetOrAdd
     {
         private static readonly ConcurrentDictionary<int, int> dictionary = new ConcurrentDictionary<int, int>(8, 9, EqualityComparer<int>.Default);

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustTryGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustTryGet.cs
@@ -23,7 +23,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     [SimpleJob(RuntimeMoniker.Net60)]
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
     [MemoryDiagnoser(displayGenColumns: false)]
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruJustTryGet
     {
         private static readonly ConcurrentDictionary<int, int> dictionary = new ConcurrentDictionary<int, int>(8, 9, EqualityComparer<int>.Default);

--- a/BitFaster.Caching.Benchmarks/Lru/LruMultiGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruMultiGet.cs
@@ -28,7 +28,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     [SimpleJob(RuntimeMoniker.Net60)]
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
     [MemoryDiagnoser(displayGenColumns: false)]
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruMultiGet
     {
         private static readonly ConcurrentDictionary<int, int> dictionary = new ConcurrentDictionary<int, int>(8, 9, EqualityComparer<int>.Default);

--- a/BitFaster.Caching.Benchmarks/Lru/LruZipDistribution.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruZipDistribution.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     [SimpleJob(RuntimeMoniker.Net60)]
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
     [MemoryDiagnoser(displayGenColumns: false)]
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruZipDistribution
     {
         const double s = 0.86;

--- a/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
@@ -11,7 +11,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     /// </summary>
     [SimpleJob(RuntimeMoniker.Net48)]
     [SimpleJob(RuntimeMoniker.Net60)]
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class TLruTimeBenchmark
     {
         private static readonly ConcurrentLruCore<int, int, TimeStampedLruItem<int, int>, TLruDateTimePolicy<int, int>, NoTelemetryPolicy<int, int>> dateTimeTLru

--- a/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
@@ -7,7 +7,7 @@ namespace BitFaster.Caching.Benchmarks
 {
     [SimpleJob(RuntimeMoniker.Net48)]
     [SimpleJob(RuntimeMoniker.Net60)]
-    [HideColumns("Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class TimeBenchmarks
     {
         private static readonly Stopwatch sw = Stopwatch.StartNew();


### PR DESCRIPTION
Cleanup benchmark columns. Directly generates this out:

|                   Method |            Runtime |       Mean |     Error |    StdDev | Ratio | Allocated |
|------------------------- |------------------- |-----------:|----------:|----------:|------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   7.310 ns | 0.0579 ns | 0.0513 ns |  1.00 |         - |
|        FastConcurrentLru |           .NET 6.0 |   9.968 ns | 0.0546 ns | 0.0511 ns |  1.36 |         - |
|            ConcurrentLru |           .NET 6.0 |  16.369 ns | 0.0962 ns | 0.0853 ns |  2.24 |         - |
|            AtomicFastLru |           .NET 6.0 |  20.298 ns | 0.1672 ns | 0.1482 ns |  2.78 |         - |
|       FastConcurrentTLru |           .NET 6.0 |  29.605 ns | 0.6149 ns | 0.5451 ns |  4.05 |         - |
|           ConcurrentTLru |           .NET 6.0 |  34.773 ns | 0.3336 ns | 0.2957 ns |  4.76 |         - |
|            ConcurrentLfu |           .NET 6.0 |  32.736 ns | 0.7241 ns | 2.1351 ns |  4.49 |         - |
|               ClassicLru |           .NET 6.0 |  48.546 ns | 0.2373 ns | 0.2219 ns |  6.64 |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 112.380 ns | 0.6764 ns | 0.5996 ns | 15.37 |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  54.497 ns | 0.4472 ns | 0.4183 ns |  7.46 |      24 B |
|                          |                    |            |           |           |       |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  13.862 ns | 0.0764 ns | 0.0677 ns |  1.00 |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  14.724 ns | 0.1671 ns | 0.1481 ns |  1.06 |         - |
|            ConcurrentLru | .NET Framework 4.8 |  19.471 ns | 0.1304 ns | 0.1156 ns |  1.40 |         - |
|            AtomicFastLru | .NET Framework 4.8 |  38.450 ns | 0.6330 ns | 0.5921 ns |  2.78 |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  45.497 ns | 0.7426 ns | 0.6947 ns |  3.28 |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  48.809 ns | 0.4034 ns | 0.3773 ns |  3.52 |         - |
|            ConcurrentLfu | .NET Framework 4.8 |  62.549 ns | 1.2508 ns | 1.5818 ns |  4.49 |         - |
|               ClassicLru | .NET Framework 4.8 |  61.053 ns | 1.0346 ns | 0.9172 ns |  4.40 |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 278.688 ns | 2.0259 ns | 1.7959 ns | 20.10 |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 120.011 ns | 2.0557 ns | 1.9229 ns |  8.66 |      24 B |