### PR TITLE
zero

### DIFF
--- a/BitFaster.Caching/Lfu/CmSketch.cs
+++ b/BitFaster.Caching/Lfu/CmSketch.cs
@@ -285,7 +285,7 @@ namespace BitFaster.Caching.Lfu
 
                 // j == index
                 index = Avx2.ShiftLeftLogical(index, 2);
-                Vector256<long> offsetLong = Vector256.Create(index, Vector128.Create(0)).AsInt64();
+                Vector256<long> offsetLong = Vector256.Create(index, Vector128<int>.Zero).AsInt64();
 
                 Vector256<int> permuteMask = Vector256.Create(0, 4, 1, 5, 2, 5, 3, 7);
                 offsetLong = Avx2.PermuteVar8x32(offsetLong.AsInt32(), permuteMask).AsInt64();


### PR DESCRIPTION
Use the intrinsic for zero which is mapped to [vzeroupper](https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/intrinsics/intrinsics-for-intel-advanced-vector-extensions/intrinsics-for-miscellaneous-operations-3/mm256-zeroupper.html).

Any difference in the increment benchmark is noise, this is theoretically better but not measurably on my machine.