### PR TITLE
bench span vs array

### DIFF
--- a/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using BitFaster.Caching.Buffers;
@@ -182,6 +183,9 @@ namespace BitFaster.Caching.Benchmarks
         }
 
         [Benchmark(Baseline =true)]
+#if NETCOREAPP3_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
         public void DrainArray()
         {
             Add();
@@ -189,6 +193,9 @@ namespace BitFaster.Caching.Benchmarks
         }
 
         [Benchmark()]
+#if NETCOREAPP3_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
         public void DrainArray2()
         {
             Add();
@@ -196,6 +203,9 @@ namespace BitFaster.Caching.Benchmarks
         }
 
         [Benchmark()]
+#if NETCOREAPP3_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
         public void DrainSpan()
         {
             Add();
@@ -205,6 +215,9 @@ namespace BitFaster.Caching.Benchmarks
         }
 
         [Benchmark()]
+#if NETCOREAPP3_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
         public void DrainSpan2()
         {
             Add();

--- a/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
@@ -9,7 +9,7 @@ namespace BitFaster.Caching.Benchmarks
     [SimpleJob(RuntimeMoniker.Net48)]
     [SimpleJob(RuntimeMoniker.Net60)]
     [SimpleJob(RuntimeMoniker.Net70)]
-    [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 4)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DrainBenchmarks
     {
@@ -206,6 +206,16 @@ namespace BitFaster.Caching.Benchmarks
 #if NETCOREAPP3_1_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
 #endif
+        public void DrainArray3()
+        {
+            Add();
+            buffer.DrainTo3(output);
+        }
+
+        [Benchmark()]
+#if NETCOREAPP3_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
         public void DrainSpan()
         {
             Add();
@@ -223,6 +233,18 @@ namespace BitFaster.Caching.Benchmarks
             Add();
 #if NETCOREAPP3_1_OR_GREATER
             buffer.DrainTo2(output.AsSpan());
+#endif
+        }
+
+        [Benchmark()]
+#if NETCOREAPP3_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+#endif
+        public void DrainSpan3()
+        {
+            Add();
+#if NETCOREAPP3_1_OR_GREATER
+            buffer.DrainTo3(output.AsSpan());
 #endif
         }
     }

--- a/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BitFaster.Caching.Buffers;
+
+namespace BitFaster.Caching.Benchmarks
+{
+    [SimpleJob(RuntimeMoniker.Net48)]
+    [SimpleJob(RuntimeMoniker.Net60)]
+    [SimpleJob(RuntimeMoniker.Net70)]
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
+    public class DrainBenchmarks
+    {
+        private const int bufferSize = 128;
+        private readonly MpscBoundedBuffer<string> buffer = new MpscBoundedBuffer<string>(bufferSize);
+
+        private readonly string[] output = new string[bufferSize];
+
+       //[Benchmark(Baseline = true)]
+        public void Add()
+        {
+            // 8
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 16
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 24
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 32
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 40
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 48
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 56
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 64
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 72
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 80
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 88
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 96
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 104
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 112
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 120
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+
+            // 128
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+            buffer.TryAdd(string.Empty);
+        }
+
+        [Benchmark(Baseline =true)]
+        public void DrainArray()
+        {
+            Add();
+            buffer.DrainTo(new ArraySegment<string>(output));
+        }
+
+        [Benchmark()]
+        public void DrainArray2()
+        {
+            Add();
+            buffer.DrainTo2(output);
+        }
+
+        [Benchmark()]
+        public void DrainSpan()
+        {
+            Add();
+#if NETCOREAPP3_1_OR_GREATER
+            buffer.DrainTo(output.AsSpan());
+#endif
+        }
+
+        [Benchmark()]
+        public void DrainSpan2()
+        {
+            Add();
+#if NETCOREAPP3_1_OR_GREATER
+            buffer.DrainTo2(output.AsSpan());
+#endif
+        }
+    }
+}

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading;
-using BitFaster.Caching.Lfu;
 
 namespace BitFaster.Caching.Buffers
 {
@@ -186,49 +185,6 @@ namespace BitFaster.Caching.Buffers
 
             return outCount;
         }
-
-        public int DrainTo(T[] output)
-        { 
-            return DrainTo(new ArraySegment<T>(output));
-        }
-
-#if !NETSTANDARD2_0
-        public int DrainTo(Span<T> output)
-        {
-            int head = Volatile.Read(ref headAndTail.Head);
-            int tail = Volatile.Read(ref headAndTail.Tail);
-            int size = tail - head;
-
-            if (size == 0)
-            {
-                return 0;
-            }
-
-            int outCount = 0;
-
-            do
-            {
-                int index = head & mask;
-
-                T item = Volatile.Read(ref buffer[index]);
-
-                if (item == null)
-                {
-                    // not published yet
-                    break;
-                }
-
-                Volatile.Write(ref buffer[index], null);
-                output[outCount++] = item;
-                head++;
-            }
-            while (head != tail && outCount < output.Length);
-
-            Volatile.Write(ref this.headAndTail.Head, head);
-
-            return outCount;
-        }
-#endif
 
         /// <summary>
         /// Removes all values from the buffer.

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -255,6 +255,7 @@ namespace BitFaster.Caching.Buffers
         /// <remarks>
         /// Thread safe for single try take/drain + multiple try add.
         /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int DrainTo2(ArraySegment<T> output)
 #else
         /// <summary>
@@ -288,6 +289,7 @@ namespace BitFaster.Caching.Buffers
         /// <remarks>
         /// Thread safe for single try take/drain + multiple try add.
         /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int DrainTo2(Span<T> output)
 #endif
         {

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -289,6 +289,11 @@ namespace BitFaster.Caching.Buffers
         public int DrainTo2(Span<T> output)
 #endif
         {
+#if NETSTANDARD2_0
+            var localBuffer = buffer;
+#else
+            var localBuffer = buffer.AsSpan();
+#endif
             int head = Volatile.Read(ref headAndTail.Head);
             int tail = Volatile.Read(ref headAndTail.Tail);
             int size = tail - head;
@@ -300,14 +305,14 @@ namespace BitFaster.Caching.Buffers
             do
             {
                 int index = head & mask;
-                T item = Volatile.Read(ref buffer[index]);
+                T item = Volatile.Read(ref localBuffer[index]);
                 if (item == null)
                 {
                     // not published yet
                     break;
                 }
 
-                Volatile.Write(ref buffer[index], null);
+                Volatile.Write(ref localBuffer[index], null);
                 Write(output, outCount++, item);
                 head++;
             }

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -311,7 +311,7 @@ namespace BitFaster.Caching.Buffers
                 Write(output, outCount++, item);
                 head++;
             }
-            while (outCount < Length(output) && head != tail);
+            while (head != tail && outCount < Length(output));
 
             Volatile.Write(ref this.headAndTail.Head, head);
 

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -68,6 +68,25 @@ namespace BitFaster.Caching.Buffers
             return count;
         }
 
+#if !NETSTANDARD2_0
+
+        public int DrainTo(Span<T> outputBuffer)
+        {
+            var count = 0;
+
+            for (var i = 0; i < buffers.Length; i++)
+            {
+                if (count == outputBuffer.Length)
+                {
+                    break;
+                }
+
+                count += buffers[i].DrainTo(outputBuffer.Slice(count, outputBuffer.Length - count));
+            }
+
+            return count;
+        }
+#endif
         /// <summary>
         /// Tries to add the specified item.
         /// </summary>

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -68,25 +68,6 @@ namespace BitFaster.Caching.Buffers
             return count;
         }
 
-#if !NETSTANDARD2_0
-
-        public int DrainTo(Span<T> outputBuffer)
-        {
-            var count = 0;
-
-            for (var i = 0; i < buffers.Length; i++)
-            {
-                if (count == outputBuffer.Length)
-                {
-                    break;
-                }
-
-                count += buffers[i].DrainTo(outputBuffer.Slice(count, outputBuffer.Length - count));
-            }
-
-            return count;
-        }
-#endif
         /// <summary>
         /// Tries to add the specified item.
         /// </summary>

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -67,7 +67,24 @@ namespace BitFaster.Caching.Buffers
 
             return count;
         }
+#if !NETSTANDARD2_0
+        public int DrainTo(Span<T> outputBuffer)
+        {
+            var count = 0;
 
+            for (var i = 0; i < buffers.Length; i++)
+            {
+                if (count == outputBuffer.Length)
+                {
+                    break;
+                }
+
+                count += buffers[i].DrainTo(outputBuffer.Slice(count, outputBuffer.Length - count));
+            }
+
+            return count;
+        }
+#endif
         /// <summary>
         /// Tries to add the specified item.
         /// </summary>

--- a/BitFaster.Caching/Span.cs
+++ b/BitFaster.Caching/Span.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace BitFaster.Caching
+{
+#if NETSTANDARD2_0
+    // To avoid an additional NuGet package reference, provide a minimal implementation of Span via ArraySegment.    
+    internal ref struct Span<T>
+    {
+        private readonly ArraySegment<T> segment;
+
+        public Span(ref ArraySegment<T> segment)
+        {
+            this.segment = segment;
+        }
+
+        public int Length 
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => this.segment.Count; 
+        }
+
+        public ref T this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => ref this.segment.Array[segment.Offset + index];
+        }
+    }
+
+    internal static class SpanExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this ArraySegment<T> segment)
+        {
+            return new Span<T>(ref segment);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Span<T> AsSpan<T>(this T[] array)
+        {
+            return new ArraySegment<T>(array).AsSpan();
+        }
+    }
+#endif
+}

--- a/BitFaster.Caching/Span.cs
+++ b/BitFaster.Caching/Span.cs
@@ -9,18 +9,18 @@ namespace BitFaster.Caching
     {
         private readonly ArraySegment<T> segment;
 
-        public Span(ref ArraySegment<T> segment)
+        internal Span(ref ArraySegment<T> segment)
         {
             this.segment = segment;
         }
 
-        public int Length 
+        internal int Length 
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => this.segment.Count; 
         }
 
-        public ref T this[int index]
+        internal ref T this[int index]
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => ref this.segment.Array[segment.Offset + index];
@@ -30,13 +30,13 @@ namespace BitFaster.Caching
     internal static class SpanExtensions
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Span<T> AsSpan<T>(this ArraySegment<T> segment)
+        internal static Span<T> AsSpan<T>(this ArraySegment<T> segment)
         {
             return new Span<T>(ref segment);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Span<T> AsSpan<T>(this T[] array)
+        internal static Span<T> AsSpan<T>(this T[] array)
         {
             return new ArraySegment<T>(array).AsSpan();
         }


### PR DESCRIPTION
This is to compare the code dedupe inlined methods to the version with dupe code.

- Drain 1: use ArraySegment
- Drain 2: use span via adaptor static methods.
- Drain 3: natively use span

Conclusion: static method adaptor is equal speed to native span.


|      Method |            Runtime |       Mean |    Error |   StdDev | Ratio | Code Size |
|------------ |------------------- |-----------:|---------:|---------:|------:|----------:|
|  DrainArray |           .NET 6.0 | 2,131.6 ns |  5.19 ns |  4.60 ns |  1.00 |   2,437 B |
| DrainArray2 |           .NET 6.0 | 1,993.0 ns | 14.25 ns | 12.64 ns |  0.93 |   2,484 B |
|   DrainSpan |           .NET 6.0 | 1,979.3 ns |  4.23 ns |  3.96 ns |  0.93 |   2,494 B |
|  DrainSpan2 |           .NET 6.0 | 1,954.8 ns |  4.11 ns |  3.65 ns |  0.92 |   2,484 B |
|             |                    |            |          |          |       |           |
|  DrainArray |           .NET 7.0 | 2,049.6 ns |  5.91 ns |  4.93 ns |  1.00 |   4,517 B |
| DrainArray2 |           .NET 7.0 | 2,026.1 ns |  1.86 ns |  1.45 ns |  0.99 |   4,528 B |
|   DrainSpan |           .NET 7.0 | 2,023.2 ns | 11.28 ns | 10.56 ns |  0.99 |   4,538 B |
|  DrainSpan2 |           .NET 7.0 | 2,036.3 ns |  4.10 ns |  3.63 ns |  0.99 |   4,528 B |
|             |                    |            |          |          |       |           |
|  DrainArray | .NET Framework 4.8 | 2,257.2 ns |  3.90 ns |  3.46 ns |  1.00 |   3,566 B |
| DrainArray2 | .NET Framework 4.8 | 2,420.6 ns |  3.91 ns |  3.47 ns |  1.07 |   3,691 B |
|   DrainSpan | .NET Framework 4.8 |   246.2 ns |  0.40 ns |  0.35 ns |  0.11 |   2,762 B |
|  DrainSpan2 | .NET Framework 4.8 |   246.2 ns |  0.51 ns |  0.46 ns |  0.11 |   2,762 B |

Update: with localBuffer variable AsSpan()

|      Method |            Runtime |       Mean |    Error |   StdDev | Ratio | Code Size |
|------------ |------------------- |-----------:|---------:|---------:|------:|----------:|
|  DrainArray |           .NET 6.0 | 2,151.2 ns |  6.99 ns |  5.84 ns |  1.00 |   2,437 B |
| DrainArray2 |           .NET 6.0 | 1,687.8 ns |  5.27 ns |  4.93 ns |  0.78 |   2,831 B |
|   DrainSpan |           .NET 6.0 | 1,950.9 ns |  9.53 ns |  8.91 ns |  0.91 |   2,494 B |
|  DrainSpan2 |           .NET 6.0 | 1,697.6 ns |  7.79 ns |  6.50 ns |  0.79 |   2,831 B |
|             |                    |            |          |          |       |           |
|  DrainArray |           .NET 7.0 | 2,135.9 ns |  4.27 ns |  4.00 ns |  1.00 |   4,517 B |
| DrainArray2 |           .NET 7.0 | 1,769.8 ns |  4.67 ns |  4.37 ns |  0.83 |   4,827 B |
|   DrainSpan |           .NET 7.0 | 1,971.2 ns | 21.30 ns | 17.78 ns |  0.92 |   4,538 B |
|  DrainSpan2 |           .NET 7.0 | 1,771.2 ns |  3.74 ns |  3.49 ns |  0.83 |   4,827 B |
|             |                    |            |          |          |       |           |
|  DrainArray | .NET Framework 4.8 | 2,255.6 ns |  3.55 ns |  3.32 ns |  1.00 |   3,566 B |
| DrainArray2 | .NET Framework 4.8 | 2,316.1 ns | 10.10 ns |  8.43 ns |  1.03 |   3,707 B |
|   DrainSpan | .NET Framework 4.8 |   250.7 ns |  4.15 ns |  3.88 ns |  0.11 |   2,762 B |
|  DrainSpan2 | .NET Framework 4.8 |   247.8 ns |  1.23 ns |  1.09 ns |  0.11 |   2,762 B |