### PR TITLE
fix AVX reset

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
@@ -76,6 +76,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
                 if (sketch.Size != i)
                 {
+                    i.Should().NotBe(1, "sketch should not be reset on the first iteration. Resize logic is broken");
+
                     reset = true;
                     break;
                 }

--- a/BitFaster.Caching/Lfu/CmSketch.cs
+++ b/BitFaster.Caching/Lfu/CmSketch.cs
@@ -257,7 +257,8 @@ namespace BitFaster.Caching.Lfu
                 *(tablePtr + indexes.GetElement(2)) += inc.GetElement(2);
                 *(tablePtr + indexes.GetElement(3)) += inc.GetElement(3);
 
-                bool wasInc = Avx2.MoveMask(masked.AsByte()) != 0; // _mm256_movemask_epi8
+                Vector256<byte> result = Avx2.CompareEqual(masked.AsByte(), Vector256.Create(0).AsByte());
+                bool wasInc = Avx2.MoveMask(result.AsByte()) == unchecked((int)(0b1111_1111_1111_1111_1111_1111_1111_1111));
 
                 if (wasInc && (++size == sampleSize))
                 {


### PR DESCRIPTION
Fix logic to detect whether the table was incremented.

| Method |     Mean |    Error |   StdDev | Ratio | Allocated |
|------- |---------:|---------:|---------:|------:|----------:|
|    Inc | 21.80 us | 0.085 us | 0.071 us |  1.00 |         - |
| IncAvx | 14.64 us | 0.032 us | 0.029 us |  0.67 |         - |

This is actually now faster because reset is called fewer times.