### PR TITLE
array

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/BitFaster.Caching.Benchmarks/Lfu/Array.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/Array.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace BitFaster.Caching.Benchmarks.Lfu
+{
+    [SimpleJob(RuntimeMoniker.Net48)]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    [MemoryDiagnoser(displayGenColumns: false)]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
+    public class Array
+    {
+        private object[] array1;
+        private object[] array2;
+
+        private Sealed[] sarray1;
+        private Sealed[] sarray2;
+
+        private Wrapper<object>[] warray1;
+        private Wrapper<object>[] warray2;
+
+        [Params(4, 128, 8192, 1_048_576)]
+        public int Size { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            array1 = new object[Size];
+            array2 = new object[Size];
+
+            sarray1 = new Sealed[Size];
+            sarray2 = new Sealed[Size];
+
+            warray1 = new Wrapper<object>[Size];
+            warray2 = new Wrapper<object>[Size];
+
+            for (int i = 0; i < Size; i++)
+            {
+                if (i % 3 == 0)
+                {
+                    array1[i] = new object();
+                    sarray1[i] = new Sealed();
+                    warray1[i] = new Wrapper<object>() { s = new object() };
+                }
+            }
+        }
+
+        [Benchmark(Baseline = true)]
+        public void CopyAcross()
+        {
+            for (int i = 0; i < array1.Length; i++)
+            {
+                array2[i] = array1[i];
+            }
+
+            for (int i = 0; i < array2.Length; i++)
+            {
+                array1[i] = array2[i];
+            }
+        }
+
+        [Benchmark]
+        public void CopyAcrossSealed()
+        {
+            for (int i = 0; i < sarray1.Length; i++)
+            {
+                sarray2[i] = sarray1[i];
+            }
+
+            for (int i = 0; i < sarray2.Length; i++)
+            {
+                sarray1[i] = sarray2[i];
+            }
+        }
+
+        [Benchmark]
+        public void CopyAcrossWrapper()
+        {
+            for (int i = 0; i < warray1.Length; i++)
+            {
+                warray2[i] = warray1[i];
+            }
+
+            for (int i = 0; i < warray2.Length; i++)
+            {
+                warray1[i] = warray2[i];
+            }
+        }
+
+        private sealed class Sealed : object { }
+
+        private struct Wrapper<T>
+        { 
+            public T s;
+        }
+    }
+}


### PR DESCRIPTION
When writing to reference type arrays, [StElem.ref](https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.stelem_ref%28v=vs.110%29.aspx) is emitted to type check the value written to the array. This has some overhead on every write.

Tests show that when the type is sealed, and elements are copied from array to array, StElem.ref is elided by the JIT. This outperforms the workaround of wrapping in a struct on .NET6.


|            Method |            Runtime |    Size |            Mean |          Error |         StdDev | Ratio | Allocated |
|------------------ |------------------- |-------- |----------------:|---------------:|---------------:|------:|----------:|
|        CopyAcross |           .NET 6.0 |       4 |        23.67 ns |       0.465 ns |       0.388 ns |  1.00 |         - |
|  CopyAcrossSealed |           .NET 6.0 |       4 |        15.35 ns |       0.238 ns |       0.222 ns |  0.65 |         - |
| CopyAcrossWrapper |           .NET 6.0 |       4 |        19.30 ns |       0.271 ns |       0.253 ns |  0.82 |         - |
|                   |                    |         |                 |                |                |       |           |
|        CopyAcross | .NET Framework 4.8 |       4 |        21.18 ns |       0.048 ns |       0.038 ns |  1.00 |         - |
|  CopyAcrossSealed | .NET Framework 4.8 |       4 |        21.06 ns |       0.111 ns |       0.093 ns |  0.99 |         - |
| CopyAcrossWrapper | .NET Framework 4.8 |       4 |        18.22 ns |       0.082 ns |       0.068 ns |  0.86 |         - |
|                   |                    |         |                 |                |                |       |           |
|        CopyAcross |           .NET 6.0 |     128 |       638.74 ns |       1.994 ns |       1.768 ns |  1.00 |         - |
|  CopyAcrossSealed |           .NET 6.0 |     128 |       487.24 ns |       1.911 ns |       1.694 ns |  0.76 |         - |
| CopyAcrossWrapper |           .NET 6.0 |     128 |       624.59 ns |       6.712 ns |       6.278 ns |  0.98 |         - |
|                   |                    |         |                 |                |                |       |           |
|        CopyAcross | .NET Framework 4.8 |     128 |       617.18 ns |       2.621 ns |       2.189 ns |  1.00 |         - |
|  CopyAcrossSealed | .NET Framework 4.8 |     128 |       615.15 ns |       2.720 ns |       2.411 ns |  1.00 |         - |
| CopyAcrossWrapper | .NET Framework 4.8 |     128 |       589.39 ns |       4.756 ns |       4.448 ns |  0.96 |         - |
|                   |                    |         |                 |                |                |       |           |
|        CopyAcross |           .NET 6.0 |    8192 |    39,499.24 ns |     216.540 ns |     191.957 ns |  1.00 |         - |
|  CopyAcrossSealed |           .NET 6.0 |    8192 |    25,816.95 ns |     130.042 ns |     121.641 ns |  0.65 |         - |
| CopyAcrossWrapper |           .NET 6.0 |    8192 |    38,664.38 ns |     186.873 ns |     165.658 ns |  0.98 |         - |
|                   |                    |         |                 |                |                |       |           |
|        CopyAcross | .NET Framework 4.8 |    8192 |    37,992.13 ns |     155.492 ns |     129.843 ns |  1.00 |         - |
|  CopyAcrossSealed | .NET Framework 4.8 |    8192 |    38,638.04 ns |     559.312 ns |     523.181 ns |  1.02 |         - |
| CopyAcrossWrapper | .NET Framework 4.8 |    8192 |    34,514.81 ns |     556.547 ns |     520.594 ns |  0.91 |         - |
|                   |                    |         |                 |                |                |       |           |
|        CopyAcross |           .NET 6.0 | 1048576 | 6,601,939.01 ns |  29,301.018 ns |  25,974.590 ns |  1.00 |       4 B |
|  CopyAcrossSealed |           .NET 6.0 | 1048576 | 4,054,510.21 ns |  23,497.694 ns |  21,979.758 ns |  0.61 |       6 B |
| CopyAcrossWrapper |           .NET 6.0 | 1048576 | 5,006,513.50 ns |  19,283.939 ns |  17,094.710 ns |  0.76 |       6 B |
|                   |                    |         |                 |                |                |       |           |
|        CopyAcross | .NET Framework 4.8 | 1048576 | 6,631,525.00 ns | 124,036.332 ns | 116,023.662 ns |  1.00 |         - |
|  CopyAcrossSealed | .NET Framework 4.8 | 1048576 | 6,568,186.21 ns |  57,765.323 ns |  48,236.661 ns |  0.99 |         - |
| CopyAcrossWrapper | .NET Framework 4.8 | 1048576 | 4,829,262.81 ns |  76,245.157 ns |  71,319.767 ns |  0.73 |         - |