### PR TITLE
max attempts = 5

### DIFF
--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -446,7 +446,7 @@ namespace BitFaster.Caching.Lru
             {
                 (var dest, var count) = CycleHot(hotCount);
 
-                const int maxAttempts = 4;
+                const int maxAttempts = 5;
                 int attempts = 0;
 
                 while (attempts++ < maxAttempts)

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -446,7 +446,7 @@ namespace BitFaster.Caching.Lru
             {
                 (var dest, var count) = CycleHot(hotCount);
 
-                const int maxAttempts = 3;
+                const int maxAttempts = 4;
                 int attempts = 0;
 
                 while (attempts++ < maxAttempts)


### PR DESCRIPTION
Increase the number of LRU cycle attempts to 5. This prevents runaway growth when stress tested on an AMD 5800X CPU.