### PR TITLE
factory delegate has arg to avoid closure allocs

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -44,10 +44,30 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
+        public void WhenKeyIsRequestedWithArgItIsCreatedAndCached()
+        {
+            var result1 = cache.GetOrAdd(1, valueFactory.Create, 9);
+            var result2 = cache.GetOrAdd(1, valueFactory.Create, 17);
+
+            valueFactory.timesCalled.Should().Be(1);
+            result1.Should().Be(result2);
+        }
+
+        [Fact]
         public async Task WhenKeyIsRequesteItIsCreatedAndCachedAsync()
         {
             var result1 = await cache.GetOrAddAsync(1, valueFactory.CreateAsync).ConfigureAwait(false);
             var result2 = await cache.GetOrAddAsync(1, valueFactory.CreateAsync).ConfigureAwait(false);
+
+            valueFactory.timesCalled.Should().Be(1);
+            result1.Should().Be(result2);
+        }
+
+        [Fact]
+        public async Task WhenKeyIsRequestedWithArgItIsCreatedAndCachedAsync()
+        {
+            var result1 = await cache.GetOrAddAsync(1, valueFactory.CreateAsync, 9).ConfigureAwait(false);
+            var result2 = await cache.GetOrAddAsync(1, valueFactory.CreateAsync, 17).ConfigureAwait(false);
 
             valueFactory.timesCalled.Should().Be(1);
             result1.Should().Be(result2);
@@ -849,10 +869,22 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 return key;
             }
 
+            public int Create(int key, int arg)
+            {
+                timesCalled++;
+                return key + arg;
+            }
+
             public Task<int> CreateAsync(int key)
             {
                 timesCalled++;
                 return Task.FromResult(key);
+            }
+
+            public Task<int> CreateAsync(int key, int arg)
+            {
+                timesCalled++;
+                return Task.FromResult(key + arg);
             }
         }
     }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -246,10 +246,30 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
-        public async Task WhenKeyIsRequesteItIsCreatedAndCachedAsync()
+        public void WhenKeyIsRequestedWithArgItIsCreatedAndCached()
+        {
+            var result1 = lru.GetOrAdd(1, valueFactory.Create, "x");
+            var result2 = lru.GetOrAdd(1, valueFactory.Create, "y");
+
+            valueFactory.timesCalled.Should().Be(1);
+            result1.Should().Be(result2);
+        }
+
+        [Fact]
+        public async Task WhenKeyIsRequestedItIsCreatedAndCachedAsync()
         {
             var result1 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync).ConfigureAwait(false);
             var result2 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync).ConfigureAwait(false);
+
+            valueFactory.timesCalled.Should().Be(1);
+            result1.Should().Be(result2);
+        }
+
+        [Fact]
+        public async Task WhenKeyIsRequestedWithArgItIsCreatedAndCachedAsync()
+        {
+            var result1 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync, "x").ConfigureAwait(false);
+            var result2 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync, "y").ConfigureAwait(false);
 
             valueFactory.timesCalled.Should().Be(1);
             result1.Should().Be(result2);

--- a/BitFaster.Caching.UnitTests/Lru/ValueFactory.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ValueFactory.cs
@@ -15,10 +15,22 @@ namespace BitFaster.Caching.UnitTests.Lru
             return key.ToString();
         }
 
+        public string Create<TArg>(int key, TArg arg)
+        {
+            timesCalled++;
+            return $"{key}{arg}";
+        }
+
         public Task<string> CreateAsync(int key)
         {
             timesCalled++;
             return Task.FromResult(key.ToString());
+        }
+
+        public Task<string> CreateAsync<TArg>(int key, TArg arg)
+        {
+            timesCalled++;
+            return Task.FromResult($"{key}{arg}");
         }
     }
 }

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -224,6 +224,16 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
+        /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
+        /// in the cache, or the new value if the key was not in the cache.</returns>
         public V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument)
         {
             while (true)
@@ -259,6 +269,15 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
+        /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
+        /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
         public async ValueTask<V> GetOrAddAsync<TArg>(K key, Func<K, TArg, Task<V>> valueFactory, TArg factoryArgument)
         {
             while (true)

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -194,8 +194,10 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
-        private bool TryAdd(K key, LfuNode<K, V> node)
+        private bool TryAdd(K key, V value)
         {
+            var node = new LfuNode<K, V>(key, value);
+
             if (this.dictionary.TryAdd(key, node))
             {
                 AfterWrite(node);
@@ -216,10 +218,10 @@ namespace BitFaster.Caching.Lfu
                     return value;
                 }
 
-                var node = new LfuNode<K, V>(key, valueFactory(key));
-                if (this.TryAdd(key, node))
+                value = valueFactory(key);
+                if (this.TryAdd(key, value))
                 {
-                    return node.Value;
+                    return value;
                 }
             }
         }
@@ -243,10 +245,10 @@ namespace BitFaster.Caching.Lfu
                     return value;
                 }
 
-                var node = new LfuNode<K, V>(key, valueFactory(key, factoryArgument));
-                if (this.TryAdd(key, node))
+                value = valueFactory(key, factoryArgument);
+                if (this.TryAdd(key, value))
                 {
-                    return node.Value;
+                    return value;
                 }
             }
         }
@@ -261,10 +263,10 @@ namespace BitFaster.Caching.Lfu
                     return value;
                 }
 
-                var node = new LfuNode<K, V>(key, await valueFactory(key).ConfigureAwait(false));
-                if (this.TryAdd(key, node))
+                value = await valueFactory(key).ConfigureAwait(false);
+                if (this.TryAdd(key, value))
                 {
-                    return node.Value;
+                    return value;
                 }
             }
         }
@@ -287,10 +289,10 @@ namespace BitFaster.Caching.Lfu
                     return value;
                 }
 
-                var node = new LfuNode<K, V>(key, await valueFactory(key, factoryArgument).ConfigureAwait(false));
-                if (this.TryAdd(key, node))
+                value = await valueFactory(key, factoryArgument).ConfigureAwait(false);
+                if (this.TryAdd(key, value))
                 {
-                    return node.Value;
+                    return value;
                 }
             }
         }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -184,8 +184,10 @@ namespace BitFaster.Caching.Lru
             return true;
         }
 
-        private bool TryAdd(K key, I newItem)
+        private bool TryAdd(K key, V value)
         {
+            var newItem = this.itemPolicy.CreateItem(key, value);
+
             if (this.dictionary.TryAdd(key, newItem))
             {
                 this.hotQueue.Enqueue(newItem);
@@ -208,12 +210,11 @@ namespace BitFaster.Caching.Lru
                 }
 
                 // The value factory may be called concurrently for the same key, but the first write to the dictionary wins.
-                // This is identical logic in ConcurrentDictionary.GetOrAdd method.
-                var newItem = this.itemPolicy.CreateItem(key, valueFactory(key));
+                value = valueFactory(key);
 
-                if (TryAdd(key, newItem))
+                if (TryAdd(key, value))
                 {
-                    return newItem.Value;
+                    return value;
                 }
             }
         }
@@ -238,12 +239,11 @@ namespace BitFaster.Caching.Lru
                 }
 
                 // The value factory may be called concurrently for the same key, but the first write to the dictionary wins.
-                // This is identical logic in ConcurrentDictionary.GetOrAdd method.
-                var newItem = this.itemPolicy.CreateItem(key, valueFactory(key, factoryArgument));
+                value = valueFactory(key, factoryArgument);
 
-                if (TryAdd(key, newItem))
+                if (TryAdd(key, value))
                 {
-                    return newItem.Value;
+                    return value;
                 }
             }
         }
@@ -260,11 +260,11 @@ namespace BitFaster.Caching.Lru
 
                 // The value factory may be called concurrently for the same key, but the first write to the dictionary wins.
                 // This is identical logic in ConcurrentDictionary.GetOrAdd method.
-                var newItem = this.itemPolicy.CreateItem(key, await valueFactory(key).ConfigureAwait(false));
+                value = await valueFactory(key).ConfigureAwait(false);
 
-                if (TryAdd(key, newItem))
+                if (TryAdd(key, value))
                 {
-                    return newItem.Value;
+                    return value;
                 }
             }
         }
@@ -288,12 +288,11 @@ namespace BitFaster.Caching.Lru
                 }
 
                 // The value factory may be called concurrently for the same key, but the first write to the dictionary wins.
-                // This is identical logic in ConcurrentDictionary.GetOrAdd method.
-                var newItem = this.itemPolicy.CreateItem(key, await valueFactory(key, factoryArgument).ConfigureAwait(false));
+                value = await valueFactory(key, factoryArgument).ConfigureAwait(false);
 
-                if (TryAdd(key, newItem))
+                if (TryAdd(key, value))
                 {
-                    return newItem.Value;
+                    return value;
                 }
             }
         }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -213,6 +213,16 @@ namespace BitFaster.Caching.Lru
             }
         }
 
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
+        /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
+        /// in the cache, or the new value if the key was not in the cache.</returns>
         public V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument)
         {
             while (true)
@@ -254,6 +264,15 @@ namespace BitFaster.Caching.Lru
             }
         }
 
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
+        /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
+        /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
         public async ValueTask<V> GetOrAddAsync<TArg>(K key, Func<K, TArg, Task<V>> valueFactory, TArg factoryArgument)
         {
             while (true)


### PR DESCRIPTION
Address https://github.com/bitfaster/BitFaster.Caching/issues/311: provide an overload that allows passing args into the factory method to avoid closure allocs. This PR so far only addresses the basic support for LRU/LFU instance methods.

To support across the board (builder support, ICache etc.) is a breaking change, and requires further changes to Atomic/Scoped etc.

Some variation on GetOrAdd, but seems to be noise not regression.

|                   Method |            Runtime |       Mean | Ratio | Code Size | Allocated |
|------------------------- |------------------- |-----------:|------:|----------:|----------:|
|     ConcurrentDictionary |           .NET 6.0 |   7.156 ns |  1.00 |   1,523 B |         - |
|        FastConcurrentLru |           .NET 6.0 |  10.178 ns |  1.42 |  10,960 B |         - |
|            ConcurrentLru |           .NET 6.0 |  16.180 ns |  2.26 |  12,506 B |         - |
|            AtomicFastLru |           .NET 6.0 |  20.102 ns |  2.81 |         - |         - |
|       FastConcurrentTLru |           .NET 6.0 |  11.774 ns |  1.65 |  11,326 B |         - |
|           ConcurrentTLru |           .NET 6.0 |  17.805 ns |  2.49 |  12,944 B |         - |
|            ConcurrentLfu |           .NET 6.0 |  31.290 ns |  4.20 |         - |         - |
|               ClassicLru |           .NET 6.0 |  48.525 ns |  6.78 |         - |         - |
|    RuntimeMemoryCacheGet |           .NET 6.0 | 112.797 ns | 15.78 |      49 B |      32 B |
| ExtensionsMemoryCacheGet |           .NET 6.0 |  61.136 ns |  9.17 |      78 B |      24 B |
|                          |                    |            |       |           |           |
|     ConcurrentDictionary | .NET Framework 4.8 |  14.167 ns |  1.00 |   4,127 B |         - |
|        FastConcurrentLru | .NET Framework 4.8 |  15.177 ns |  1.07 |  23,788 B |         - |
|            ConcurrentLru | .NET Framework 4.8 |  18.888 ns |  1.33 |  24,084 B |         - |
|            AtomicFastLru | .NET Framework 4.8 |  30.609 ns |  2.16 |     358 B |         - |
|       FastConcurrentTLru | .NET Framework 4.8 |  45.442 ns |  3.21 |  24,052 B |         - |
|           ConcurrentTLru | .NET Framework 4.8 |  48.891 ns |  3.45 |  24,416 B |         - |
|            ConcurrentLfu | .NET Framework 4.8 |  54.348 ns |  3.84 |         - |         - |
|               ClassicLru | .NET Framework 4.8 |  59.530 ns |  4.20 |         - |         - |
|    RuntimeMemoryCacheGet | .NET Framework 4.8 | 277.100 ns | 19.57 |      33 B |      32 B |
| ExtensionsMemoryCacheGet | .NET Framework 4.8 | 115.311 ns |  8.14 |      82 B |      24 B |