### PR TITLE
faster zipf

### DIFF
--- a/BitFaster.Caching.HitRateAnalysis/BitFaster.Caching.HitRateAnalysis.csproj
+++ b/BitFaster.Caching.HitRateAnalysis/BitFaster.Caching.HitRateAnalysis.csproj
@@ -30,8 +30,4 @@
     <ProjectReference Include="..\BitFaster.Caching\BitFaster.Caching.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
-
 </Project>

--- a/BitFaster.Caching.HitRateAnalysis/BitFaster.Caching.HitRateAnalysis.csproj
+++ b/BitFaster.Caching.HitRateAnalysis/BitFaster.Caching.HitRateAnalysis.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -14,9 +14,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\BitFaster.Caching.ThroughputAnalysis\FastZipf.cs" Link="FastZipf.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="ConsoleTables" Version="2.4.2" />
     <PackageReference Include="CsvHelper" Version="28.0.1" />
-    <PackageReference Include="EasyConsole" Version="1.1.0" >
+    <PackageReference Include="EasyConsole" Version="1.1.0">
         <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
@@ -24,6 +28,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BitFaster.Caching\BitFaster.Caching.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
   </ItemGroup>
 
 </Project>

--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
+using BitFaster.Caching.ThroughputAnalysis;
 using MathNet.Numerics;
 using MathNet.Numerics.Distributions;
 
@@ -58,8 +59,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
             {
                 Console.WriteLine($"Generating Zipfian distribution with {sampleCount} samples, s = {sValues[index]}, N = {n}");
                 var sw = Stopwatch.StartNew();
-                zipdfDistribution[index] = new int[sampleCount];
-                Zipf.Samples(zipdfDistribution[index], sValues[index], n);
+                zipdfDistribution[index] = FastZipf.Generate(new Random(666), sampleCount, sValues[index], n);
                 Console.WriteLine($"Took {sw.Elapsed} for s = {sValues[index]}.");
             });
 

--- a/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MathNet.Numerics;
+
+namespace BitFaster.Caching.ThroughputAnalysis
+{
+    // produces the same output as MathNet.Numerics Zipf.Samples(random, samples[], s, n)
+    // but about 20x faster.
+    public class FastZipf
+    {
+        static Random srandom = new Random(666);
+
+        public static int[] Generate(Random random, int sampleCount, double s, int n)
+        {
+            double[] num = new double[sampleCount];
+            int[] samples = new int[sampleCount];
+
+            for (int i = 0; i < sampleCount; i++)
+            {
+                while (num[i] == 0.0)
+                {
+                    num[i] = random.NextDouble();
+                }
+            }
+
+            double num2 = 1.0 / SpecialFunctions.GeneralHarmonic(n, s);
+
+            Parallel.ForEach(Enumerable.Range(0, samples.Length), (x, j) =>
+            {
+                double num3 = 0.0;
+                int i;
+
+                for (i = 1; i <= n; i++)
+                {
+                    num3 += num2 / Math.Pow(i, s);
+                    if (num3 >= num[x])
+                    {
+                        break;
+                    }
+                }
+
+                samples[x] = i;
+            });
+
+            return samples;
+        }
+
+        public static int[] Generate(int sampleCount, double s, int n)
+        {
+            return Generate(srandom, sampleCount, s, n);
+        }
+    }
+}

--- a/BitFaster.Caching.ThroughputAnalysis/Program.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Program.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using BitFaster.Caching.ThroughputAnalysis;
+using Iced.Intel;
+using MathNet.Numerics.Distributions;
 
 Host.PrintInfo();
 

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
@@ -25,10 +25,10 @@ namespace BitFaster.Caching.ThroughputAnalysis
         {
             this.iterations = iterations;
 
-            Random random = new Random(666);
+            samples = FastZipf.Generate(sampleCount, s, n);
 
-            samples = new int[sampleCount];
-            Zipf.Samples(random, samples, s, n);
+            //Random random = new Random(666);
+            //Zipf.Samples(random, samples, s, n);
         }
 
         public int Iterations => iterations;

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
@@ -26,9 +26,6 @@ namespace BitFaster.Caching.ThroughputAnalysis
             this.iterations = iterations;
 
             samples = FastZipf.Generate(sampleCount, s, n);
-
-            //Random random = new Random(666);
-            //Zipf.Samples(random, samples, s, n);
         }
 
         public int Iterations => iterations;


### PR DESCRIPTION
This is about 20x faster than using Math.Numerics, since the harmonic is computed once and the loop that generates the values is now parallelized. 

Only the random generation is serial - this means that the output is identical Math.Numerics since the same 'random' numbers are generated.