### PR TITLE
Setting stopwatch policy TTL to TimeSpan.MaxValue gives invalid TTL

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -2,9 +2,6 @@
 using FluentAssertions.Extensions;
 using BitFaster.Caching.Lru;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -25,7 +22,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenTtlIsZeroThrow()
         {
-            Action constructor = () => { new TLruTickCount64Policy<int, int>(TimeSpan.MaxValue); };
+            Action constructor = () => { new TLruTickCount64Policy<int, int>(TimeSpan.Zero); };
 
             constructor.Should().Throw<ArgumentOutOfRangeException>();
         }

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -12,10 +12,18 @@ namespace BitFaster.Caching.UnitTests.Lru
         private readonly TlruStopwatchPolicy<int, int> policy = new TlruStopwatchPolicy<int, int>(TimeSpan.FromSeconds(10));
 
         [Fact]
-        public void WhenTtlIsMaxSetAsMax()
+        public void WhenTtlIsZeroThrow()
+        {
+            Action constructor = () => { new TlruStopwatchPolicy<int, int>(TimeSpan.Zero); };
+
+            constructor.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WhenTtlIsMaxDontOverflow()
         {
             var policy = new TlruStopwatchPolicy<int, int>(TimeSpan.MaxValue);
-            policy.TimeToLive.Should().BeCloseTo(TlruStopwatchPolicy<int, int>.MaxTtl, TimeSpan.FromMilliseconds(1));
+            policy.TimeToLive.Should().Be(TimeSpan.MaxValue);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -12,6 +12,13 @@ namespace BitFaster.Caching.UnitTests.Lru
         private readonly TlruStopwatchPolicy<int, int> policy = new TlruStopwatchPolicy<int, int>(TimeSpan.FromSeconds(10));
 
         [Fact]
+        public void WhenTtlIsMaxSetAsMax()
+        {
+            var policy = new TlruStopwatchPolicy<int, int>(TimeSpan.MaxValue);
+            policy.TimeToLive.Should().BeCloseTo(TlruStopwatchPolicy<int, int>.MaxTtl, TimeSpan.FromMilliseconds(1));
+        }
+
+        [Fact]
         public void TimeToLiveShouldBeTenSecs()
         {
             this.policy.TimeToLive.Should().Be(TimeSpan.FromSeconds(10));

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -20,22 +20,20 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
-        public void WhenTtlIsMaxDontOverflow()
+        public void WhenTtlIsTimeSpanMaxThrow()
         {
-            var policy = new TlruStopwatchPolicy<int, int>(TimeSpan.MaxValue);
-            policy.TimeToLive.Should().Be(TimeSpan.MaxValue);
+            Action constructor = () => { new TlruStopwatchPolicy<int, int>(TimeSpan.MaxValue); };
+
+            constructor.Should().Throw<ArgumentOutOfRangeException>();
         }
 
         [Fact]
-        public void TicksPerSec()
+        public void WhenTtlIsCloseToMaxAllow()
         {
-            TimeSpan.TicksPerSecond.Should().Be(1);
-        }
+            double maxTicks = long.MaxValue / 100.0d;
+            var ttl = TimeSpan.FromTicks((long)maxTicks) - TimeSpan.FromTicks(10);
 
-        [Fact]
-        public void Frequency()
-        {
-            Stopwatch.Frequency.Should().Be(1);
+            new TlruStopwatchPolicy<int, int>(ttl).TimeToLive.Should().BeCloseTo(ttl, TimeSpan.FromTicks(20));
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -27,6 +27,18 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void TicksPerSec()
+        {
+            TimeSpan.TicksPerSecond.Should().Be(1);
+        }
+
+        [Fact]
+        public void Frequency()
+        {
+            Stopwatch.Frequency.Should().Be(1);
+        }
+
+        [Fact]
         public void TimeToLiveShouldBeTenSecs()
         {
             this.policy.TimeToLive.Should().Be(TimeSpan.FromSeconds(10));

--- a/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
@@ -130,16 +130,15 @@ namespace BitFaster.Caching.Lru
         {
             // mac adjustment factor is 100, giving lowest maximum TTL on mac platform - use same upper limit on all platforms for consistency
             // this also avoids overflow when multipling long.MaxValue by 1.0
-            double maxTicks = long.MaxValue / 100.0d;
-            double value = timespan.Ticks * stopwatchAdjustmentFactor;
+            double maxTicks = long.MaxValue * 0.01d;
 
-            if (timespan <= TimeSpan.Zero || value >= maxTicks)
+            if (timespan <= TimeSpan.Zero || timespan.Ticks >= maxTicks)
             {
                 TimeSpan maxRepresentable = TimeSpan.FromTicks((long)maxTicks);
                 Ex.ThrowArgOutOfRange(nameof(timespan), $"Value must be greater than zero and less than {maxRepresentable}");
             }
 
-            return (long)(value);
+            return (long)(timespan.Ticks * stopwatchAdjustmentFactor);
         }
 
         /// <summary>

--- a/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace BitFaster.Caching.Lru

--- a/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
@@ -132,7 +132,7 @@ namespace BitFaster.Caching.Lru
             // mac adjustment factor is 100, giving lowest maximum TTL on mac platform - use same upper limit on all platforms for consistency
             // this also avoids overflow when multipling long.MaxValue by 1.0
             double maxTicks = long.MaxValue / 100.0d;
-            double value = timespan.Ticks / stopwatchAdjustmentFactor;
+            double value = timespan.Ticks * stopwatchAdjustmentFactor;
 
             if (timespan <= TimeSpan.Zero || value >= maxTicks)
             {

--- a/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
@@ -14,6 +14,11 @@ namespace BitFaster.Caching.Lru
     [DebuggerDisplay("TTL = {TimeToLive,nq})")]
     public readonly struct TlruStopwatchPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
     {
+        /// <summary>
+        /// The maximum representable time to live.
+        /// </summary>
+        public static readonly TimeSpan MaxTtl = TimeSpan.FromTicks(TimeSpan.MaxValue.Ticks >> 1); 
+
         // On some platforms (e.g. MacOS), stopwatch and timespan have different resolution
         private static readonly double stopwatchAdjustmentFactor = Stopwatch.Frequency / (double)TimeSpan.TicksPerSecond;
         private readonly long timeToLive;
@@ -128,6 +133,11 @@ namespace BitFaster.Caching.Lru
         /// <returns>The time represented as ticks.</returns>
         public static long ToTicks(TimeSpan timespan)
         {
+            if (timespan > MaxTtl)
+            {
+                timespan = MaxTtl;
+            }
+
             return (long)(timespan.Ticks * stopwatchAdjustmentFactor);
         }
 

--- a/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruStopwatchPolicy.cs
@@ -150,8 +150,7 @@ namespace BitFaster.Caching.Lru
         /// <returns>The time represented as a TimeSpan.</returns>
         public static TimeSpan FromTicks(long ticks)
         {
-            double value = ticks / stopwatchAdjustmentFactor;
-            return TimeSpan.FromTicks((long)value);
+            return TimeSpan.FromTicks((long)(ticks / stopwatchAdjustmentFactor));
         }
     }
 }

--- a/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
+++ b/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
@@ -27,7 +27,7 @@ namespace BitFaster.Caching.Lru
         public TLruTickCount64Policy(TimeSpan timeToLive)
         {
             TimeSpan maxRepresentable = TimeSpan.FromTicks(9223372036854769664);
-            if (timeToLive < TimeSpan.Zero || timeToLive > maxRepresentable)
+            if (timeToLive <= TimeSpan.Zero || timeToLive > maxRepresentable)
             {
                 Ex.ThrowArgOutOfRange(nameof(timeToLive), $"Value must greater than zero and less than {maxRepresentable}");
             }


### PR DESCRIPTION
Setting TlruStopwatchPolicy TTL to TimeSpan.MaxValue results in a negative TTL, silently putting TLRU into an invalid state. This is because multiplying long.MaxValue by 1.0d results in silent overflow (1 is the stopwatch adjustment factor on my machine).

Instead, take the maximum possible TTL across platforms (Mac has highest stopwatch adjustment factor, and therefore lowest TTL), and throw if user attempts to set a TTL higher than this. Since this value is much lower than long.MaxValue, we also avoid overflow. For reference, the max is a little less than 106,751 days, or about 292 years.

With this approach, the user will get the same behavior on all platforms. Either you can set the TTL, or it will throw.
