### PR TITLE
isa

### DIFF
--- a/BitFaster.Caching.Benchmarks/Lfu/SketchFrequency.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/SketchFrequency.cs
@@ -12,8 +12,8 @@ namespace BitFaster.Caching.Benchmarks.Lfu
     public class SketchFrequency
     {
         const int iterations = 512;
-        private static CmSketch<int, Disable> std = new CmSketch<int, Disable>(10, EqualityComparer<int>.Default);
-        private static CmSketch<int, Detect> avx = new CmSketch<int, Detect>(10, EqualityComparer<int>.Default);
+        private static CmSketch<int, DisableHardwareIntrinsics> std = new CmSketch<int, DisableHardwareIntrinsics>(10, EqualityComparer<int>.Default);
+        private static CmSketch<int, DetectIsa> avx = new CmSketch<int, DetectIsa>(10, EqualityComparer<int>.Default);
 
         [GlobalSetup]
         public void Setup()

--- a/BitFaster.Caching.Benchmarks/Lfu/SketchFrequency.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/SketchFrequency.cs
@@ -12,8 +12,8 @@ namespace BitFaster.Caching.Benchmarks.Lfu
     public class SketchFrequency
     {
         const int iterations = 512;
-        private static CmSketch<int, DisableAvx2> std = new CmSketch<int, DisableAvx2>(10, EqualityComparer<int>.Default);
-        private static CmSketch<int, DetectAvx2> avx = new CmSketch<int, DetectAvx2>(10, EqualityComparer<int>.Default);
+        private static CmSketch<int, Disable> std = new CmSketch<int, Disable>(10, EqualityComparer<int>.Default);
+        private static CmSketch<int, Detect> avx = new CmSketch<int, Detect>(10, EqualityComparer<int>.Default);
 
         [GlobalSetup]
         public void Setup()

--- a/BitFaster.Caching.Benchmarks/Lfu/SketchIncrement.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/SketchIncrement.cs
@@ -12,8 +12,8 @@ namespace BitFaster.Caching.Benchmarks.Lfu
     public class SketchIncrement
     {
         const int iterations = 1024;
-        private static CmSketch<int, DisableAvx2> std = new CmSketch<int, DisableAvx2>(10, EqualityComparer<int>.Default);
-        private static CmSketch<int, DetectAvx2> avx = new CmSketch<int, DetectAvx2>(10, EqualityComparer<int>.Default);
+        private static CmSketch<int, Disable> std = new CmSketch<int, Disable>(10, EqualityComparer<int>.Default);
+        private static CmSketch<int, Detect> avx = new CmSketch<int, Detect>(10, EqualityComparer<int>.Default);
 
         [Benchmark(Baseline = true)]
         public void Inc()

--- a/BitFaster.Caching.Benchmarks/Lfu/SketchIncrement.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/SketchIncrement.cs
@@ -12,8 +12,8 @@ namespace BitFaster.Caching.Benchmarks.Lfu
     public class SketchIncrement
     {
         const int iterations = 1024;
-        private static CmSketch<int, Disable> std = new CmSketch<int, Disable>(10, EqualityComparer<int>.Default);
-        private static CmSketch<int, Detect> avx = new CmSketch<int, Detect>(10, EqualityComparer<int>.Default);
+        private static CmSketch<int, DisableHardwareIntrinsics> std = new CmSketch<int, DisableHardwareIntrinsics>(10, EqualityComparer<int>.Default);
+        private static CmSketch<int, DetectIsa> avx = new CmSketch<int, DetectIsa>(10, EqualityComparer<int>.Default);
 
         [Benchmark(Baseline = true)]
         public void Inc()

--- a/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
@@ -17,9 +17,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
     {
     }
 
-    public abstract class CmSketchTestBase<AVX2> where AVX2 : struct, Isa
+    public abstract class CmSketchTestBase<TISA> where TISA : struct, Isa
     {
-        private CmSketch<int, AVX2> sketch = new CmSketch<int, AVX2>(512, EqualityComparer<int>.Default);
+        private CmSketch<int, TISA> sketch = new CmSketch<int, TISA>(512, EqualityComparer<int>.Default);
 
         public CmSketchTestBase()
         {
@@ -29,7 +29,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [SkippableFact]
         public void WhenCapacityIsZeroDefaultsSelected()
         {
-            sketch = new CmSketch<int, AVX2>(0, EqualityComparer<int>.Default);
+            sketch = new CmSketch<int, TISA>(0, EqualityComparer<int>.Default);
 
             sketch.ResetSampleSize.Should().Be(10);
         }
@@ -68,7 +68,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             bool reset = false;
 
-            sketch = new CmSketch<int, AVX2>(64, EqualityComparer<int>.Default);
+            sketch = new CmSketch<int, TISA>(64, EqualityComparer<int>.Default);
 
             for (int i = 1; i < 20 * 64; i++)
             {
@@ -101,7 +101,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private static void SkipAvxIfNotSupported()
         {
             // when we are trying to test Avx2, skip the test if it's not supported
-            Skip.If(typeof(AVX2) == typeof(Detect) && !Avx2.IsSupported);
+            Skip.If(typeof(TISA) == typeof(Detect) && !Avx2.IsSupported);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
@@ -8,12 +8,12 @@ using Xunit;
 namespace BitFaster.Caching.UnitTests.Lfu
 {
     // Test with AVX2 if it is supported
-    public class CMSketchAvx2Tests : CmSketchTestBase<Detect>
+    public class CMSketchAvx2Tests : CmSketchTestBase<DetectIsa>
     {
     }
 
     // Test with AVX2 disabled
-    public class CmSketchTests : CmSketchTestBase<Disable>
+    public class CmSketchTests : CmSketchTestBase<DisableHardwareIntrinsics>
     {
     }
 
@@ -101,7 +101,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private static void SkipAvxIfNotSupported()
         {
             // when we are trying to test Avx2, skip the test if it's not supported
-            Skip.If(typeof(I) == typeof(Detect) && !Avx2.IsSupported);
+            Skip.If(typeof(I) == typeof(DetectIsa) && !Avx2.IsSupported);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
@@ -8,16 +8,16 @@ using Xunit;
 namespace BitFaster.Caching.UnitTests.Lfu
 {
     // Test with AVX2 if it is supported
-    public class CMSketchAvx2Tests : CmSketchTestBase<DetectAvx2>
+    public class CMSketchAvx2Tests : CmSketchTestBase<Detect>
     {
     }
 
     // Test with AVX2 disabled
-    public class CmSketchTests : CmSketchTestBase<DisableAvx2>
+    public class CmSketchTests : CmSketchTestBase<Disable>
     {
     }
 
-    public abstract class CmSketchTestBase<AVX2> where AVX2 : struct, IAvx2
+    public abstract class CmSketchTestBase<AVX2> where AVX2 : struct, Isa
     {
         private CmSketch<int, AVX2> sketch = new CmSketch<int, AVX2>(512, EqualityComparer<int>.Default);
 
@@ -101,7 +101,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private static void SkipAvxIfNotSupported()
         {
             // when we are trying to test Avx2, skip the test if it's not supported
-            Skip.If(typeof(AVX2) == typeof(DetectAvx2) && !Avx2.IsSupported);
+            Skip.If(typeof(AVX2) == typeof(Detect) && !Avx2.IsSupported);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
@@ -17,9 +17,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
     {
     }
 
-    public abstract class CmSketchTestBase<TISA> where TISA : struct, Isa
+    public abstract class CmSketchTestBase<I> where I : struct, IsaProbe
     {
-        private CmSketch<int, TISA> sketch = new CmSketch<int, TISA>(512, EqualityComparer<int>.Default);
+        private CmSketch<int, I> sketch = new CmSketch<int, I>(512, EqualityComparer<int>.Default);
 
         public CmSketchTestBase()
         {
@@ -29,7 +29,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [SkippableFact]
         public void WhenCapacityIsZeroDefaultsSelected()
         {
-            sketch = new CmSketch<int, TISA>(0, EqualityComparer<int>.Default);
+            sketch = new CmSketch<int, I>(0, EqualityComparer<int>.Default);
 
             sketch.ResetSampleSize.Should().Be(10);
         }
@@ -68,7 +68,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             bool reset = false;
 
-            sketch = new CmSketch<int, TISA>(64, EqualityComparer<int>.Default);
+            sketch = new CmSketch<int, I>(64, EqualityComparer<int>.Default);
 
             for (int i = 1; i < 20 * 64; i++)
             {
@@ -101,7 +101,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private static void SkipAvxIfNotSupported()
         {
             // when we are trying to test Avx2, skip the test if it's not supported
-            Skip.If(typeof(TISA) == typeof(Detect) && !Avx2.IsSupported);
+            Skip.If(typeof(I) == typeof(Detect) && !Avx2.IsSupported);
         }
     }
 }

--- a/BitFaster.Caching/Intrinsics.cs
+++ b/BitFaster.Caching/Intrinsics.cs
@@ -5,20 +5,20 @@ using System.Runtime.Intrinsics.X86;
 namespace BitFaster.Caching
 {
     /// <summary>
-    /// Represents a marker interface to enable AVX2 specific optimization.
+    /// Represents a marker interface to enable instruction set hardware intrinsics.
     /// </summary>
-    public interface Isa
+    public interface IsaProbe
     {
         /// <summary>
-        /// Gets a value indicating whether Avx2 is supported
+        /// Gets a value indicating whether Avx2 is supported.
         /// </summary>
         bool IsAvx2Supported { get; }
     }
 
     /// <summary>
-    /// Detect AVX2 support and enable if available.
+    /// Detect support for hardware intrinsics.
     /// </summary>
-    public struct Detect : Isa
+    public struct Detect : IsaProbe
     {
 #if NETSTANDARD2_0
         /// <inheritdoc/>
@@ -30,9 +30,9 @@ namespace BitFaster.Caching
     }
 
     /// <summary>
-    /// Force disable AVX2.
+    /// Force disable hardware intrinsics.
     /// </summary>
-    public struct Disable : Isa
+    public struct Disable : IsaProbe
     {
         /// <inheritdoc/>
         public bool IsAvx2Supported => false;

--- a/BitFaster.Caching/Intrinsics.cs
+++ b/BitFaster.Caching/Intrinsics.cs
@@ -10,15 +10,15 @@ namespace BitFaster.Caching
     public interface IsaProbe
     {
         /// <summary>
-        /// Gets a value indicating whether Avx2 is supported.
+        /// Gets a value indicating whether AVX2 is supported.
         /// </summary>
         bool IsAvx2Supported { get; }
     }
 
     /// <summary>
-    /// Detect support for hardware intrinsics.
+    /// Detect support for hardware instructions via intrinsics.
     /// </summary>
-    public struct Detect : IsaProbe
+    public readonly struct DetectIsa : IsaProbe
     {
 #if NETSTANDARD2_0
         /// <inheritdoc/>
@@ -30,9 +30,9 @@ namespace BitFaster.Caching
     }
 
     /// <summary>
-    /// Force disable hardware intrinsics.
+    /// Force disable hardware instructions via intrinsics.
     /// </summary>
-    public struct Disable : IsaProbe
+    public readonly struct DisableHardwareIntrinsics : IsaProbe
     {
         /// <inheritdoc/>
         public bool IsAvx2Supported => false;

--- a/BitFaster.Caching/Intrinsics.cs
+++ b/BitFaster.Caching/Intrinsics.cs
@@ -7,34 +7,34 @@ namespace BitFaster.Caching
     /// <summary>
     /// Represents a marker interface to enable AVX2 specific optimization.
     /// </summary>
-    public interface IAvx2
+    public interface Isa
     {
         /// <summary>
         /// Gets a value indicating whether Avx2 is supported
         /// </summary>
-        bool IsSupported { get; }
+        bool IsAvx2Supported { get; }
     }
 
     /// <summary>
     /// Detect AVX2 support and enable if available.
     /// </summary>
-    public struct DetectAvx2 : IAvx2
+    public struct Detect : Isa
     {
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        public bool IsSupported => false;
+        public bool IsAvx2Supported => false;
 #else
         /// <inheritdoc/>
-        public bool IsSupported => Avx2.IsSupported;
+        public bool IsAvx2Supported => Avx2.IsSupported;
 #endif
     }
 
     /// <summary>
     /// Force disable AVX2.
     /// </summary>
-    public struct DisableAvx2 : IAvx2
+    public struct Disable : Isa
     {
         /// <inheritdoc/>
-        public bool IsSupported => false;
+        public bool IsAvx2Supported => false;
     }
 }

--- a/BitFaster.Caching/Lfu/CmSketch.cs
+++ b/BitFaster.Caching/Lfu/CmSketch.cs
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.Lfu
     /// </summary>
     /// This is a direct C# translation of FrequencySketch in the Caffeine library by ben.manes@gmail.com (Ben Manes).
     /// https://github.com/ben-manes/caffeine
-    public sealed class CmSketch<T, TISA> where TISA : struct, Isa
+    public sealed class CmSketch<T, I> where I : struct, IsaProbe
     {
         // A mixture of seeds from FNV-1a, CityHash, and Murmur3
         private static readonly ulong[] Seed = { 0xc3a5c85c97cb3127L, 0xb492b66fbe98f273L, 0x9ae16a3b2f90404fL, 0xcbf29ce484222325L};
@@ -61,9 +61,9 @@ namespace BitFaster.Caching.Lfu
             return EstimateFrequencyStd(value);
 #else
             
-            TISA avx2 = default;
+            I isa = default;
 
-            if (avx2.IsAvx2Supported)
+            if (isa.IsAvx2Supported)
             {
                 return EstimateFrequencyAvx(value);
             }
@@ -84,9 +84,9 @@ namespace BitFaster.Caching.Lfu
             IncrementStd(value);
 #else
 
-            TISA avx2 = default;
+            I isa = default;
 
-            if (avx2.IsAvx2Supported)
+            if (isa.IsAvx2Supported)
             {
                 IncrementAvx(value);
             }

--- a/BitFaster.Caching/Lfu/CmSketch.cs
+++ b/BitFaster.Caching/Lfu/CmSketch.cs
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.Lfu
     /// </summary>
     /// This is a direct C# translation of FrequencySketch in the Caffeine library by ben.manes@gmail.com (Ben Manes).
     /// https://github.com/ben-manes/caffeine
-    public sealed class CmSketch<T, AVX2> where AVX2 : struct, IAvx2
+    public sealed class CmSketch<T, AVX2> where AVX2 : struct, Isa
     {
         // A mixture of seeds from FNV-1a, CityHash, and Murmur3
         private static readonly ulong[] Seed = { 0xc3a5c85c97cb3127L, 0xb492b66fbe98f273L, 0x9ae16a3b2f90404fL, 0xcbf29ce484222325L};
@@ -63,7 +63,7 @@ namespace BitFaster.Caching.Lfu
             
             AVX2 avx2 = default;
 
-            if (avx2.IsSupported)
+            if (avx2.IsAvx2Supported)
             {
                 return EstimateFrequencyAvx(value);
             }
@@ -86,7 +86,7 @@ namespace BitFaster.Caching.Lfu
 
             AVX2 avx2 = default;
 
-            if (avx2.IsSupported)
+            if (avx2.IsAvx2Supported)
             {
                 IncrementAvx(value);
             }

--- a/BitFaster.Caching/Lfu/CmSketch.cs
+++ b/BitFaster.Caching/Lfu/CmSketch.cs
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.Lfu
     /// </summary>
     /// This is a direct C# translation of FrequencySketch in the Caffeine library by ben.manes@gmail.com (Ben Manes).
     /// https://github.com/ben-manes/caffeine
-    public sealed class CmSketch<T, AVX2> where AVX2 : struct, Isa
+    public sealed class CmSketch<T, TISA> where TISA : struct, Isa
     {
         // A mixture of seeds from FNV-1a, CityHash, and Murmur3
         private static readonly ulong[] Seed = { 0xc3a5c85c97cb3127L, 0xb492b66fbe98f273L, 0x9ae16a3b2f90404fL, 0xcbf29ce484222325L};
@@ -61,7 +61,7 @@ namespace BitFaster.Caching.Lfu
             return EstimateFrequencyStd(value);
 #else
             
-            AVX2 avx2 = default;
+            TISA avx2 = default;
 
             if (avx2.IsAvx2Supported)
             {
@@ -84,7 +84,7 @@ namespace BitFaster.Caching.Lfu
             IncrementStd(value);
 #else
 
-            AVX2 avx2 = default;
+            TISA avx2 = default;
 
             if (avx2.IsAvx2Supported)
             {

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -57,7 +57,7 @@ namespace BitFaster.Caching.Lfu
 
         private readonly CacheMetrics metrics = new CacheMetrics();
 
-        private readonly CmSketch<K, DetectAvx2> cmSketch;
+        private readonly CmSketch<K, Detect> cmSketch;
 
         private readonly LfuNodeList<K, V> windowLru;
         private readonly LfuNodeList<K, V> probationLru;
@@ -100,7 +100,7 @@ namespace BitFaster.Caching.Lfu
             int writeBufferSize = Math.Min(BitOps.CeilingPowerOfTwo(capacity), 128);
             this.writeBuffer = new MpscBoundedBuffer<LfuNode<K, V>>(writeBufferSize);
 
-            this.cmSketch = new CmSketch<K, DetectAvx2>(capacity, comparer);
+            this.cmSketch = new CmSketch<K, Detect>(capacity, comparer);
             this.windowLru = new LfuNodeList<K, V>();
             this.probationLru = new LfuNodeList<K, V>();
             this.protectedLru = new LfuNodeList<K, V>();
@@ -617,11 +617,11 @@ namespace BitFaster.Caching.Lfu
 
         private ref struct EvictIterator
         {
-            private readonly CmSketch<K, DetectAvx2> sketch;
+            private readonly CmSketch<K, Detect> sketch;
             public LfuNode<K, V> node;
             public int freq;
 
-            public EvictIterator(CmSketch<K, DetectAvx2> sketch, LfuNode<K, V> node)
+            public EvictIterator(CmSketch<K, Detect> sketch, LfuNode<K, V> node)
             {
                 this.sketch = sketch;
                 this.node = node;

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -57,7 +57,7 @@ namespace BitFaster.Caching.Lfu
 
         private readonly CacheMetrics metrics = new CacheMetrics();
 
-        private readonly CmSketch<K, Detect> cmSketch;
+        private readonly CmSketch<K, DetectIsa> cmSketch;
 
         private readonly LfuNodeList<K, V> windowLru;
         private readonly LfuNodeList<K, V> probationLru;
@@ -100,7 +100,7 @@ namespace BitFaster.Caching.Lfu
             int writeBufferSize = Math.Min(BitOps.CeilingPowerOfTwo(capacity), 128);
             this.writeBuffer = new MpscBoundedBuffer<LfuNode<K, V>>(writeBufferSize);
 
-            this.cmSketch = new CmSketch<K, Detect>(capacity, comparer);
+            this.cmSketch = new CmSketch<K, DetectIsa>(capacity, comparer);
             this.windowLru = new LfuNodeList<K, V>();
             this.probationLru = new LfuNodeList<K, V>();
             this.protectedLru = new LfuNodeList<K, V>();
@@ -617,11 +617,11 @@ namespace BitFaster.Caching.Lfu
 
         private ref struct EvictIterator
         {
-            private readonly CmSketch<K, Detect> sketch;
+            private readonly CmSketch<K, DetectIsa> sketch;
             public LfuNode<K, V> node;
             public int freq;
 
-            public EvictIterator(CmSketch<K, Detect> sketch, LfuNode<K, V> node)
+            public EvictIterator(CmSketch<K, DetectIsa> sketch, LfuNode<K, V> node)
             {
                 this.sketch = sketch;
                 this.node = node;


### PR DESCRIPTION
Rename AVX probing.

If we later add support for ARM or AVX512 intrinsics, following the existing scheme there would need to be another type parameter for each instruction set. Since this type is used to control which code path should be used for testing, rename assuming it will eventually contain information about other ISAs and we would just use a single type to control it.