### PR TITLE
span

### DIFF
--- a/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
@@ -1,0 +1,190 @@
+﻿
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BitFaster.Caching.Buffers;
+using BitFaster.Caching.Lfu;
+
+namespace BitFaster.Caching.Benchmarks
+{
+    [SimpleJob(RuntimeMoniker.Net48)]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
+    public class DrainBenchmarks
+    {
+        private readonly StripedMpscBuffer<string> buffer = new StripedMpscBuffer<string>(1, ConcurrentLfu<int, int>.DefaultBufferSize);
+
+        private readonly string[] output = new string[ConcurrentLfu<int, int>.DefaultBufferSize];
+
+        [Benchmark(Baseline = true)]
+        public void Add()
+        {
+            // 8
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 16
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 24
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 32
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 40
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 48
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 56
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 64
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 72
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 80
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 88
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 96
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 104
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 112
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 120
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 128
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+        }
+
+        [Benchmark()]
+        public void Drain()
+        {
+            Add();
+            buffer.DrainTo(output);
+        }
+    }
+}

--- a/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
@@ -8,7 +8,6 @@ namespace BitFaster.Caching.Benchmarks
 {
     [SimpleJob(RuntimeMoniker.Net48)]
     [SimpleJob(RuntimeMoniker.Net60)]
-    [SimpleJob(RuntimeMoniker.Net70)]
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DrainBenchmarks
@@ -186,15 +185,10 @@ namespace BitFaster.Caching.Benchmarks
         public void DrainArray()
         {
             Add();
-            buffer.DrainTo(new ArraySegment<string>(output));
-        }
-
-        [Benchmark()]
-        public void DrainSpan()
-        {
-            Add();
 #if NETCOREAPP3_1_OR_GREATER
             buffer.DrainTo(output.AsSpan());
+#else
+            buffer.DrainTo(new ArraySegment<string>(output));
 #endif
         }
     }

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -106,6 +106,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             buffer.DrainTo(output).Should().Be(0);
         }
 
+#if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void WhenBufferContainsItemsDrainArrayTakesItems()
         {
@@ -115,12 +116,13 @@ namespace BitFaster.Caching.UnitTests.Buffers
 
             var outputBuffer = new string[16];
 
-            buffer.DrainTo(outputBuffer).Should().Be(3);
+            buffer.DrainTo(outputBuffer.AsSpan()).Should().Be(3);
 
             outputBuffer[0].Should().Be("1");
             outputBuffer[1].Should().Be("2");
             outputBuffer[2].Should().Be("3");
         }
+#endif
 
         [Fact]
         public void WhenBufferContainsItemsDrainSegmentTakesItems()

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -107,7 +107,23 @@ namespace BitFaster.Caching.UnitTests.Buffers
         }
 
         [Fact]
-        public void WhenBufferContainsItemsDrainTakesItems()
+        public void WhenBufferContainsItemsDrainArrayTakesItems()
+        {
+            buffer.TryAdd("1");
+            buffer.TryAdd("2");
+            buffer.TryAdd("3");
+
+            var outputBuffer = new string[16];
+
+            buffer.DrainTo(outputBuffer).Should().Be(3);
+
+            outputBuffer[0].Should().Be("1");
+            outputBuffer[1].Should().Be("2");
+            outputBuffer[2].Should().Be("3");
+        }
+
+        [Fact]
+        public void WhenBufferContainsItemsDrainSegmentTakesItems()
         {
             buffer.TryAdd("1");
             buffer.TryAdd("2");

--- a/BitFaster.Caching/Buffers/ArrayExtensions.cs
+++ b/BitFaster.Caching/Buffers/ArrayExtensions.cs
@@ -18,6 +18,12 @@ namespace BitFaster.Caching.Buffers
         {
             return new ArraySegment<T>(array);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ArraySegment<T> Slice<T>(this T[] array, int start, int length)
+        {
+            return new ArraySegment<T>(array, start, length);
+        }
 #else
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static Span<T> WrapAsSpan<T>(this T[] array)

--- a/BitFaster.Caching/Buffers/ArrayExtensions.cs
+++ b/BitFaster.Caching/Buffers/ArrayExtensions.cs
@@ -8,13 +8,13 @@ namespace BitFaster.Caching.Buffers
     {
 #if NETSTANDARD2_0
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static T[] WrapAsSpan<T>(this T[] array)
+        internal static T[] AsSpanOrArray<T>(this T[] array)
         { 
             return array;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ArraySegment<T> WrapAsSegment<T>(this T[] array)
+        internal static ArraySegment<T> AsSpanOrSegment<T>(this T[] array)
         {
             return new ArraySegment<T>(array);
         }
@@ -26,13 +26,13 @@ namespace BitFaster.Caching.Buffers
         }
 #else
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static Span<T> WrapAsSpan<T>(this T[] array)
+        internal static Span<T> AsSpanOrArray<T>(this T[] array)
         { 
             return array.AsSpan();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static Span<T> WrapAsSegment<T>(this Span<T> span)
+        internal static Span<T> AsSpanOrSegment<T>(this Span<T> span)
         {
             return span;
         }

--- a/BitFaster.Caching/Buffers/ArrayExtensions.cs
+++ b/BitFaster.Caching/Buffers/ArrayExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace BitFaster.Caching.Buffers
+{
+    // Used to avoid conditional compilation to work with Span<T> and ArraySegment<T>.
+    internal static class ArrayExtensions
+    {
+#if NETSTANDARD2_0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static T[] WrapAsSpan<T>(this T[] array)
+        { 
+            return array;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ArraySegment<T> WrapAsSegment<T>(this T[] array)
+        {
+            return new ArraySegment<T>(array);
+        }
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static Span<T> WrapAsSpan<T>(this T[] array)
+        { 
+            return array.AsSpan();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static Span<T> WrapAsSegment<T>(this Span<T> span)
+        {
+            return span;
+        }
+#endif
+    }
+}

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -144,6 +144,8 @@ namespace BitFaster.Caching.Buffers
             return BufferStatus.Success;
         }
 
+        // On NETSTANDARD2_0 all code paths are internally based on ArraySegment<T>.
+        // After NETSTANDARD2_0, all code paths are internally based on Span<T>.
 #if NETSTANDARD2_0
         /// <summary>
         /// Drains the buffer into the specified array.
@@ -203,6 +205,17 @@ namespace BitFaster.Caching.Buffers
         /// Thread safe for single try take/drain + multiple try add.
         /// </remarks>
         public int DrainTo(Span<T> output)
+#endif
+        {
+            return DrainToImpl(output);
+        }
+
+        // use an outer wrapper method to force the JIT to inline the inner adaptor methods
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#if NETSTANDARD2_0
+        private int DrainToImpl(ArraySegment<T> output)
+#else
+        private int DrainToImpl(Span<T> output)
 #endif
         {
             int head = Volatile.Read(ref headAndTail.Head);

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -201,11 +201,7 @@ namespace BitFaster.Caching.Buffers
                 return 0;
             }
 
-#if NETSTANDARD2_0
-            var localBuffer = buffer;
-#else
-            var localBuffer = buffer.AsSpan();
-#endif
+            var localBuffer = buffer.WrapAsSpan();
 
             int outCount = 0;
 

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -214,13 +214,19 @@ namespace BitFaster.Caching.Buffers
                 return 0;
             }
 
+#if NETSTANDARD2_0
+            var localBuffer = buffer;
+#else
+            var localBuffer = buffer.AsSpan();
+#endif
+
             int outCount = 0;
 
             do
             {
                 int index = head & mask;
 
-                T item = Volatile.Read(ref buffer[index]);
+                T item = Volatile.Read(ref localBuffer[index]);
 
                 if (item == null)
                 {
@@ -228,7 +234,7 @@ namespace BitFaster.Caching.Buffers
                     break;
                 }
 
-                Volatile.Write(ref buffer[index], null);
+                Volatile.Write(ref localBuffer[index], null);
                 Write(output, outCount++, item);
                 head++;
             }

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -201,7 +201,7 @@ namespace BitFaster.Caching.Buffers
                 return 0;
             }
 
-            var localBuffer = buffer.WrapAsSpan();
+            var localBuffer = buffer.AsSpanOrArray();
 
             int outCount = 0;
 

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -148,19 +148,6 @@ namespace BitFaster.Caching.Buffers
         // After NETSTANDARD2_0, all code paths are internally based on Span<T>.
 #if NETSTANDARD2_0
         /// <summary>
-        /// Drains the buffer into the specified array.
-        /// </summary>
-        /// <param name="output">The output buffer</param>
-        /// <returns>The number of items written to the output buffer.</returns>
-        /// <remarks>
-        /// Thread safe for single try take/drain + multiple try add.
-        /// </remarks>
-        public int DrainTo(T[] output)
-        { 
-            return DrainTo(new ArraySegment<T>(output));
-        }
-
-        /// <summary>
         /// Drains the buffer into the specified array segment.
         /// </summary>
         /// <param name="output">The output buffer</param>
@@ -170,19 +157,6 @@ namespace BitFaster.Caching.Buffers
         /// </remarks>
         public int DrainTo(ArraySegment<T> output)
 #else
-        /// <summary>
-        /// Drains the buffer into the specified array.
-        /// </summary>
-        /// <param name="output">The output buffer</param>
-        /// <returns>The number of items written to the output buffer.</returns>
-        /// <remarks>
-        /// Thread safe for single try take/drain + multiple try add.
-        /// </remarks>
-        public int DrainTo(T[] output)
-        {
-            return DrainTo(output.AsSpan());
-        }
-
         /// <summary>
         /// Drains the buffer into the specified array segment.
         /// </summary>

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -78,11 +78,8 @@ namespace BitFaster.Caching.Buffers
                     break;
                 }
 
-#if NETSTANDARD2_0
-                var segment = new ArraySegment<T>(outputBuffer, count, outputBuffer.Length - count);
-#else
                 var segment = outputBuffer.Slice(count, outputBuffer.Length - count);
-#endif
+
                 count += buffers[i].DrainTo(segment);
             }
 

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -68,6 +68,25 @@ namespace BitFaster.Caching.Buffers
             return count;
         }
 
+#if !NETSTANDARD2_0
+
+        public int DrainTo(Span<T> outputBuffer)
+        {
+            var count = 0;
+
+            for (var i = 0; i < buffers.Length; i++)
+            {
+                if (count == outputBuffer.Length)
+                {
+                    break;
+                }
+
+                count += buffers[i].DrainTo(outputBuffer.Slice(count, outputBuffer.Length - count));
+            }
+
+            return count;
+        }
+#endif
         /// <summary>
         /// Tries to add the specified item.
         /// </summary>

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -43,7 +43,7 @@ namespace BitFaster.Caching.Buffers
         public int Capacity => buffers.Length * buffers[0].Capacity;
 
         /// <summary>
-        /// Drains the buffer into the specified array segment.
+        /// Drains the buffer into the specified array.
         /// </summary>
         /// <param name="outputBuffer">The output buffer</param>
         /// <returns>The number of items written to the output buffer.</returns>
@@ -59,7 +59,7 @@ namespace BitFaster.Caching.Buffers
         }
 
         /// <summary>
-        /// Drains the buffer into the specified array segment.
+        /// Drains the buffer into the specified span.
         /// </summary>
         /// <param name="outputBuffer">The output buffer</param>
         /// <returns>The number of items written to the output buffer.</returns>

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -515,7 +515,8 @@ namespace BitFaster.Caching.Lfu
         {
             this.drainStatus.Set(DrainStatus.ProcessingToIdle);
 
-            var buffer = this.drainBuffer.WrapAsSpan();
+            // Note: this is only Span on .NET Core 3.1+, else Wrap is no-op and it is still an array
+            var buffer = this.drainBuffer.AsSpanOrArray();
 
             // extract to a buffer before doing book keeping work, ~2x faster
             int readCount = readBuffer.DrainTo(buffer);
@@ -530,7 +531,7 @@ namespace BitFaster.Caching.Lfu
                 OnAccess(buffer[i]);
             }
 
-            int writeCount = this.writeBuffer.DrainTo(buffer.WrapAsSegment());
+            int writeCount = this.writeBuffer.DrainTo(buffer.AsSpanOrSegment());
 
             for (int i = 0; i < writeCount; i++)
             {

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -515,7 +515,7 @@ namespace BitFaster.Caching.Lfu
         {
             this.drainStatus.Set(DrainStatus.ProcessingToIdle);
 
-            // Note: this is only Span on .NET Core 3.1+, else Wrap is no-op and it is still an array
+            // Note: this is only Span on .NET Core 3.1+, else this is no-op and it is still an array
             var buffer = this.drainBuffer.AsSpanOrArray();
 
             // extract to a buffer before doing book keeping work, ~2x faster

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -515,11 +515,7 @@ namespace BitFaster.Caching.Lfu
         {
             this.drainStatus.Set(DrainStatus.ProcessingToIdle);
 
-#if NETSTANDARD2_0
-            var buffer = this.drainBuffer;
-#else
-            var buffer = this.drainBuffer.AsSpan();
-#endif
+            var buffer = this.drainBuffer.WrapAsSpan();
 
             // extract to a buffer before doing book keeping work, ~2x faster
             int readCount = readBuffer.DrainTo(buffer);
@@ -534,11 +530,7 @@ namespace BitFaster.Caching.Lfu
                 OnAccess(buffer[i]);
             }
 
-#if NETSTANDARD2_0
-            int writeCount = this.writeBuffer.DrainTo(new ArraySegment<LfuNode<K, V>>(buffer));
-#else
-            int writeCount = this.writeBuffer.DrainTo(buffer);
-#endif
+            int writeCount = this.writeBuffer.DrainTo(buffer.WrapAsSegment());
 
             for (int i = 0; i < writeCount; i++)
             {


### PR DESCRIPTION
Use span APIs for buffers - this does appear to be marginally faster when benchmarking drain and in end to end LFU latency benchmark. Dissassembly shows that bounds check is still present in all cases and span version produces larger code(?).

Without adding a reference to the System.Memory NuGet packge, options are code duplication in the buffer classes or #ifdef tricks (current option). This can be cleaned up later in the next major version.

Compared the inlined de-dupe code to hand written span and array versions in PR https://github.com/bitfaster/BitFaster.Caching/pull/341. Found that Span is ~20% faster than an array for DrainTo, and with a wrapper method to inline the adaptor calls, it is equal to handwritten code using span end to end. This PR uses the inline wrapper approach.

Throughput test results with default input param 500, end to end we see span has a very slight edge that is repeatable.

<table>
  <tr>
    <td/>
    <td colspan="3">Array (Before)</td>
    <td colspan="3">Span (This PR)</td>
  </tr>
  <tr>
    <td/>
    <td>Avg</td>
    <td>p80</td>
    <td>p20</td>
    <td>Avg</td>
    <td>p80</td>
    <td>p20</td>
  </tr>
  <tr>
    <td>Read</td>
    <td>78.51</td>
    <td>40.11</td>
    <td>99.20</td>
    <td>78.78</td>
    <td>60.74</td>
    <td>103.10</td>
  </tr>
  <tr>
    <td>Read+Write</td>
    <td>5.53</td>
    <td>5.44</td>
    <td>5.58</td>
    <td>5.65</td>
    <td>5.54</td>
    <td>5.69</td>
  </tr>
  <tr>
    <td>Update</td>
    <td>75.82</td>
    <td>66.08</td>
    <td>89.17</td>
    <td>81.90</td>
    <td>65.53</td>
    <td>93.46</td>
  </tr>
  <tr>
    <td>Evict</td>
    <td>3.79</td>
    <td>3.67</td>
    <td>3.76</td>
    <td>3.81</td>
    <td>3.73</td>
    <td>3.79</td>
  </tr>
</table>

Looking at the disassembled code, in the span version there are no calls to [CORINFO_HELP_LDELEMA_REF](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldelema), which internally checks the array for null, type mismatch, index out of range etc. This appears to be why span is faster, even though it generates slightly larger code. 