### PR TITLE
avx reset

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/BitFaster.Caching.Benchmarks/Lfu/SketchReset.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/SketchReset.cs
@@ -1,6 +1,11 @@
 ﻿
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using BitFaster.Caching.Lfu;
+using System.Collections.Generic;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
 
 namespace BitFaster.Caching.Benchmarks.Lfu
 {
@@ -74,6 +79,107 @@ namespace BitFaster.Caching.Benchmarks.Lfu
             }
 
             return (count0 + count1) + (count2 + count3);
+        }
+
+        [Benchmark()]
+        public int Reset4NoPopcount()
+        {
+            for (int i = 0; i < table.Length; i += 4)
+            {
+                table[i] = (long)((ulong)table[i] >> 1) & ResetMask;
+                table[i + 1] = (long)((ulong)table[i + 1] >> 1) & ResetMask;
+                table[i + 2] = (long)((ulong)table[i + 2] >> 1) & ResetMask;
+                table[i + 3] = (long)((ulong)table[i + 3] >> 1) & ResetMask;
+            }
+
+            return 0;
+        }
+
+        [Benchmark()]
+        public unsafe int ResetAVXNoPopcount()
+        {
+            var resetMaskVector = Vector256.Create(ResetMask);
+
+            fixed (long* tPtr = &table[0])
+            {
+                for (int i = 0; i < table.Length; i += 4)
+                {
+                    Vector256<long> t = Avx2.LoadVector256(tPtr + i).AsInt64();
+                    t = Avx2.ShiftRightLogical(t, 1);
+                    t = Avx2.And(t, resetMaskVector);
+                    Avx2.Store(tPtr + i, t);
+                }
+            }
+
+            return 0;
+        }
+
+        [Benchmark()]
+        public unsafe int ResetAVXNoPopcountUnroll2()
+        {
+            if (table.Length < 16)
+            {
+                return ResetAVXNoPopcount();
+            }
+
+            var resetMaskVector = Vector256.Create(ResetMask);
+
+            fixed (long* tPtr = &table[0])
+            {
+                for (int i = 0; i < table.Length; i += 8)
+                {
+                    Vector256<long> t1 = Avx2.LoadVector256(tPtr + i).AsInt64();
+                    t1 = Avx2.ShiftRightLogical(t1, 1);
+                    t1 = Avx2.And(t1, resetMaskVector);
+                    Avx2.Store(tPtr + i, t1);
+
+                    Vector256<long> t2 = Avx2.LoadVector256(tPtr + i + 4).AsInt64();
+                    t2 = Avx2.ShiftRightLogical(t2, 1);
+                    t2 = Avx2.And(t2, resetMaskVector);
+                    Avx2.Store(tPtr + i + 4, t2);
+                }
+            }
+
+            return 0;
+        }
+
+        [Benchmark()]
+        public unsafe int ResetAVXNoPopcountUnroll4()
+        {
+            if (table.Length < 16)
+            {
+                return ResetAVXNoPopcount();
+            }
+
+            var resetMaskVector = Vector256.Create(ResetMask);
+
+            fixed (long* tPtr = &table[0])
+            {
+                for (int i = 0; i < table.Length; i += 16)
+                {
+                    Vector256<long> t1 = Avx2.LoadVector256(tPtr + i).AsInt64();
+                    t1 = Avx2.ShiftRightLogical(t1, 1);
+                    t1 = Avx2.And(t1, resetMaskVector);
+                    Avx2.Store(tPtr + i, t1);
+
+                    Vector256<long> t2 = Avx2.LoadVector256(tPtr + i + 4).AsInt64();
+                    t2 = Avx2.ShiftRightLogical(t2, 1);
+                    t2 = Avx2.And(t2, resetMaskVector);
+                    Avx2.Store(tPtr + i + 4, t2);
+
+                    Vector256<long> t3 = Avx2.LoadVector256(tPtr + i + 8).AsInt64();
+                    t3 = Avx2.ShiftRightLogical(t3, 1);
+                    t3 = Avx2.And(t3, resetMaskVector);
+                    Avx2.Store(tPtr + i + 8, t3);
+
+                    Vector256<long> t4 = Avx2.LoadVector256(tPtr + i + 12).AsInt64();
+                    t4 = Avx2.ShiftRightLogical(t4, 1);
+                    t4 = Avx2.And(t4, resetMaskVector);
+                    Avx2.Store(tPtr + i + 12, t4);
+                }
+            }
+
+            return 0;
         }
     }
 }


### PR DESCRIPTION


Compare AVX to unrolled reset, without popcount:

|                    Method |    Size |             Mean |          Error |         StdDev | Ratio |
|-------------------------- |-------- |-----------------:|---------------:|---------------:|------:|
|                    Reset1 |       4 |         9.151 ns |      0.1928 ns |      0.1804 ns |  1.00 |
|                    Reset2 |       4 |         6.342 ns |      0.0821 ns |      0.0768 ns |  0.69 |
|                    Reset4 |       4 |         6.270 ns |      0.1115 ns |      0.1043 ns |  0.69 |
|          Reset4NoPopcount |       4 |         4.205 ns |      0.0570 ns |      0.0505 ns |  0.46 |
|        ResetAVXNoPopcount |       4 |         2.800 ns |      0.0373 ns |      0.0349 ns |  0.31 |
| ResetAVXNoPopcountUnroll2 |       4 |         4.532 ns |      0.0331 ns |      0.0310 ns |  0.50 |
| ResetAVXNoPopcountUnroll4 |       4 |         4.750 ns |      0.1034 ns |      0.0967 ns |  0.52 |
|                           |         |                  |                |                |       |
|                    Reset1 |     128 |       283.191 ns |      3.5599 ns |      3.1558 ns |  1.00 |
|                    Reset2 |     128 |       179.379 ns |      0.9743 ns |      0.9114 ns |  0.63 |
|                    Reset4 |     128 |       162.091 ns |      0.8050 ns |      0.7530 ns |  0.57 |
|          Reset4NoPopcount |     128 |       105.598 ns |      0.6973 ns |      0.5823 ns |  0.37 |
|        ResetAVXNoPopcount |     128 |        21.846 ns |      0.3369 ns |      0.3152 ns |  0.08 |
| ResetAVXNoPopcountUnroll2 |     128 |        21.359 ns |      0.0918 ns |      0.0859 ns |  0.08 |
| ResetAVXNoPopcountUnroll4 |     128 |        16.176 ns |      0.3352 ns |      0.3725 ns |  0.06 |
|                           |         |                  |                |                |       |
|                    Reset1 |    8192 |    17,517.450 ns |    122.9018 ns |    114.9624 ns |  1.00 |
|                    Reset2 |    8192 |    10,969.356 ns |     82.8480 ns |     77.4961 ns |  0.63 |
|                    Reset4 |    8192 |    10,953.080 ns |     65.4486 ns |     58.0185 ns |  0.63 |
|          Reset4NoPopcount |    8192 |     6,815.917 ns |     90.6199 ns |     80.3322 ns |  0.39 |
|        ResetAVXNoPopcount |    8192 |     1,476.894 ns |     12.3802 ns |     10.9747 ns |  0.08 |
| ResetAVXNoPopcountUnroll2 |    8192 |     1,244.725 ns |      4.9322 ns |      4.1186 ns |  0.07 |
| ResetAVXNoPopcountUnroll4 |    8192 |     1,237.992 ns |      9.3695 ns |      8.7642 ns |  0.07 |
|                           |         |                  |                |                |       |
|                    Reset1 | 1048576 | 2,324,550.871 ns | 29,512.8866 ns | 24,644.5969 ns |  1.00 |
|                    Reset2 | 1048576 | 1,490,467.669 ns | 13,307.7889 ns | 12,448.1140 ns |  0.64 |
|                    Reset4 | 1048576 | 1,420,903.278 ns |  9,196.8434 ns |  8,152.7621 ns |  0.61 |
|          Reset4NoPopcount | 1048576 | 1,001,215.091 ns | 19,047.1537 ns | 19,560.0245 ns |  0.43 |
|        ResetAVXNoPopcount | 1048576 |   476,548.980 ns |  8,520.8924 ns | 12,489.8137 ns |  0.21 |
| ResetAVXNoPopcountUnroll2 | 1048576 |   431,470.897 ns |  8,490.5386 ns | 14,417.5790 ns |  0.19 |
| ResetAVXNoPopcountUnroll4 | 1048576 |   425,734.271 ns |  8,506.6079 ns | 17,943.3233 ns |  0.18 |