### PR TITLE
multi-target unit tests

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} 
         path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.netcoreapp3.1.info
-        flag-name: win6
+        flag-name: win3
         parallel: true
 
     - name: Test .NET 6

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Debug --no-restore
     - name: Test .NET Framework
       run: dotnet test --no-restore --verbosity normal --no-build -f net48 --logger "trx;LogFileName=results4.trx"
     - name: Test .NET Core 3.1
@@ -93,7 +93,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Debug --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal --no-build -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results.trx"
     - name: Publish coverage report to coveralls.io   

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -24,27 +24,56 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results.trx"
+    - name: Test .NET Framework
+      run: dotnet test --no-restore --verbosity normal --no-build -f net48 --logger "trx;LogFileName=results4.trx"
+    - name: Test .NET Core 3.1
+      run: dotnet test --no-restore --verbosity normal --no-build -f netcoreapp3.1 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results3.trx"
+    - name: Test .NET 6
+      run: dotnet test --no-restore --verbosity normal --no-build -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results6.trx"
     - name: Publish NuGet artifacts
       uses: actions/upload-artifact@v3
       with:
         name: NuGet package
         path: BitFaster.Caching/bin/Release/
-    - name: Publish coverage report to coveralls.io   
+    - name: Publish net3 coverage report to coveralls.io  
       uses: coverallsapp/github-action@master   
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} 
-        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.info
-        flag-name: win
+        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.netcoreapp3.1.info
+        flag-name: win6
+        parallel: true
+    - name: Publish net6 coverage report to coveralls.io  
+      uses: coverallsapp/github-action@master   
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }} 
+        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.net6.0.info
+        flag-name: win6
         parallel: true
     - name: Generate unit test report
       uses: phoenix-actions/test-reporting@v8
-      id: unit-test-report-win
+      id: unit-test-report-win48
       if: success() || failure() 
       with:
-        name: test results (win)
-        path: BitFaster.Caching.UnitTests/TestResults/results.trx
+        name: test results (win net4.8)
+        path: BitFaster.Caching.UnitTests/TestResults/results4.trx
+        reporter: dotnet-trx 
+        only-summary: 'true'
+    - name: Generate unit test report
+      uses: phoenix-actions/test-reporting@v8
+      id: unit-test-report-win3
+      if: success() || failure() 
+      with:
+        name: test results (win net3.1)
+        path: BitFaster.Caching.UnitTests/TestResults/results3.trx
+        reporter: dotnet-trx 
+        only-summary: 'true'
+    - name: Generate unit test report
+      uses: phoenix-actions/test-reporting@v8
+      id: unit-test-report-win6
+      if: success() || failure() 
+      with:
+        name: test results (win net6)
+        path: BitFaster.Caching.UnitTests/TestResults/results6.trx
         reporter: dotnet-trx 
         only-summary: 'true'
 
@@ -66,7 +95,7 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results.trx"
+      run: dotnet test --no-restore --verbosity normal --no-build -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results.trx"
     - name: Publish coverage report to coveralls.io   
       uses: coverallsapp/github-action@master   
       with:

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -19,7 +19,9 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v2
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          3.1.x
+          6.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build
@@ -104,7 +106,7 @@ jobs:
       uses: coverallsapp/github-action@master   
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} 
-        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.info
+        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.net6.0.info
         flag-name: mac
         parallel: true
     - name: Generate unit test report

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -23,33 +23,11 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Debug --no-restore
-    - name: Test .NET Framework
-      run: dotnet test --no-restore --verbosity normal --no-build -f net48 --logger "trx;LogFileName=results4.trx"
-    - name: Test .NET Core 3.1
-      run: dotnet test --no-restore --verbosity normal --no-build -f netcoreapp3.1 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results3.trx"
-    - name: Test .NET 6
-      run: dotnet test --no-restore --verbosity normal --no-build -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results6.trx"
-    - name: Publish NuGet artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: NuGet package
-        path: BitFaster.Caching/bin/Release/
-    - name: Publish net3 coverage report to coveralls.io  
-      uses: coverallsapp/github-action@master   
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }} 
-        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.netcoreapp3.1.info
-        flag-name: win6
-        parallel: true
-    - name: Publish net6 coverage report to coveralls.io  
-      uses: coverallsapp/github-action@master   
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }} 
-        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.net6.0.info
-        flag-name: win6
-        parallel: true
-    - name: Generate unit test report
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Test (4.8)
+      run: dotnet test --no-restore --verbosity normal -f net48 --logger "trx;LogFileName=results4.trx"
+    - name: Generate unit test report (4.8)
       uses: phoenix-actions/test-reporting@v8
       id: unit-test-report-win48
       if: success() || failure() 
@@ -58,7 +36,10 @@ jobs:
         path: BitFaster.Caching.UnitTests/TestResults/results4.trx
         reporter: dotnet-trx 
         only-summary: 'true'
-    - name: Generate unit test report
+    
+    - name: Test (3.1)
+      run: dotnet test --no-restore --verbosity normal -f netcoreapp3.1 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results3.trx"
+    - name: Generate unit test report (3.1)
       uses: phoenix-actions/test-reporting@v8
       id: unit-test-report-win3
       if: success() || failure() 
@@ -67,7 +48,17 @@ jobs:
         path: BitFaster.Caching.UnitTests/TestResults/results3.trx
         reporter: dotnet-trx 
         only-summary: 'true'
-    - name: Generate unit test report
+    - name: Publish coverage report to coveralls.io (3.0)
+      uses: coverallsapp/github-action@master   
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }} 
+        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.netcoreapp3.1.info
+        flag-name: win6
+        parallel: true
+
+    - name: Test .NET 6
+      run: dotnet test --no-restore --verbosity normal -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results6.trx"
+    - name: Generate unit test report (6.0)
       uses: phoenix-actions/test-reporting@v8
       id: unit-test-report-win6
       if: success() || failure() 
@@ -76,6 +67,19 @@ jobs:
         path: BitFaster.Caching.UnitTests/TestResults/results6.trx
         reporter: dotnet-trx 
         only-summary: 'true'
+    - name: Publish coverage report to coveralls.io (6.0)
+      uses: coverallsapp/github-action@master   
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }} 
+        path-to-lcov: BitFaster.Caching.UnitTests/TestResults/coverage.net6.0.info
+        flag-name: win6
+        parallel: true
+
+    - name: Publish NuGet artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet package
+        path: BitFaster.Caching/bin/Release/
 
   mac:
 
@@ -93,9 +97,9 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Debug --no-restore
+      run: dotnet build --configuration Release --no-restore
     - name: Test
-      run: dotnet test --no-restore --verbosity normal --no-build -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results.trx"
+      run: dotnet test --no-restore --verbosity normal -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results.trx"
     - name: Publish coverage report to coveralls.io   
       uses: coverallsapp/github-action@master   
       with:

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -50,7 +50,7 @@ jobs:
         path: BitFaster.Caching.UnitTests/TestResults/results3.trx
         reporter: dotnet-trx 
         only-summary: 'true'
-    - name: Publish coverage report to coveralls.io (3.0)
+    - name: Publish coverage report to coveralls.io (3.1)
       uses: coverallsapp/github-action@master   
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }} 
@@ -58,14 +58,14 @@ jobs:
         flag-name: win3
         parallel: true
 
-    - name: Test .NET 6
+    - name: Test (6.0)
       run: dotnet test --no-restore --verbosity normal -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results6.trx"
     - name: Generate unit test report (6.0)
       uses: phoenix-actions/test-reporting@v8
       id: unit-test-report-win6
       if: success() || failure() 
       with:
-        name: test results (win net6)
+        name: test results (win net6.0)
         path: BitFaster.Caching.UnitTests/TestResults/results6.trx
         reporter: dotnet-trx 
         only-summary: 'true'
@@ -114,7 +114,7 @@ jobs:
       id: unit-test-report-mac
       if: success() || failure() 
       with:
-        name: test results (mac)
+        name: test results (mac net6.0)
         path: BitFaster.Caching.UnitTests/TestResults/results.trx
         reporter: dotnet-trx 
         only-summary: 'true'

--- a/BitFaster.Caching.UnitTests/BitFaster.Caching.UnitTests.csproj
+++ b/BitFaster.Caching.UnitTests/BitFaster.Caching.UnitTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1;net6.0</TargetFrameworks>
+      <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,6 +19,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+  </ItemGroup>
+    
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BitFaster.Caching.UnitTests/Intrinsics.cs
+++ b/BitFaster.Caching.UnitTests/Intrinsics.cs
@@ -1,5 +1,6 @@
-﻿
+﻿#if NETCOREAPP3_1_OR_GREATER
 using System.Runtime.Intrinsics.X86;
+#endif
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -8,8 +9,14 @@ namespace BitFaster.Caching.UnitTests
     {
         public static void SkipAvxIfNotSupported<I>()
         {
+#if NETCOREAPP3_1_OR_GREATER
             // when we are trying to test Avx2, skip the test if it's not supported
             Skip.If(typeof(I) == typeof(DetectIsa) && !Avx2.IsSupported);
+#else
+            Skip.If(true);
+#endif
         }
     }
 }
+
+

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -58,7 +58,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            await Task.Delay(timeToLive * ttlWaitMlutiplier);
+            await Task.Delay(timeToLive.MultiplyBy(ttlWaitMlutiplier));
 
             lru.TryGet(1, out var value).Should().BeFalse();
         }
@@ -68,7 +68,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            await Task.Delay(timeToLive * ttlWaitMlutiplier);
+            await Task.Delay(timeToLive.MultiplyBy(ttlWaitMlutiplier));
 
             lru.TryUpdate(1, "3");
 
@@ -134,7 +134,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(8, "8");
             lru.AddOrUpdate(9, "9");
 
-            await Task.Delay(timeToLive * ttlWaitMlutiplier);
+            await Task.Delay(timeToLive.MultiplyBy(ttlWaitMlutiplier));
 
             lru.Policy.ExpireAfterWrite.Value.TrimExpired();
 
@@ -152,7 +152,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(5, "5");
             lru.AddOrUpdate(6, "6");
 
-            await Task.Delay(timeToLive * ttlWaitMlutiplier);
+            await Task.Delay(timeToLive.MultiplyBy(ttlWaitMlutiplier));
 
             lru.GetOrAdd(1, valueFactory.Create);
             lru.GetOrAdd(2, valueFactory.Create);
@@ -170,7 +170,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(2, "2");
             lru.AddOrUpdate(3, "3");
 
-            await Task.Delay(timeToLive * ttlWaitMlutiplier);
+            await Task.Delay(timeToLive.MultiplyBy(ttlWaitMlutiplier));
 
             lru.Policy.Eviction.Value.Trim(1);
 

--- a/BitFaster.Caching.UnitTests/Lru/FastConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/FastConcurrentTLruTests.cs
@@ -47,7 +47,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(2, "2");
             lru.AddOrUpdate(3, "3");
 
-            await Task.Delay(ttl * 2);
+            await Task.Delay(ttl.MultiplyBy(2));
 
             lru.Policy.ExpireAfterWrite.Value.TrimExpired();
 

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -1,4 +1,6 @@
-﻿using FluentAssertions;
+﻿#if NETCOREAPP3_1_OR_GREATER
+
+using FluentAssertions;
 using FluentAssertions.Extensions;
 using BitFaster.Caching.Lru;
 using System;
@@ -157,3 +159,5 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
     }
 }
+
+#endif

--- a/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Scheduler;
@@ -36,8 +33,8 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         {
             bool run = false;
 
-            TaskCompletionSource tcs = new TaskCompletionSource();
-            scheduler.Run(() => { Volatile.Write(ref run, true); tcs.SetResult(); });
+            var tcs = new TaskCompletionSource<bool>();
+            scheduler.Run(() => { Volatile.Write(ref run, true); tcs.SetResult(true); });
             await tcs.Task;
 
             Volatile.Read(ref run).Should().BeTrue();
@@ -58,8 +55,8 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         [Fact]
         public async Task WhenWorkThrowsLastExceptionIsPopulated()
         {
-            TaskCompletionSource tcs = new TaskCompletionSource();
-            scheduler.Run(() => { tcs.SetResult();  throw new InvalidCastException(); });
+            var tcs = new TaskCompletionSource<bool>();
+            scheduler.Run(() => { tcs.SetResult(true);  throw new InvalidCastException(); });
 
             await tcs.Task;
             await scheduler.WaitForExceptionAsync();
@@ -71,14 +68,14 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         [Fact]
         public void WhenBacklogExceededTasksAreDropped()
         {
-            TaskCompletionSource tcs = new TaskCompletionSource();
+            var tcs = new TaskCompletionSource<bool>();
 
             for (int i = 0; i < BackgroundThreadScheduler.MaxBacklog * 2; i++)
             {
                 scheduler.Run(() => { tcs.Task.Wait(); });
             }
 
-            tcs.SetResult();
+            tcs.SetResult(true);
 
             scheduler.RunCount.Should().BeCloseTo(BackgroundThreadScheduler.MaxBacklog, 1);
         }

--- a/BitFaster.Caching.UnitTests/Scheduler/ThreadPoolSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/ThreadPoolSchedulerTests.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Scheduler;
@@ -30,8 +27,8 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         {
             bool run = false;
 
-            TaskCompletionSource tcs = new TaskCompletionSource();
-            scheduler.Run(() => { Volatile.Write(ref run, true); tcs.SetResult(); });
+            var tcs = new TaskCompletionSource<bool>();
+            scheduler.Run(() => { Volatile.Write(ref run, true); tcs.SetResult(true); });
 
             await tcs.Task;
 
@@ -41,10 +38,10 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         [Fact]
         public async Task WhenWorkDoesNotThrowLastExceptionIsEmpty()
         {
-            TaskCompletionSource tcs = new TaskCompletionSource();
+            var tcs = new TaskCompletionSource<bool>();
             scheduler.RunCount.Should().Be(0);
 
-            scheduler.Run(() => { tcs.SetResult(); });
+            scheduler.Run(() => { tcs.SetResult(true); });
 
             await tcs.Task;
 
@@ -54,9 +51,9 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         [Fact]
         public async Task WhenWorkThrowsLastExceptionIsPopulated()
         {
-            TaskCompletionSource tcs = new TaskCompletionSource();
+            var tcs = new TaskCompletionSource<bool>();
             scheduler.Run(() => { throw new InvalidCastException(); });
-            scheduler.Run(() => { tcs.SetResult(); });
+            scheduler.Run(() => { tcs.SetResult(true); });
 
             await tcs.Task;
             await scheduler.WaitForExceptionAsync();

--- a/BitFaster.Caching.UnitTests/TimeSpanExtensions.cs
+++ b/BitFaster.Caching.UnitTests/TimeSpanExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace BitFaster.Caching.UnitTests
+{
+    internal static class TimeSpanExtensions
+    {
+        // .NET Framework has no TimeSpan operator*
+        public static TimeSpan MultiplyBy(this TimeSpan multiplicand, int multiplier)
+        {
+            return TimeSpan.FromTicks(multiplicand.Ticks * multiplier);
+        }
+    }
+}


### PR DESCRIPTION
This PR:

1. Enables unit tests to build and run on .NET 4.8, .NET Core 3.1 and .NET 6 targets.
2. Runs all targets on windows
3. Runs .NET6 on mac
4. Collects code coverage for 3.1 and 6.0, since .NET Framework is not well supported in dotnet test.