### PR TITLE
auto detect high res clock

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -53,6 +53,33 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.Policy.Eviction.Value.Capacity.Should().Be(128);
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public void TestHighResClockTLru()
+        {
+            ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
+                 .WithExpireAfterWrite(TimeSpan.FromSeconds(1))
+                 .WithHighResolutionClock()
+                 .Build();
+
+            lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, NoTelemetryPolicy<int, int>>>();
+            lru.Policy.Eviction.Value.Capacity.Should().Be(128);
+        }
+
+        [Fact]
+        public void TestHighResClockMetricsTLru()
+        {
+            ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
+                 .WithExpireAfterWrite(TimeSpan.FromSeconds(1))
+                 .WithHighResolutionClock()
+                 .WithMetrics()
+                 .Build();
+
+            lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, TelemetryPolicy<int, int>>>();
+            lru.Policy.Eviction.Value.Capacity.Should().Be(128);
+        }
+#endif
+
         [Fact]
         public void AsAsyncTestFastLru()
         {
@@ -97,7 +124,6 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.Should().BeOfType<ConcurrentTLru<int, int>>();
             lru.Policy.Eviction.Value.Capacity.Should().Be(128);
         }
-
 
         [Fact]
         public void TestComparer()

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -58,8 +58,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void TestHighResClockTLru()
         {
             ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
-                 .WithExpireAfterWrite(TimeSpan.FromSeconds(1))
-                 .WithHighResolutionClock()
+                 .WithExpireAfterWrite(TimeSpan.FromMilliseconds(10))
                  .Build();
 
             lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, NoTelemetryPolicy<int, int>>>();
@@ -70,8 +69,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void TestHighResClockMetricsTLru()
         {
             ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
-                 .WithExpireAfterWrite(TimeSpan.FromSeconds(1))
-                 .WithHighResolutionClock()
+                 .WithExpireAfterWrite(TimeSpan.FromMilliseconds(10))
                  .WithMetrics()
                  .Build();
 

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -9,11 +9,11 @@ using System.Runtime.InteropServices;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
-    public class ConcurrentTLruTests
+    public abstract class ConcurrentTLruTests
     {
         private readonly TimeSpan timeToLive = TimeSpan.FromMilliseconds(10);
         private readonly ICapacityPartition capacity = new EqualCapacityPartition(9);
-        private ConcurrentTLru<int, string> lru;
+        private ICache<int, string> lru;
 
         private ValueFactory valueFactory = new ValueFactory();
 
@@ -27,33 +27,11 @@ namespace BitFaster.Caching.UnitTests.Lru
             removedItems.Add(e);
         }
 
+        protected abstract ICache<K, V> CreateTLru<K, V>(ICapacityPartition capacity, TimeSpan timeToLive);
+
         public ConcurrentTLruTests()
         {
-            lru = new ConcurrentTLru<int, string>(1, capacity, EqualityComparer<int>.Default, timeToLive);
-        }
-
-        [Fact]
-        public void ConstructWithDefaultCtorReturnsCapacity()
-        {
-            var x = new ConcurrentTLru<int, int>(3, TimeSpan.FromSeconds(1));
-
-            x.Capacity.Should().Be(3);
-        }
-
-        [Fact]
-        public void ConstructCapacityCtorReturnsCapacity()
-        {
-            var x = new ConcurrentTLru<int, int>(1, 3, EqualityComparer<int>.Default, TimeSpan.FromSeconds(1));
-
-            x.Capacity.Should().Be(3);
-        }
-
-        [Fact]
-        public void ConstructPartitionCtorReturnsCapacity()
-        {
-            var x = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, TimeSpan.FromSeconds(1));
-
-            x.Capacity.Should().Be(3);
+            lru = CreateTLru<int, string>(capacity, timeToLive);
         }
 
         [Fact]
@@ -101,7 +79,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenValueEvictedItemRemovedEventIsFired()
         {
-            var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
+            //var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
+            var lruEvents = CreateTLru<int, int>(new EqualCapacityPartition(6), timeToLive);
             lruEvents.Events.Value.ItemRemoved += OnLruItemRemoved;
 
             // First 6 adds
@@ -127,7 +106,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenItemRemovedEventIsUnregisteredEventIsNotFired()
         {
-            var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
+            //var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
+            var lruEvents = CreateTLru<int, int>(new EqualCapacityPartition(6), timeToLive);
             lruEvents.Events.Value.ItemRemoved += OnLruItemRemoved;
             lruEvents.Events.Value.ItemRemoved -= OnLruItemRemoved;
 
@@ -195,9 +175,49 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             await Task.Delay(timeToLive * ttlWaitMlutiplier);
 
-            lru.Trim(1);
+            lru.Policy.Eviction.Value.Trim(1);
 
             lru.Count.Should().Be(0);
+        }
+    }
+
+    public class ConcurrentTLruDefaultClockTests : ConcurrentTLruTests
+    {
+        protected override ICache<K, V> CreateTLru<K, V>(ICapacityPartition capacity, TimeSpan timeToLive)
+        {
+             return new ConcurrentTLru<K, V>(1, capacity, EqualityComparer<K>.Default, timeToLive);
+        }
+
+        [Fact]
+        public void ConstructWithDefaultCtorReturnsCapacity()
+        {
+            var x = new ConcurrentTLru<int, int>(3, TimeSpan.FromSeconds(1));
+
+            x.Capacity.Should().Be(3);
+        }
+
+        [Fact]
+        public void ConstructCapacityCtorReturnsCapacity()
+        {
+            var x = new ConcurrentTLru<int, int>(1, 3, EqualityComparer<int>.Default, TimeSpan.FromSeconds(1));
+
+            x.Capacity.Should().Be(3);
+        }
+
+        [Fact]
+        public void ConstructPartitionCtorReturnsCapacity()
+        {
+            var x = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, TimeSpan.FromSeconds(1));
+
+            x.Capacity.Should().Be(3);
+        }
+    }
+
+    public class ConcurrentTLruHighResClockTests : ConcurrentTLruTests
+    {
+        protected override ICache<K, V> CreateTLru<K, V>(ICapacityPartition capacity, TimeSpan timeToLive)
+        {
+            return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, TelemetryPolicy<K, V>>(1, capacity, EqualityComparer<K>.Default, new TlruStopwatchPolicy<K, V>(timeToLive), default);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -2,7 +2,6 @@
 using BitFaster.Caching.Lru;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using System.Runtime.InteropServices;
@@ -79,7 +78,6 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenValueEvictedItemRemovedEventIsFired()
         {
-            //var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
             var lruEvents = CreateTLru<int, int>(new EqualCapacityPartition(6), timeToLive);
             lruEvents.Events.Value.ItemRemoved += OnLruItemRemoved;
 
@@ -106,7 +104,6 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenItemRemovedEventIsUnregisteredEventIsNotFired()
         {
-            //var lruEvents = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(6), EqualityComparer<int>.Default, timeToLive);
             var lruEvents = CreateTLru<int, int>(new EqualCapacityPartition(6), timeToLive);
             lruEvents.Events.Value.ItemRemoved += OnLruItemRemoved;
             lruEvents.Events.Value.ItemRemoved -= OnLruItemRemoved;

--- a/BitFaster.Caching/Lru/Builder/LruBuilderBase.cs
+++ b/BitFaster.Caching/Lru/Builder/LruBuilderBase.cs
@@ -79,25 +79,16 @@ namespace BitFaster.Caching.Lru.Builder
         public TBuilder WithExpireAfterWrite(TimeSpan expiration)
         {
             this.info.TimeToExpireAfterWrite = expiration;
-            return this as TBuilder;
-        }
 
 #if NETCOREAPP3_0_OR_GREATER
-        /// <summary>
-        /// Use the high resolution clock for time based expiry. The high resolution clock incurs a performance penalty, but item expiry time is more precise.
-        /// </summary>
-        /// <remarks>
-        /// The high resolution clock should be used when items must be expired faster than 16ms.
-        /// The default clock is based on Environment.TickCount64, which has a resolution of around 16ms.
-        /// The high resolution clock is based on Stopwatch.GetTimestamp() which has a resolution of around 1us.
-        /// </remarks>
-        /// <returns>A ConcurrentLruBuilder</returns>
-        public TBuilder WithHighResolutionClock()
-        {
-            this.info.WithHighResolutionTime = true;
+            // if the expiration time is less than 2x default precision, switch to high resolution clock automatically.
+            if (expiration < TimeSpan.FromMilliseconds(32))
+            {
+                this.info.WithHighResolutionTime = true;
+            }
+#endif
             return this as TBuilder;
         }
-#endif
 
         /// <summary>
         /// Builds a cache configured via the method calls invoked on the builder instance.

--- a/BitFaster.Caching/Lru/Builder/LruBuilderBase.cs
+++ b/BitFaster.Caching/Lru/Builder/LruBuilderBase.cs
@@ -82,6 +82,23 @@ namespace BitFaster.Caching.Lru.Builder
             return this as TBuilder;
         }
 
+#if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Use the high resolution clock for time based expiry. The high resolution clock incurs a performance penalty, but item expiry time is more precise.
+        /// </summary>
+        /// <remarks>
+        /// The high resolution clock should be used when items must be expired faster than 16ms.
+        /// The default clock is based on Environment.TickCount64, which has a resolution of around 16ms.
+        /// The high resolution clock is based on Stopwatch.GetTimestamp() which has a resolution of around 1us.
+        /// </remarks>
+        /// <returns>A ConcurrentLruBuilder</returns>
+        public TBuilder WithHighResolutionClock()
+        {
+            this.info.WithHighResolutionTime = true;
+            return this as TBuilder;
+        }
+#endif
+
         /// <summary>
         /// Builds a cache configured via the method calls invoked on the builder instance.
         /// </summary>

--- a/BitFaster.Caching/Lru/Builder/LruInfo.cs
+++ b/BitFaster.Caching/Lru/Builder/LruInfo.cs
@@ -14,5 +14,9 @@ namespace BitFaster.Caching.Lru.Builder
         public bool WithMetrics { get; set; } = false;
 
         public IEqualityComparer<K> KeyComparer { get; set; } = EqualityComparer<K>.Default;
+
+#if NETCOREAPP3_0_OR_GREATER
+        public bool WithHighResolutionTime { get; set; } = false;
+#endif
     }
 }

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
@@ -41,6 +41,14 @@ namespace BitFaster.Caching.Lru
         {
             switch (info)
             {
+#if NETCOREAPP3_0_OR_GREATER
+                case LruInfo<K> i when i.WithMetrics && i.TimeToExpireAfterWrite.HasValue && i.WithHighResolutionTime:
+                    return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, TelemetryPolicy<K, V>>(
+                        info.ConcurrencyLevel, info.Capacity, info.KeyComparer, new TlruStopwatchPolicy<K, V>(info.TimeToExpireAfterWrite.Value), default);
+                case LruInfo<K> i when !i.WithMetrics && i.TimeToExpireAfterWrite.HasValue && i.WithHighResolutionTime:
+                    return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, NoTelemetryPolicy<K, V>>(
+                        info.ConcurrencyLevel, info.Capacity, info.KeyComparer, new TlruStopwatchPolicy<K, V>(info.TimeToExpireAfterWrite.Value), default);
+#endif
                 case LruInfo<K> i when i.WithMetrics && !i.TimeToExpireAfterWrite.HasValue:
                     return new ConcurrentLru<K, V>(info.ConcurrencyLevel, info.Capacity, info.KeyComparer);
                 case LruInfo<K> i when i.WithMetrics && i.TimeToExpireAfterWrite.HasValue:


### PR DESCRIPTION
Enable auto fallback to high resolution clock on .NET core, enabling use of the previous higher precision expiry when time to live is low enough (2x clock resolution). 

Ensure unit tests cover both variants of TLRU.