### PR TITLE
Use Environment.TickCount64 for TLRU on .NET6

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net48;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
@@ -22,9 +22,9 @@ namespace BitFaster.Caching.Benchmarks.Lru
             = new ConcurrentLruCore<int, int, TickCountLruItem<int, int>, TLruTicksPolicy<int, int>, NoTelemetryPolicy<int, int>>
                 (1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, new TLruTicksPolicy<int, int>(TimeSpan.FromSeconds(1)), default);
 
-        private static readonly ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TLruLongTicksPolicy<int, int>, NoTelemetryPolicy<int, int>> stopwatchTLru
-            = new ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TLruLongTicksPolicy<int, int>, NoTelemetryPolicy<int, int>>
-                (1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, new TLruLongTicksPolicy<int, int>(TimeSpan.FromSeconds(1)), default);
+        private static readonly ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, NoTelemetryPolicy<int, int>> stopwatchTLru
+            = new ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, NoTelemetryPolicy<int, int>>
+                (1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, new TlruStopwatchPolicy<int, int>(TimeSpan.FromSeconds(1)), default);
 
         [Benchmark(Baseline = true)]
         public void DateTimeUtcNow()

--- a/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Jobs;
 
 namespace BitFaster.Caching.Benchmarks
 {
-   // [SimpleJob(RuntimeMoniker.Net48)]
+    [SimpleJob(RuntimeMoniker.Net48)]
     [SimpleJob(RuntimeMoniker.Net60)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class TimeBenchmarks
@@ -23,13 +23,17 @@ namespace BitFaster.Caching.Benchmarks
         {
             return Environment.TickCount;
         }
-#if NET6_0_OR_GREATER
+
         [Benchmark()]
         public long EnvironmentTickCount64()
         {
+#if NETCOREAPP3_0_OR_GREATER
             return Environment.TickCount64;
-        }
+#else
+            return 0;
 #endif
+        }
+
         [Benchmark()]
         public long StopWatchGetElapsed()
         {

--- a/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
@@ -5,7 +5,7 @@ using BenchmarkDotNet.Jobs;
 
 namespace BitFaster.Caching.Benchmarks
 {
-    [SimpleJob(RuntimeMoniker.Net48)]
+   // [SimpleJob(RuntimeMoniker.Net48)]
     [SimpleJob(RuntimeMoniker.Net60)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class TimeBenchmarks
@@ -23,7 +23,13 @@ namespace BitFaster.Caching.Benchmarks
         {
             return Environment.TickCount;
         }
-
+#if NET6_0_OR_GREATER
+        [Benchmark()]
+        public long EnvironmentTickCount64()
+        {
+            return Environment.TickCount64;
+        }
+#endif
         [Benchmark()]
         public long StopWatchGetElapsed()
         {

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -10,9 +10,9 @@ using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
-    public class TLruTicksPolicyTests
+    public class TLruTickCount64PolicyTests
     {
-        private readonly TLruTicksPolicy<int, int> policy = new TLruTicksPolicy<int, int>(TimeSpan.FromSeconds(10));
+        private readonly TLruTickCount64Policy<int, int> policy = new TLruTickCount64Policy<int, int>(TimeSpan.FromSeconds(10));
 
         [Fact]
         public void TimeToLiveShouldBeTenSecs()
@@ -34,7 +34,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.TickCount.Should().BeCloseTo(Environment.TickCount, 20);
+            item.TickCount.Should().BeCloseTo(Environment.TickCount64, 20);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsExpiredShouldDiscardIsTrue()
         {
             var item = this.policy.CreateItem(1, 2);
-            item.TickCount = Environment.TickCount - (int)TimeSpan.FromSeconds(11).ToEnvTicks();
+            item.TickCount = Environment.TickCount - (int)TimeSpan.FromSeconds(11).ToEnvTick64();
 
             this.policy.ShouldDiscard(item).Should().BeTrue();
         }
@@ -74,7 +74,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsNotExpiredShouldDiscardIsFalse()
         {
             var item = this.policy.CreateItem(1, 2);
-            item.TickCount = Environment.TickCount - (int)TimeSpan.FromSeconds(9).ToEnvTicks();
+            item.TickCount = Environment.TickCount - (int)TimeSpan.FromSeconds(9).ToEnvTick64();
 
             this.policy.ShouldDiscard(item).Should().BeFalse();
         }
@@ -121,7 +121,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             this.policy.RouteCold(item).Should().Be(expectedDestination);
         }
 
-        private TickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)
+        private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)
         {
             var item = this.policy.CreateItem(1, 2);
 
@@ -129,23 +129,10 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             if (isExpired)
             {
-                item.TickCount = Environment.TickCount - TimeSpan.FromSeconds(11).ToEnvTicks();
+                item.TickCount = Environment.TickCount - TimeSpan.FromSeconds(11).ToEnvTick64();
             }
 
             return item;
-        }
-    }
-
-    public static class TimeSpanExtensions
-    {
-        public static int ToEnvTicks(this TimeSpan ts)
-        {
-            return (int)ts.TotalMilliseconds;
-        }
-
-        public static long ToEnvTick64(this TimeSpan ts)
-        {
-            return (long)ts.TotalMilliseconds;
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -1,19 +1,15 @@
 ﻿using FluentAssertions;
-using FluentAssertions.Extensions;
 using BitFaster.Caching.Lru;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using System.Diagnostics;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
-    public class TLruLongTicksPolicyTests
+    public class TlruStopwatchPolicyTests
     {
-        private readonly TLruLongTicksPolicy<int, int> policy = new TLruLongTicksPolicy<int, int>(TimeSpan.FromSeconds(10));
+        private readonly TlruStopwatchPolicy<int, int> policy = new TlruStopwatchPolicy<int, int>(TimeSpan.FromSeconds(10));
 
         [Fact]
         public void TimeToLiveShouldBeTenSecs()
@@ -68,7 +64,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsExpiredShouldDiscardIsTrue()
         {
             var item = this.policy.CreateItem(1, 2);
-            item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
+            item.TickCount = Stopwatch.GetTimestamp() - TlruStopwatchPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
 
             this.policy.ShouldDiscard(item).Should().BeTrue();
         }
@@ -77,7 +73,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsNotExpiredShouldDiscardIsFalse()
         {
             var item = this.policy.CreateItem(1, 2);
-            item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(9));
+            item.TickCount = Stopwatch.GetTimestamp() - TlruStopwatchPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(9));
 
             this.policy.ShouldDiscard(item).Should().BeFalse();
         }
@@ -132,7 +128,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             if (isExpired)
             {
-                item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
+                item.TickCount = Stopwatch.GetTimestamp() - TlruStopwatchPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
             }
 
             return item;

--- a/BitFaster.Caching/Lru/ConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentTLru.cs
@@ -7,7 +7,11 @@ namespace BitFaster.Caching.Lru
     ///<inheritdoc/>
     [DebuggerTypeProxy(typeof(CacheDebugView<,>))]
     [DebuggerDisplay("Count = {Count}/{Capacity}")]
-    public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, TelemetryPolicy<K, V>>
+#if NETCOREAPP3_0_OR_GREATER
+    public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruTickCount64Policy<K, V>, TelemetryPolicy<K, V>>
+#else
+    public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, TelemetryPolicy<K, V>>
+#endif
     {
         /// <summary>
         /// Initializes a new instance of the ConcurrentTLru class with the specified capacity and time to live that has the default 
@@ -16,8 +20,12 @@ namespace BitFaster.Caching.Lru
         /// <param name="capacity">The maximum number of elements that the ConcurrentTLru can contain.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int capacity, TimeSpan timeToLive)
-            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), default)
-        { 
+#if NETCOREAPP3_0_OR_GREATER
+            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruTickCount64Policy<K, V>(timeToLive), default)
+#else
+            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TlruStopwatchPolicy<K, V>(timeToLive), default)
+#endif
+        {
         }
 
         /// <summary>
@@ -29,7 +37,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+#if NETCOREAPP3_0_OR_GREATER
+            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
+#else
+            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
+#endif
         {
         }
 
@@ -42,7 +54,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int concurrencyLevel, ICapacityPartition capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-            : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+#if NETCOREAPP3_0_OR_GREATER
+            : base(concurrencyLevel, capacity, comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
+#else
+            : base(concurrencyLevel, capacity, comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
+#endif
         {
         }
     }

--- a/BitFaster.Caching/Lru/FastConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/FastConcurrentTLru.cs
@@ -7,7 +7,11 @@ namespace BitFaster.Caching.Lru
     ///<inheritdoc/>
     [DebuggerTypeProxy(typeof(CacheDebugView<,>))]
     [DebuggerDisplay("Count = {Count}/{Capacity}")]
+#if NETCOREAPP3_0_OR_GREATER
+    public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruTickCount64Policy<K, V>, NoTelemetryPolicy<K, V>>
+#else
     public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, NoTelemetryPolicy<K, V>>
+#endif
     {
         /// <summary>
         /// Initializes a new instance of the FastConcurrentTLru class with the specified capacity and time to live that has the default 
@@ -16,7 +20,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="capacity">The maximum number of elements that the FastConcurrentTLru can contain.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int capacity, TimeSpan timeToLive)
+#if NETCOREAPP3_0_OR_GREATER
+            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruTickCount64Policy<K, V>(timeToLive), default)
+#else
             : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TlruStopwatchPolicy<K, V>(timeToLive), default)
+#endif
         {
         }
 
@@ -29,7 +37,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
+#if NETCOREAPP3_0_OR_GREATER
+            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
+#else
             : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
+#endif
         {
         }
 
@@ -42,7 +54,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int concurrencyLevel, ICapacityPartition capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-            : base(concurrencyLevel, capacity, comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
+#if NETCOREAPP3_0_OR_GREATER
+             : base(concurrencyLevel, capacity, comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
+#else
+             : base(concurrencyLevel, capacity, comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
+#endif
         {
         }
     }

--- a/BitFaster.Caching/Lru/FastConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/FastConcurrentTLru.cs
@@ -7,7 +7,7 @@ namespace BitFaster.Caching.Lru
     ///<inheritdoc/>
     [DebuggerTypeProxy(typeof(CacheDebugView<,>))]
     [DebuggerDisplay("Count = {Count}/{Capacity}")]
-    public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, NoTelemetryPolicy<K, V>>
+    public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, NoTelemetryPolicy<K, V>>
     {
         /// <summary>
         /// Initializes a new instance of the FastConcurrentTLru class with the specified capacity and time to live that has the default 
@@ -16,7 +16,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="capacity">The maximum number of elements that the FastConcurrentTLru can contain.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int capacity, TimeSpan timeToLive)
-            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TlruStopwatchPolicy<K, V>(timeToLive), default)
         {
         }
 
@@ -29,7 +29,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
         {
         }
 
@@ -42,7 +42,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int concurrencyLevel, ICapacityPartition capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-            : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+            : base(concurrencyLevel, capacity, comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
         {
         }
     }

--- a/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
@@ -9,7 +9,7 @@ namespace BitFaster.Caching.Lru
     /// recently used items first, and any item that has expired.
     /// </summary>
     /// <remarks>
-    /// This class measures time using stopwatch.
+    /// This class measures time using Stopwatch.GetTimestamp() with a resolution of ~1us.
     /// </remarks>
     [DebuggerDisplay("TTL = {TimeToLive,nq})")]
     public readonly struct TlruStopwatchPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>

--- a/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace BitFaster.Caching.Lru
+{
+    /// <summary>
+    /// Time aware Least Recently Used (TLRU) is a variant of LRU which discards the least 
+    /// recently used items first, and any item that has expired.
+    /// </summary>
+    /// <remarks>
+    /// This class measures time using stopwatch.
+    /// </remarks>
+    [DebuggerDisplay("TTL = {TimeToLive,nq})")]
+    public readonly struct TlruStopwatchPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
+    {
+        // On some platforms (e.g. MacOS), stopwatch and timespan have different resolution
+        private static readonly double stopwatchAdjustmentFactor = Stopwatch.Frequency / (double)TimeSpan.TicksPerSecond;
+        private readonly long timeToLive;
+
+        /// <summary>
+        /// Initializes a new instance of the TLruLongTicksPolicy class with the specified time to live.
+        /// </summary>
+        /// <param name="timeToLive">The time to live.</param>
+        public TlruStopwatchPolicy(TimeSpan timeToLive)
+        {
+            this.timeToLive = ToTicks(timeToLive);
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public LongTickCountLruItem<K, V> CreateItem(K key, V value)
+        {
+            return new LongTickCountLruItem<K, V>(key, value, Stopwatch.GetTimestamp());
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Touch(LongTickCountLruItem<K, V> item)
+        {
+            item.WasAccessed = true;
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Update(LongTickCountLruItem<K, V> item)
+        {
+            item.TickCount = Stopwatch.GetTimestamp();
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ShouldDiscard(LongTickCountLruItem<K, V> item)
+        {
+            if (Stopwatch.GetTimestamp() - item.TickCount > this.timeToLive)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool CanDiscard()
+        {
+            return true;
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteHot(LongTickCountLruItem<K, V> item)
+        {
+            if (this.ShouldDiscard(item))
+            {
+                return ItemDestination.Remove;
+            }
+
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Cold;
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteWarm(LongTickCountLruItem<K, V> item)
+        {
+            if (this.ShouldDiscard(item))
+            {
+                return ItemDestination.Remove;
+            }
+
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Cold;
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ItemDestination RouteCold(LongTickCountLruItem<K, V> item)
+        {
+            if (this.ShouldDiscard(item))
+            {
+                return ItemDestination.Remove;
+            }
+
+            if (item.WasAccessed)
+            {
+                return ItemDestination.Warm;
+            }
+
+            return ItemDestination.Remove;
+        }
+
+        ///<inheritdoc/>
+        public TimeSpan TimeToLive => FromTicks(timeToLive);
+
+        /// <summary>
+        /// Convert from TimeSpan to ticks.
+        /// </summary>
+        /// <param name="timespan">The time represented as a TimeSpan.</param>
+        /// <returns>The time represented as ticks.</returns>
+        public static long ToTicks(TimeSpan timespan)
+        {
+            return (long)(timespan.Ticks * stopwatchAdjustmentFactor);
+        }
+
+        /// <summary>
+        /// Convert from ticks to a TimeSpan.
+        /// </summary>
+        /// <param name="ticks">The time represented as ticks.</param>
+        /// <returns>The time represented as a TimeSpan.</returns>
+        public static TimeSpan FromTicks(long ticks)
+        { 
+            return TimeSpan.FromTicks((long)(ticks / stopwatchAdjustmentFactor));
+        }
+    }
+}

--- a/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
+++ b/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
@@ -9,9 +9,9 @@ namespace BitFaster.Caching.Lru
     /// recently used items first, and any item that has expired.
     /// </summary>
     /// <remarks>
-    /// This class measures time using Environment.TickCount, which is significantly faster
-    /// than DateTime.Now. However, if the process runs for longer than 24.8 days, the integer
-    /// value will wrap and time measurement will become invalid.
+    /// This class measures time using Environment.TickCount64, which is significantly faster
+    /// than both Stopwatch.GetTimestamp and DateTime.UtcNow. However, resolution is lower (typically 
+    /// between 10-16ms), vs 1us for Stopwatch.GetTimestamp.
     /// </remarks>
     public readonly struct TLruTickCount64Policy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
     {


### PR DESCRIPTION
Environment.TickCount64 was introduced in .NET Core. Use this as the default time policy on .NET Core3+ to reduce lookup latency for TLRU. This has the effect of reducing time resolution from ~1us to 10-16ms, but is substantially faster. Expiring items faster than 10ms is not a likely use case, so this is a good trade off.

TickCount64 takes 292,277,266 years to wrap around, so for practical purposes we assume it will never wrap.

|                 Method |      Mean |     Error |    StdDev | Ratio |
|----------------------- |----------:|----------:|----------:|------:|
|         DateTimeUtcNow | 25.411 ns | 0.2257 ns | 0.1885 ns |  1.00 |
|   EnvironmentTickCount |  1.830 ns | 0.0676 ns | 0.1270 ns |  0.07 |
| EnvironmentTickCount64 |  1.843 ns | 0.0683 ns | 0.1122 ns |  0.07 |
|    StopWatchGetElapsed | 16.586 ns | 0.1485 ns | 0.1317 ns |  0.65 |

Ratio of FastConcurrentTLru vs ConcurrentDictionary drops from 3.63 to 1.65.

|                   Method |            Runtime |       Mean |    StdDev | Ratio | Code Size | Allocated |
|------------------------- |------------------- |-----------:|----------:|------:|----------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   7.414 ns | 0.2003 ns |  1.00 |   1,523 B |         - |
|        FastConcurrentLru |           .NET 6.0 |  10.132 ns | 0.1374 ns |  1.36 |  12,214 B |         - |
|            ConcurrentLru |           .NET 6.0 |  16.768 ns | 0.3520 ns |  2.26 |  12,506 B |         - |
|            AtomicFastLru |           .NET 6.0 |  20.682 ns | 0.3037 ns |  2.78 |         - |         - |
|       FastConcurrentTLru |           .NET 6.0 |  12.261 ns | 0.1368 ns |  1.65 |  10,322 B |         - |
|           ConcurrentTLru |           .NET 6.0 |  18.277 ns | 0.4559 ns |  2.46 |  10,694 B |         - |
|            ConcurrentLfu |           .NET 6.0 |  30.369 ns | 0.9932 ns |  4.11 |         - |         - |
|               ClassicLru |           .NET 6.0 |  49.094 ns | 0.5863 ns |  6.59 |         - |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 114.814 ns | 1.3774 ns | 15.41 |      49 B |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  64.554 ns | 3.0551 ns |  8.57 |      78 B |      24 B |
|                          |                    |            |           |       |           |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  14.250 ns | 0.2224 ns |  1.00 |   4,157 B |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  15.120 ns | 0.3588 ns |  1.07 |  37,149 B |         - |
|            ConcurrentLru | .NET Framework 4.8 |  23.980 ns | 0.5742 ns |  1.69 |  37,445 B |         - |
|            AtomicFastLru | .NET Framework 4.8 |  38.954 ns | 0.5826 ns |  2.74 |     364 B |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  45.314 ns | 0.8630 ns |  3.19 |  37,415 B |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  48.843 ns | 0.4182 ns |  3.42 |  37,779 B |         - |
|            ConcurrentLfu | .NET Framework 4.8 |  54.933 ns | 0.9048 ns |  3.86 |         - |         - |
|               ClassicLru | .NET Framework 4.8 |  60.762 ns | 1.1949 ns |  4.27 |         - |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 288.522 ns | 3.1063 ns | 20.26 |      33 B |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 123.936 ns | 1.0675 ns |  8.70 |      88 B |      24 B |