### PR TITLE
TLruTickCount64Policy uses 64 bit time

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -15,6 +15,30 @@ namespace BitFaster.Caching.UnitTests.Lru
         private readonly TLruTickCount64Policy<int, int> policy = new TLruTickCount64Policy<int, int>(TimeSpan.FromSeconds(10));
 
         [Fact]
+        public void WhenTtlIsTimeSpanMaxThrow()
+        {
+            Action constructor = () => { new TLruTickCount64Policy<int, int>(TimeSpan.MaxValue); };
+
+            constructor.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WhenTtlIsZeroThrow()
+        {
+            Action constructor = () => { new TLruTickCount64Policy<int, int>(TimeSpan.MaxValue); };
+
+            constructor.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WhenTtlIsMaxSetAsMax()
+        {
+            var maxRepresentable = TimeSpan.FromTicks(9223372036854769664);
+            var policy = new TLruTickCount64Policy<int, int>(maxRepresentable);
+            policy.TimeToLive.Should().Be(maxRepresentable);
+        }
+
+        [Fact]
         public void TimeToLiveShouldBeTenSecs()
         {
             this.policy.TimeToLive.Should().Be(TimeSpan.FromSeconds(10));

--- a/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
+++ b/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
@@ -29,7 +29,7 @@ namespace BitFaster.Caching.Lru
             TimeSpan maxRepresentable = TimeSpan.FromTicks(9223372036854769664);
             if (timeToLive < TimeSpan.Zero || timeToLive > maxRepresentable)
             {
-                throw new ArgumentOutOfRangeException(nameof(timeToLive), $"Value must greater than zero and less than {maxRepresentable}");
+                Ex.ThrowArgOutOfRange(nameof(timeToLive), $"Value must greater than zero and less than {maxRepresentable}");
             }
 
             this.timeToLive = (long)timeToLive.TotalMilliseconds;

--- a/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
+++ b/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
@@ -125,16 +125,6 @@ namespace BitFaster.Caching.Lru
 
             return ItemDestination.Remove;
         }
-
-        private static TimeSpan Clamp(double ticks)
-        {
-            if (ticks > long.MaxValue)
-            {
-                return TimeSpan.MaxValue;
-            }
-
-            return TimeSpan.FromMilliseconds(ticks);
-        }
     }
 #endif
 }


### PR DESCRIPTION
- Not all code paths use Environment.TickCount64
- Guard against setting invalid time to live