### PR TITLE
optimize sketch reset

### DIFF
--- a/BitFaster.Caching.Benchmarks/Lfu/Reset.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/Reset.cs
@@ -1,0 +1,59 @@
+﻿
+using BenchmarkDotNet.Attributes;
+
+namespace BitFaster.Caching.Benchmarks.Lfu
+{
+    public class Reset
+    {
+        static long ResetMask = 0x7777777777777777L;
+        static long OneMask = 0x1111111111111111L;
+
+        long[] table;
+
+        [Params(4, 128, 8192, 1048576)]
+        public int Size { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            table = new long[Size];
+        }
+
+        [Benchmark(Baseline = true)]
+        public int ResetStd()
+        {
+            int count = 0;
+            for (int i = 0; i < table.Length; i++)
+            {
+                count += BitOps.BitCount(table[i] & OneMask);
+                table[i] = (long)((ulong)table[i] >> 1) & ResetMask;
+            }
+
+            return count;
+        }
+
+        [Benchmark()]
+        public int Reset4()
+        {
+            int count0 = 0;
+            int count1 = 0;
+            int count2 = 0;
+            int count3 = 0;
+
+            for (int i = 0; i < table.Length; i += 4)
+            {
+                count0 += BitOps.BitCount(table[i] & OneMask);
+                count1 += BitOps.BitCount(table[i + 1] & OneMask);
+                count2 += BitOps.BitCount(table[i + 2] & OneMask);
+                count3 += BitOps.BitCount(table[i + 3] & OneMask);
+
+                table[i] = (long)((ulong)table[i] >> 1) & ResetMask;
+                table[i + 1] = (long)((ulong)table[i + 1] >> 1) & ResetMask;
+                table[i + 2] = (long)((ulong)table[i + 2] >> 1) & ResetMask;
+                table[i + 3] = (long)((ulong)table[i + 3] >> 1) & ResetMask;
+            }
+
+            return (count0 + count1) + (count2 + count3);
+        }
+    }
+}

--- a/BitFaster.Caching.Benchmarks/Lfu/SketchReset.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/SketchReset.cs
@@ -1,8 +1,10 @@
 ﻿
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 
 namespace BitFaster.Caching.Benchmarks.Lfu
 {
+    [SimpleJob(RuntimeMoniker.Net60)]
     public class Reset
     {
         static long ResetMask = 0x7777777777777777L;
@@ -20,7 +22,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
         }
 
         [Benchmark(Baseline = true)]
-        public int ResetStd()
+        public int Reset1()
         {
             int count = 0;
             for (int i = 0; i < table.Length; i++)
@@ -30,6 +32,24 @@ namespace BitFaster.Caching.Benchmarks.Lfu
             }
 
             return count;
+        }
+
+        [Benchmark()]
+        public int Reset2()
+        {
+            int count0 = 0;
+            int count1 = 0;
+
+            for (int i = 0; i < table.Length; i += 2)
+            {
+                count0 += BitOps.BitCount(table[i] & OneMask);
+                count1 += BitOps.BitCount(table[i + 1] & OneMask);
+
+                table[i] = (long)((ulong)table[i] >> 1) & ResetMask;
+                table[i + 1] = (long)((ulong)table[i + 1] >> 1) & ResetMask;
+            }
+
+            return count0 + count1;
         }
 
         [Benchmark()]

--- a/BitFaster.Caching.Benchmarks/Lfu/SketchReset.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/SketchReset.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Jobs;
 namespace BitFaster.Caching.Benchmarks.Lfu
 {
     [SimpleJob(RuntimeMoniker.Net60)]
-    public class Reset
+    public class SketchReset
     {
         static long ResetMask = 0x7777777777777777L;
         static long OneMask = 0x1111111111111111L;

--- a/BitFaster.Caching/Lfu/CmSketch.cs
+++ b/BitFaster.Caching/Lfu/CmSketch.cs
@@ -319,21 +319,6 @@ namespace BitFaster.Caching.Lfu
             Vector256<ulong> prodll = Avx2.Multiply(a.AsUInt32(), b.AsUInt32());    // a0Lb0L,a1Lb1L, 64 bit unsigned products
             return Avx2.Add(prodll.AsInt64(), prodlh3.AsInt64()).AsUInt64();        // a0Lb0L+(a0Lb0H+a0Hb0L)<<32, a1Lb1L+(a1Lb1H+a1Hb1L)<<32
         }
-
-        // https://stackoverflow.com/questions/50081465/counting-1-bits-population-count-on-large-data-using-avx-512-or-avx-2
-        private void ResetAvx()
-        {
-            Vector256<byte> lut = Vector256.Create(
-                (byte) /* 0 */ 0, /* 1 */ 1, /* 2 */ 1, /* 3 */ 2,
-                       /* 4 */ 1, /* 5 */ 2, /* 6 */ 2, /* 7 */ 3,
-                       /* 8 */ 1, /* 9 */ 2, /* a */ 2, /* b */ 3,
-                       /* c */ 2, /* d */ 3, /* e */ 3, /* f */ 4,
-                       /* 0 */ 0, /* 1 */ 1, /* 2 */ 1, /* 3 */ 2,
-                       /* 4 */ 1, /* 5 */ 2, /* 6 */ 2, /* 7 */ 3,
-                       /* 8 */ 1, /* 9 */ 2, /* a */ 2, /* b */ 3,
-                       /* c */ 2, /* d */ 3, /* e */ 3, /* f */ 4
-                );
-        }
 #endif
     }
 }


### PR DESCRIPTION
Unroll the reset loop to improve throughput. Not earth shattering, but worth almost 1 ms for a 1 million element table.

| Method |    Size |             Mean |          Error |         StdDev | Ratio |
|------- |-------- |-----------------:|---------------:|---------------:|------:|
| Reset1 |       4 |         8.893 ns |      0.0390 ns |      0.0304 ns |  1.00 |
| Reset2 |       4 |         6.170 ns |      0.0873 ns |      0.0816 ns |  0.70 |
| Reset4 |       4 |         5.883 ns |      0.0722 ns |      0.0675 ns |  0.66 |
|        |         |                  |                |                |       |
| Reset1 |     128 |       282.571 ns |      2.4478 ns |      2.2896 ns |  1.00 |
| Reset2 |     128 |       176.850 ns |      0.7743 ns |      0.6045 ns |  0.63 |
| Reset4 |     128 |       160.341 ns |      0.9347 ns |      0.7806 ns |  0.57 |
|        |         |                  |                |                |       |
| Reset1 |    8192 |    17,454.963 ns |     84.2848 ns |     74.7163 ns |  1.00 |
| Reset2 |    8192 |    10,810.292 ns |     36.0139 ns |     30.0733 ns |  0.62 |
| Reset4 |    8192 |    10,252.838 ns |     36.5366 ns |     30.5097 ns |  0.59 |
|        |         |                  |                |                |       |
| Reset1 | 1048576 | 2,258,716.657 ns |  7,187.0479 ns |  6,371.1308 ns |  1.00 |
| Reset2 | 1048576 | 1,481,100.085 ns | 28,584.5228 ns | 28,073.8235 ns |  0.66 |
| Reset4 | 1048576 | 1,391,683.608 ns | 13,086.8858 ns | 11,601.1834 ns |  0.62 |