### PR TITLE
zero again

### DIFF
--- a/BitFaster.Caching/Lfu/CmSketch.cs
+++ b/BitFaster.Caching/Lfu/CmSketch.cs
@@ -309,8 +309,10 @@ namespace BitFaster.Caching.Lfu
                 tablePtr[blockOffset.GetElement(2)] += inc.GetElement(2);
                 tablePtr[blockOffset.GetElement(3)] += inc.GetElement(3);
 
-                Vector256<byte> result = Avx2.CompareEqual(masked.AsByte(), Vector256.Create(0).AsByte());
-                bool wasInc = Avx2.MoveMask(result.AsByte()) == unchecked((int)(0b1111_1111_1111_1111_1111_1111_1111_1111));
+                Vector256<byte> result = Avx2.CompareEqual(masked.AsByte(), Vector256<byte>.Zero);
+
+                bool wasInc = !Avx2.TestZ(result, result);
+                //Avx2.MoveMask(result.AsByte()) == unchecked((int)(0b1111_1111_1111_1111_1111_1111_1111_1111));
 
                 if (wasInc && (++size == sampleSize))
                 {

--- a/BitFaster.Caching/Lfu/CmSketch.cs
+++ b/BitFaster.Caching/Lfu/CmSketch.cs
@@ -247,7 +247,7 @@ namespace BitFaster.Caching.Lfu
                 index = Avx2.ShiftLeftLogical(index, 2);
 
                 // convert index from int to long via permute
-                Vector256<long> indexLong = Vector256.Create(index, Vector128.Create(0)).AsInt64();
+                Vector256<long> indexLong = Vector256.Create(index, Vector128<int>.Zero).AsInt64();
                 Vector256<int> permuteMask2 = Vector256.Create(0, 4, 1, 5, 2, 5, 3, 7);
                 indexLong = Avx2.PermuteVar8x32(indexLong.AsInt32(), permuteMask2).AsInt64();
                 tableVector = Avx2.ShiftRightLogicalVariable(tableVector, indexLong.AsUInt64());
@@ -259,7 +259,12 @@ namespace BitFaster.Caching.Lfu
                     .AsUInt16();
 
                 // set the zeroed high parts of the long value to ushort.Max
+#if NET6_0
+                count = Avx2.Blend(count, Vector128<ushort>.AllBitsSet, 0b10101010);
+#else
                 count = Avx2.Blend(count, Vector128.Create(ushort.MaxValue), 0b10101010);
+#endif
+
                 return Avx2.MinHorizontal(count).GetElement(0);
             }
         }
@@ -310,9 +315,7 @@ namespace BitFaster.Caching.Lfu
                 tablePtr[blockOffset.GetElement(3)] += inc.GetElement(3);
 
                 Vector256<byte> result = Avx2.CompareEqual(masked.AsByte(), Vector256<byte>.Zero);
-
-                bool wasInc = !Avx2.TestZ(result, result);
-                //Avx2.MoveMask(result.AsByte()) == unchecked((int)(0b1111_1111_1111_1111_1111_1111_1111_1111));
+                bool wasInc = Avx2.MoveMask(result.AsByte()) == unchecked((int)(0b1111_1111_1111_1111_1111_1111_1111_1111));
 
                 if (wasInc && (++size == sampleSize))
                 {
@@ -321,5 +324,5 @@ namespace BitFaster.Caching.Lfu
             }
         }
 #endif
-    }
+            }
 }


### PR DESCRIPTION
I had missed a couple of `Vector128<int>.Zero` cases, and there was also a call site where it is possible to use `AllBitsSet`.

Considered swapping to 

```cs
bool wasInc = !Avx2.TestZ(result, result);
```

Avx2.TestZ is [_mm256_testz_si256/VPTEST](https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/intrinsics/intrinsics-for-intel-advanced-vector-extensions/intrinsics-for-packed-test-operations/mm256-testz-si256.html).

Avx2.MoveMask is [_mm256_movemask_epi8/VPMOVMSKB](https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/intrinsics/intrinsics-for-avx2/intrinsics-for-miscellaneous-operations-2/mm256-movemask-epi8.html).


According to https://uops.info/table.html, they are equal throughput, but VPTEST is higher latency:

| Instruction | Throughput | Latency | UOPS |
|------------ |---------------|---------|--------|
| VPTEST     |             1         |      < 6       | 2/3 |
| VPMOVMSKB|       1         |   < 4 | 1 |
