### PR TITLE
Fix back compat issues against v2.0.0

### DIFF
--- a/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
@@ -22,9 +22,9 @@ namespace BitFaster.Caching.Benchmarks.Lru
             = new ConcurrentLruCore<int, int, TickCountLruItem<int, int>, TLruTicksPolicy<int, int>, NoTelemetryPolicy<int, int>>
                 (1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, new TLruTicksPolicy<int, int>(TimeSpan.FromSeconds(1)), default);
 
-        private static readonly ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, NoTelemetryPolicy<int, int>> stopwatchTLru
-            = new ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, NoTelemetryPolicy<int, int>>
-                (1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, new TlruStopwatchPolicy<int, int>(TimeSpan.FromSeconds(1)), default);
+        private static readonly ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TLruLongTicksPolicy<int, int>, NoTelemetryPolicy<int, int>> stopwatchTLru
+            = new ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TLruLongTicksPolicy<int, int>, NoTelemetryPolicy<int, int>>
+                (1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, new TLruLongTicksPolicy<int, int>(TimeSpan.FromSeconds(1)), default);
 
         [Benchmark(Baseline = true)]
         public void DateTimeUtcNow()

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryAsyncCacheTests.cs
@@ -76,6 +76,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.removedItems.First().Key.Should().Be(1);
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -88,6 +90,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.updatedItems.First().OldValue.Should().Be(2);
             this.updatedItems.First().NewValue.Should().Be(3);
         }
+#endif
 
         [Fact]
         public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
@@ -65,6 +65,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.removedItems.First().Key.Should().Be(1);
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -77,7 +79,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.updatedItems.First().OldValue.Should().Be(2);
             this.updatedItems.First().NewValue.Should().Be(3);
         }
-
+#endif
         [Fact]
         public void WhenNoInnerEventsNoOuterEvents()
         {

--- a/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
@@ -54,6 +54,8 @@ namespace BitFaster.Caching.UnitTests
             this.removedItems.First().Key.Should().Be(1);
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void WheUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -88,7 +90,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.updatedItems.First().Key.Should().Be(1);
         }
-
+#endif
         private void OnItemRemoved(object sender, ItemRemovedEventArgs<int, int> e)
         {
             this.removedItems.Add(e);

--- a/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
@@ -144,5 +144,32 @@ namespace BitFaster.Caching.UnitTests
                 return new ItemUpdatedEventArgs<K, V>(inner.Key, inner.OldValue.ValueIfCreated, inner.NewValue.ValueIfCreated);
             }
         }
+
+        // backcompat: remove (virtual method with default impl only needed for back compat)
+        [Fact]
+        public void WhenUpdatedEventHandlerIsRegisteredAndProxyUsesDefaultUpdateTranslateItIsFired()
+        {
+            var proxy = new EventProxyWithDefault<int, int>(this.testCacheEvents);
+
+            proxy.ItemUpdated += OnItemUpdated;
+
+            this.testCacheEvents.FireUpdated(1, new AtomicFactory<int, int>(2), new AtomicFactory<int, int>(3));
+
+            this.updatedItems.First().Key.Should().Be(1);
+        }
+
+        // backcompat: remove (class uses default TranslateOnUpdated method)
+        private class EventProxyWithDefault<K, V> : CacheEventProxyBase<K, AtomicFactory<K, V>, V>
+        {
+            public EventProxyWithDefault(ICacheEvents<K, AtomicFactory<K, V>> inner)
+                : base(inner)
+            {
+            }
+
+            protected override ItemRemovedEventArgs<K, V> TranslateOnRemoved(ItemRemovedEventArgs<K, AtomicFactory<K, V>> inner)
+            {
+                return new ItemRemovedEventArgs<K, V>(inner.Key, inner.Value.ValueIfCreated, inner.Reason);
+            }
+        }
     }
 }

--- a/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
@@ -155,7 +155,11 @@ namespace BitFaster.Caching.UnitTests
 
             this.testCacheEvents.FireUpdated(1, new AtomicFactory<int, int>(2), new AtomicFactory<int, int>(3));
 
+#if NETCOREAPP3_0_OR_GREATER
             this.updatedItems.First().Key.Should().Be(1);
+#else
+            this.updatedItems.Should().BeEmpty();
+#endif
         }
 
         // backcompat: remove (class uses default TranslateOnUpdated method)

--- a/BitFaster.Caching.UnitTests/CacheEventsTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheEventsTests.cs
@@ -1,0 +1,26 @@
+﻿
+using Moq;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests
+{
+// backcompat: remove 
+#if NETCOREAPP3_1_OR_GREATER
+    public class CacheEventsTests
+    {
+        [Fact]
+        public void WhenInterfaceDefaultItemUpdatedRegisteredNoOp()
+        {
+            var metrics = new Mock<ICacheEvents<int, int>>();
+            metrics.CallBase = true;
+
+            metrics.Object.ItemUpdated += NoOpItemUpdated;
+            metrics.Object.ItemUpdated -= NoOpItemUpdated;
+        }
+
+        private void NoOpItemUpdated(object sender, ItemUpdatedEventArgs<int, int> e)
+        {
+        }
+    }
+#endif
+}

--- a/BitFaster.Caching.UnitTests/CacheMetricsTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheMetricsTests.cs
@@ -1,0 +1,22 @@
+﻿
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests
+{
+// backcompat: remove 
+#if NETCOREAPP3_1_OR_GREATER
+    public class CacheMetricsTests
+    {
+        [Fact]
+        public void WhenInterfaceDefaultUpdatedInvokedReturnZero()
+        { 
+            var metrics = new Mock<ICacheMetrics>();
+            metrics.CallBase = true;
+
+            metrics.Object.Updated.Should().Be(0);
+        }
+    }
+#endif
+}

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -432,6 +432,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.TryGet(-1, out var _).Should().BeFalse();
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void WhenWriteBufferIsFullUpdatesAreDropped()
         {
@@ -453,6 +455,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             cache.Metrics.Value.Updated.Should().Be(bufferSize);
         }
+#endif
 
         [Fact]
         public void EvictionPolicyReturnsCapacity()

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -373,6 +373,16 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryUpdate(2, "3").Should().BeFalse();
+        }
+
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
         public void WhenKeyExistsTryUpdateIncrementsUpdateCount()
         {
             lru.GetOrAdd(1, valueFactory.Create);
@@ -380,14 +390,6 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.TryUpdate(1, "2").Should().BeTrue();
 
             lru.Metrics.Value.Updated.Should().Be(1);
-        }
-
-        [Fact]
-        public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
-        {
-            lru.GetOrAdd(1, valueFactory.Create);
-
-            lru.TryUpdate(2, "3").Should().BeFalse();
         }
 
         [Fact]
@@ -399,6 +401,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Metrics.Value.Updated.Should().Be(0);
         }
+#endif
 
         [Fact]
         public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -61,7 +61,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                  .WithExpireAfterWrite(TimeSpan.FromMilliseconds(10))
                  .Build();
 
-            lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, NoTelemetryPolicy<int, int>>>();
+            lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TLruLongTicksPolicy<int, int>, NoTelemetryPolicy<int, int>>>();
             lru.Policy.Eviction.Value.Capacity.Should().Be(128);
         }
 
@@ -73,7 +73,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                  .WithMetrics()
                  .Build();
 
-            lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TlruStopwatchPolicy<int, int>, TelemetryPolicy<int, int>>>();
+            lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TLruLongTicksPolicy<int, int>, TelemetryPolicy<int, int>>>();
             lru.Policy.Eviction.Value.Capacity.Should().Be(128);
         }
 #endif

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -53,31 +53,6 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.Policy.Eviction.Value.Capacity.Should().Be(128);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
-        [Fact]
-        public void TestHighResClockTLru()
-        {
-            ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
-                 .WithExpireAfterWrite(TimeSpan.FromMilliseconds(10))
-                 .Build();
-
-            lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TLruLongTicksPolicy<int, int>, NoTelemetryPolicy<int, int>>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(128);
-        }
-
-        [Fact]
-        public void TestHighResClockMetricsTLru()
-        {
-            ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
-                 .WithExpireAfterWrite(TimeSpan.FromMilliseconds(10))
-                 .WithMetrics()
-                 .Build();
-
-            lru.Should().BeOfType<ConcurrentLruCore<int, int, LongTickCountLruItem<int, int>, TLruLongTicksPolicy<int, int>, TelemetryPolicy<int, int>>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(128);
-        }
-#endif
-
         [Fact]
         public void AsAsyncTestFastLru()
         {

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -642,6 +642,16 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryUpdate(2, "3").Should().BeFalse();
+        }
+
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
         public void WhenKeyExistsTryUpdateIncrementsUpdateCount()
         {
             lru.GetOrAdd(1, valueFactory.Create);
@@ -649,14 +659,6 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.TryUpdate(1, "2").Should().BeTrue();
 
             lru.Metrics.Value.Updated.Should().Be(1);
-        }
-
-        [Fact]
-        public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
-        {
-            lru.GetOrAdd(1, valueFactory.Create);
-
-            lru.TryUpdate(2, "3").Should().BeFalse();
         }
 
         [Fact]
@@ -668,7 +670,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Metrics.Value.Updated.Should().Be(0);
         }
-
+#endif
         [Fact]
         public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()
         {
@@ -713,6 +715,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.WarmCount.Should().Be(1); // items must have been enqueued and cycled for one of them to reach the warm queue
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void WhenItemExistsAddOrUpdateFiresUpdateEvent()
         {
@@ -761,6 +765,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             updatedItems.Count.Should().Be(0);
         }
+#endif
 
         [Fact]
         public void WhenCacheIsEmptyClearIsNoOp()

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -214,7 +214,7 @@ namespace BitFaster.Caching.UnitTests.Lru
     {
         protected override ICache<K, V> CreateTLru<K, V>(ICapacityPartition capacity, TimeSpan timeToLive)
         {
-            return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, TelemetryPolicy<K, V>>(1, capacity, EqualityComparer<K>.Default, new TlruStopwatchPolicy<K, V>(timeToLive), default);
+            return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, TelemetryPolicy<K, V>>(1, capacity, EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), default);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -182,7 +182,8 @@ namespace BitFaster.Caching.UnitTests.Lru
     {
         protected override ICache<K, V> CreateTLru<K, V>(ICapacityPartition capacity, TimeSpan timeToLive)
         {
-             return new ConcurrentTLru<K, V>(1, capacity, EqualityComparer<K>.Default, timeToLive);
+            // backcompat: use TLruTickCount64Policy
+            return new ConcurrentTLru<K, V>(1, capacity, EqualityComparer<K>.Default, timeToLive);
         }
 
         [Fact]
@@ -214,6 +215,7 @@ namespace BitFaster.Caching.UnitTests.Lru
     {
         protected override ICache<K, V> CreateTLru<K, V>(ICapacityPartition capacity, TimeSpan timeToLive)
         {
+            // backcompat: use TlruStopwatchPolicy
             return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, TelemetryPolicy<K, V>>(1, capacity, EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), default);
         }
     }

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -166,6 +166,24 @@ namespace BitFaster.Caching.UnitTests.Lru
             var ticks = TLruLongTicksPolicy<int, int>.ToTicks(time);
             TLruLongTicksPolicy<int, int>.FromTicks(ticks).Should().Be(time);
         }
+
+        // backcompat: remove (methods only added for TLruLongTicksPolicy)
+        [Fact]
+        public void WhenTimeLessThanEqualZeroToTicksThrows()
+        {
+            Action toTicks = () => { TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.Zero); };
+
+            toTicks.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        // backcompat: remove (methods only added for TLruLongTicksPolicy)
+        [Fact]
+        public void WhenTimeGreaterThanMaxToTicksThrows()
+        {
+            Action toTicks = () => { TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.MaxValue); };
+
+            toTicks.Should().Throw<ArgumentOutOfRangeException>();
+        }
     }
 }
 

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -1,7 +1,6 @@
 ﻿#if NETCOREAPP3_1_OR_GREATER
 
 using FluentAssertions;
-using FluentAssertions.Extensions;
 using BitFaster.Caching.Lru;
 using System;
 using System.Threading.Tasks;
@@ -11,12 +10,13 @@ namespace BitFaster.Caching.UnitTests.Lru
 {
     public class TLruTickCount64PolicyTests
     {
-        private readonly TLruTickCount64Policy<int, int> policy = new TLruTickCount64Policy<int, int>(TimeSpan.FromSeconds(10));
+        // backcompat: change type to TLruTickCount64Policy
+        private readonly TLruLongTicksPolicy<int, int> policy = new TLruLongTicksPolicy<int, int>(TimeSpan.FromSeconds(10));
 
         [Fact]
         public void WhenTtlIsTimeSpanMaxThrow()
         {
-            Action constructor = () => { new TLruTickCount64Policy<int, int>(TimeSpan.MaxValue); };
+            Action constructor = () => { new TLruLongTicksPolicy<int, int>(TimeSpan.MaxValue); };
 
             constructor.Should().Throw<ArgumentOutOfRangeException>();
         }
@@ -24,7 +24,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenTtlIsZeroThrow()
         {
-            Action constructor = () => { new TLruTickCount64Policy<int, int>(TimeSpan.Zero); };
+            Action constructor = () => { new TLruLongTicksPolicy<int, int>(TimeSpan.Zero); };
 
             constructor.Should().Throw<ArgumentOutOfRangeException>();
         }
@@ -33,7 +33,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenTtlIsMaxSetAsMax()
         {
             var maxRepresentable = TimeSpan.FromTicks(9223372036854769664);
-            var policy = new TLruTickCount64Policy<int, int>(maxRepresentable);
+            var policy = new TLruLongTicksPolicy<int, int>(maxRepresentable);
             policy.TimeToLive.Should().Be(maxRepresentable);
         }
 

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -157,6 +157,15 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             return item;
         }
+
+        // backcompat: remove (methods only added for TLruLongTicksPolicy)
+        [Fact]
+        public void CanConvertToAndFromTicks()
+        {
+            var time = TimeSpan.FromSeconds(10);
+            var ticks = TLruLongTicksPolicy<int, int>.ToTicks(time);
+            TLruLongTicksPolicy<int, int>.FromTicks(ticks).Should().Be(time);
+        }
     }
 }
 

--- a/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
@@ -2,6 +2,8 @@
 using BitFaster.Caching.Lru;
 using System.Collections.Generic;
 using Xunit;
+using Moq;
+using System;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
@@ -144,5 +146,19 @@ namespace BitFaster.Caching.UnitTests.Lru
             eventSourceList.Should().HaveCount(1);
             eventSourceList[0].Should().Be(this);
         }
+
+// backcompat: remove 
+#if NETCOREAPP3_1_OR_GREATER
+        [Fact]
+        public void WhenInterfaceDefaultItemUpdatedRegisteredNoOp()
+        {
+            var policy = new Mock<ITelemetryPolicy<int, int>>();
+            policy.CallBase = true;
+
+            Action act = () => policy.Object.OnItemUpdated(1, 2, 3);
+
+            act.Should().NotThrow();
+        }
+#endif
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -9,12 +9,12 @@ namespace BitFaster.Caching.UnitTests.Lru
 {
     public class TlruStopwatchPolicyTests
     {
-        private readonly TlruStopwatchPolicy<int, int> policy = new TlruStopwatchPolicy<int, int>(TimeSpan.FromSeconds(10));
+        private readonly TLruLongTicksPolicy<int, int> policy = new TLruLongTicksPolicy<int, int>(TimeSpan.FromSeconds(10));
 
         [Fact]
         public void WhenTtlIsZeroThrow()
         {
-            Action constructor = () => { new TlruStopwatchPolicy<int, int>(TimeSpan.Zero); };
+            Action constructor = () => { new TLruLongTicksPolicy<int, int>(TimeSpan.Zero); };
 
             constructor.Should().Throw<ArgumentOutOfRangeException>();
         }
@@ -22,7 +22,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenTtlIsTimeSpanMaxThrow()
         {
-            Action constructor = () => { new TlruStopwatchPolicy<int, int>(TimeSpan.MaxValue); };
+            Action constructor = () => { new TLruLongTicksPolicy<int, int>(TimeSpan.MaxValue); };
 
             constructor.Should().Throw<ArgumentOutOfRangeException>();
         }
@@ -33,7 +33,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             double maxTicks = long.MaxValue / 100.0d;
             var ttl = TimeSpan.FromTicks((long)maxTicks) - TimeSpan.FromTicks(10);
 
-            new TlruStopwatchPolicy<int, int>(ttl).TimeToLive.Should().BeCloseTo(ttl, TimeSpan.FromTicks(20));
+            new TLruLongTicksPolicy<int, int>(ttl).TimeToLive.Should().BeCloseTo(ttl, TimeSpan.FromTicks(20));
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsExpiredShouldDiscardIsTrue()
         {
             var item = this.policy.CreateItem(1, 2);
-            item.TickCount = Stopwatch.GetTimestamp() - TlruStopwatchPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
+            item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
 
             this.policy.ShouldDiscard(item).Should().BeTrue();
         }
@@ -98,7 +98,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsNotExpiredShouldDiscardIsFalse()
         {
             var item = this.policy.CreateItem(1, 2);
-            item.TickCount = Stopwatch.GetTimestamp() - TlruStopwatchPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(9));
+            item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(9));
 
             this.policy.ShouldDiscard(item).Should().BeFalse();
         }
@@ -153,7 +153,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             if (isExpired)
             {
-                item.TickCount = Stopwatch.GetTimestamp() - TlruStopwatchPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
+                item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
             }
 
             return item;

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
+// backcompat: remove conditional compile
+#if !NETCOREAPP3_1_OR_GREATER
     public class TlruStopwatchPolicyTests
     {
         private readonly TLruLongTicksPolicy<int, int> policy = new TLruLongTicksPolicy<int, int>(TimeSpan.FromSeconds(10));
@@ -159,4 +161,5 @@ namespace BitFaster.Caching.UnitTests.Lru
             return item;
         }
     }
+#endif
 }

--- a/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
@@ -59,6 +59,8 @@ namespace BitFaster.Caching.UnitTests
             this.removedItems.First().Key.Should().Be(1);
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -69,6 +71,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.updatedItems.First().Key.Should().Be(1);
         }
+#endif
 
         [Fact]
         public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()

--- a/BitFaster.Caching.UnitTests/ScopedCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTestBase.cs
@@ -57,6 +57,8 @@ namespace BitFaster.Caching.UnitTests
             this.removedItems.First().Key.Should().Be(1);
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -67,6 +69,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.updatedItems.First().Key.Should().Be(1);
         }
+#endif
 
         [Fact]
         public void WhenKeyDoesNotExistAddOrUpdateAddsNewItem()

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -27,9 +27,9 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!--Package Validation-->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>2.1.3</PackageValidationBaselineVersion>
-    <!--FastConcurrentTLru/ConcurrentTLru have illegal base type switching -->
-    <NoWarn >$(NoWarn);CP0007</NoWarn>
+    <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
+    <!--FastConcurrentTLru/ConcurrentTLru have illegal base type switching <NoWarn >$(NoWarn);CP0007</NoWarn>-->
+    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -27,9 +27,7 @@
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!--Package Validation-->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
-    <!--FastConcurrentTLru/ConcurrentTLru have illegal base type switching <NoWarn >$(NoWarn);CP0007</NoWarn>-->
-    
+    <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/BitFaster.Caching/CacheEventProxyBase.cs
+++ b/BitFaster.Caching/CacheEventProxyBase.cs
@@ -104,7 +104,7 @@ namespace BitFaster.Caching
         // backcompat: make abstract, remove default no-op impl
         protected virtual ItemUpdatedEventArgs<K, TOuter> TranslateOnUpdated(ItemUpdatedEventArgs<K, TInner> inner)
         {
-            return new ItemUpdatedEventArgs<K, TOuter>(inner.Key, default(TOuter), default(TOuter));
+            return new ItemUpdatedEventArgs<K, TOuter>(inner.Key, default, default);
         }
     }
 }

--- a/BitFaster.Caching/CacheEventProxyBase.cs
+++ b/BitFaster.Caching/CacheEventProxyBase.cs
@@ -59,17 +59,21 @@ namespace BitFaster.Caching
         private void RegisterUpdated(EventHandler<ItemUpdatedEventArgs<K, TOuter>> value)
         {
             itemUpdatedProxy += value;
+#if NETCOREAPP3_0_OR_GREATER
             events.ItemUpdated += OnItemUpdated;
+#endif
         }
 
         private void UnRegisterUpdated(EventHandler<ItemUpdatedEventArgs<K, TOuter>> value)
         {
             this.itemUpdatedProxy -= value;
 
+#if NETCOREAPP3_0_OR_GREATER
             if (this.itemUpdatedProxy == null)
             {
                 this.events.ItemUpdated -= OnItemUpdated;
             }
+#endif
         }
 
         private void OnItemRemoved(object sender, ItemRemovedEventArgs<K, TInner> args)

--- a/BitFaster.Caching/CacheEventProxyBase.cs
+++ b/BitFaster.Caching/CacheEventProxyBase.cs
@@ -94,6 +94,9 @@ namespace BitFaster.Caching
         /// </summary>
         /// <param name="inner">The inner arg.</param>
         /// <returns>The translated arg.</returns>
-        protected abstract ItemUpdatedEventArgs<K, TOuter> TranslateOnUpdated(ItemUpdatedEventArgs<K, TInner> inner);
+        protected virtual ItemUpdatedEventArgs<K, TOuter> TranslateOnUpdated(ItemUpdatedEventArgs<K, TInner> inner)
+        {
+            return new ItemUpdatedEventArgs<K, TOuter>(inner.Key, default(TOuter), default(TOuter));
+        }
     }
 }

--- a/BitFaster.Caching/CacheEventProxyBase.cs
+++ b/BitFaster.Caching/CacheEventProxyBase.cs
@@ -59,6 +59,8 @@ namespace BitFaster.Caching
         private void RegisterUpdated(EventHandler<ItemUpdatedEventArgs<K, TOuter>> value)
         {
             itemUpdatedProxy += value;
+
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
             events.ItemUpdated += OnItemUpdated;
 #endif
@@ -68,6 +70,7 @@ namespace BitFaster.Caching
         {
             this.itemUpdatedProxy -= value;
 
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
             if (this.itemUpdatedProxy == null)
             {
@@ -98,6 +101,7 @@ namespace BitFaster.Caching
         /// </summary>
         /// <param name="inner">The inner arg.</param>
         /// <returns>The translated arg.</returns>
+        // backcompat: make abstract, remove default no-op impl
         protected virtual ItemUpdatedEventArgs<K, TOuter> TranslateOnUpdated(ItemUpdatedEventArgs<K, TInner> inner)
         {
             return new ItemUpdatedEventArgs<K, TOuter>(inner.Key, default(TOuter), default(TOuter));

--- a/BitFaster.Caching/ICacheEvents.cs
+++ b/BitFaster.Caching/ICacheEvents.cs
@@ -12,12 +12,14 @@ namespace BitFaster.Caching
         /// </summary>
         event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
 
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>
         /// Occurs when an item is updated.
         /// </summary>
         event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
         {
+            // backcompat: remove default no-op impl
             add { }
             remove { }
         }

--- a/BitFaster.Caching/ICacheEvents.cs
+++ b/BitFaster.Caching/ICacheEvents.cs
@@ -12,9 +12,15 @@ namespace BitFaster.Caching
         /// </summary>
         event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
 
+#if NETCOREAPP3_0_OR_GREATER
         /// <summary>
         /// Occurs when an item is updated.
         /// </summary>
-        event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated;
+        event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
+        {
+            add { }
+            remove { }
+        }
+#endif
     }
 }

--- a/BitFaster.Caching/ICacheMetrics.cs
+++ b/BitFaster.Caching/ICacheMetrics.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace BitFaster.Caching
 {
     /// <summary>
@@ -37,6 +32,7 @@ namespace BitFaster.Caching
         /// </summary>
         long Evicted { get; }
 
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>
         /// Gets the total number of updated items.

--- a/BitFaster.Caching/ICacheMetrics.cs
+++ b/BitFaster.Caching/ICacheMetrics.cs
@@ -37,9 +37,11 @@ namespace BitFaster.Caching
         /// </summary>
         long Evicted { get; }
 
+#if NETCOREAPP3_0_OR_GREATER
         /// <summary>
         /// Gets the total number of updated items.
         /// </summary>
-        long Updated { get; }
+        long Updated => 0;
+#endif
     }
 }

--- a/BitFaster.Caching/Lru/Builder/LruBuilderBase.cs
+++ b/BitFaster.Caching/Lru/Builder/LruBuilderBase.cs
@@ -14,6 +14,7 @@ namespace BitFaster.Caching.Lru.Builder
         /// Creates an LruBuilderBase.
         /// </summary>
         /// <param name="info">The LRU info</param>
+        // backcompat: make internal
         protected LruBuilderBase(LruInfo<K> info)
         {
             this.info = info;
@@ -83,14 +84,6 @@ namespace BitFaster.Caching.Lru.Builder
         public TBuilder WithExpireAfterWrite(TimeSpan expiration)
         {
             this.info.TimeToExpireAfterWrite = expiration;
-
-#if NETCOREAPP3_0_OR_GREATER
-            // if the expiration time is less than 2x default precision, switch to high resolution clock automatically.
-            if (expiration < TimeSpan.FromMilliseconds(32))
-            {
-                this.info.WithHighResolutionTime = true;
-            }
-#endif
             return this as TBuilder;
         }
 

--- a/BitFaster.Caching/Lru/Builder/LruBuilderBase.cs
+++ b/BitFaster.Caching/Lru/Builder/LruBuilderBase.cs
@@ -10,7 +10,11 @@ namespace BitFaster.Caching.Lru.Builder
     {
         internal readonly LruInfo<K> info;
 
-        internal LruBuilderBase(LruInfo<K> info)
+        /// <summary>
+        /// Creates an LruBuilderBase.
+        /// </summary>
+        /// <param name="info">The LRU info</param>
+        protected LruBuilderBase(LruInfo<K> info)
         {
             this.info = info;
         }

--- a/BitFaster.Caching/Lru/Builder/LruInfo.cs
+++ b/BitFaster.Caching/Lru/Builder/LruInfo.cs
@@ -7,6 +7,7 @@ namespace BitFaster.Caching.Lru.Builder
     /// Parameters for buiding an LRU.
     /// </summary>
     /// <typeparam name="K">The LRU key type</typeparam>
+    // backcompat: make class internal
     public sealed class LruInfo<K>
     {
         /// <summary>
@@ -33,12 +34,5 @@ namespace BitFaster.Caching.Lru.Builder
         /// Gets or sets the KeyComparer.
         /// </summary>
         public IEqualityComparer<K> KeyComparer { get; set; } = EqualityComparer<K>.Default;
-
-#if NETCOREAPP3_0_OR_GREATER
-        /// <summary>
-        /// Gets or sets a value indicating whether to use high resolution time.
-        /// </summary>
-        public bool WithHighResolutionTime { get; set; } = false;
-#endif
     }
 }

--- a/BitFaster.Caching/Lru/Builder/LruInfo.cs
+++ b/BitFaster.Caching/Lru/Builder/LruInfo.cs
@@ -3,19 +3,41 @@ using System.Collections.Generic;
 
 namespace BitFaster.Caching.Lru.Builder
 {
-    internal sealed class LruInfo<K>
+    /// <summary>
+    /// Parameters for buiding an LRU.
+    /// </summary>
+    /// <typeparam name="K">The LRU key type</typeparam>
+    public sealed class LruInfo<K>
     {
+        /// <summary>
+        /// Gets or sets the capacity partition.
+        /// </summary>
         public ICapacityPartition Capacity { get; set; } = new FavorWarmPartition(128);
 
+        /// <summary>
+        /// Gets or sets the concurrency level.
+        /// </summary>
         public int ConcurrencyLevel { get; set; } = Defaults.ConcurrencyLevel;
 
+        /// <summary>
+        /// Gets or sets the time to expire after write.
+        /// </summary>
         public TimeSpan? TimeToExpireAfterWrite { get; set; } = null;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to use metrics.
+        /// </summary>
         public bool WithMetrics { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets the KeyComparer.
+        /// </summary>
         public IEqualityComparer<K> KeyComparer { get; set; } = EqualityComparer<K>.Default;
 
 #if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Gets or sets a value indicating whether to use high resolution time.
+        /// </summary>
         public bool WithHighResolutionTime { get; set; } = false;
 #endif
     }

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
@@ -43,11 +43,11 @@ namespace BitFaster.Caching.Lru
             {
 #if NETCOREAPP3_0_OR_GREATER
                 case LruInfo<K> i when i.WithMetrics && i.TimeToExpireAfterWrite.HasValue && i.WithHighResolutionTime:
-                    return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, TelemetryPolicy<K, V>>(
-                        info.ConcurrencyLevel, info.Capacity, info.KeyComparer, new TlruStopwatchPolicy<K, V>(info.TimeToExpireAfterWrite.Value), default);
+                    return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, TelemetryPolicy<K, V>>(
+                        info.ConcurrencyLevel, info.Capacity, info.KeyComparer, new TLruLongTicksPolicy<K, V>(info.TimeToExpireAfterWrite.Value), default);
                 case LruInfo<K> i when !i.WithMetrics && i.TimeToExpireAfterWrite.HasValue && i.WithHighResolutionTime:
-                    return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, NoTelemetryPolicy<K, V>>(
-                        info.ConcurrencyLevel, info.Capacity, info.KeyComparer, new TlruStopwatchPolicy<K, V>(info.TimeToExpireAfterWrite.Value), default);
+                    return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, NoTelemetryPolicy<K, V>>(
+                        info.ConcurrencyLevel, info.Capacity, info.KeyComparer, new TLruLongTicksPolicy<K, V>(info.TimeToExpireAfterWrite.Value), default);
 #endif
                 case LruInfo<K> i when i.WithMetrics && !i.TimeToExpireAfterWrite.HasValue:
                     return new ConcurrentLru<K, V>(info.ConcurrencyLevel, info.Capacity, info.KeyComparer);

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
@@ -41,14 +41,6 @@ namespace BitFaster.Caching.Lru
         {
             switch (info)
             {
-#if NETCOREAPP3_0_OR_GREATER
-                case LruInfo<K> i when i.WithMetrics && i.TimeToExpireAfterWrite.HasValue && i.WithHighResolutionTime:
-                    return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, TelemetryPolicy<K, V>>(
-                        info.ConcurrencyLevel, info.Capacity, info.KeyComparer, new TLruLongTicksPolicy<K, V>(info.TimeToExpireAfterWrite.Value), default);
-                case LruInfo<K> i when !i.WithMetrics && i.TimeToExpireAfterWrite.HasValue && i.WithHighResolutionTime:
-                    return new ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, NoTelemetryPolicy<K, V>>(
-                        info.ConcurrencyLevel, info.Capacity, info.KeyComparer, new TLruLongTicksPolicy<K, V>(info.TimeToExpireAfterWrite.Value), default);
-#endif
                 case LruInfo<K> i when i.WithMetrics && !i.TimeToExpireAfterWrite.HasValue:
                     return new ConcurrentLru<K, V>(info.ConcurrencyLevel, info.Capacity, info.KeyComparer);
                 case LruInfo<K> i when i.WithMetrics && i.TimeToExpireAfterWrite.HasValue:

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -286,6 +286,7 @@ namespace BitFaster.Caching.Lru
                         V oldValue = existing.Value;
                         existing.Value = value;
                         this.itemPolicy.Update(existing);
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
                         this.telemetryPolicy.OnItemUpdated(existing.Key, oldValue, existing.Value);
 #endif
@@ -379,6 +380,7 @@ namespace BitFaster.Caching.Lru
         /// Trim discarded items from all queues.
         /// </summary>
         /// <returns>The number of items removed.</returns>
+        // backcompat: make internal
         protected int TrimAllDiscardedItems()
         {
             int itemsRemoved = 0;
@@ -714,6 +716,7 @@ namespace BitFaster.Caching.Lru
 
             public long Evicted => lru.telemetryPolicy.Evicted;
 
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
             public long Updated => lru.telemetryPolicy.Updated;
 #endif
@@ -726,6 +729,8 @@ namespace BitFaster.Caching.Lru
                 add { this.lru.telemetryPolicy.ItemRemoved += value; }
                 remove { this.lru.telemetryPolicy.ItemRemoved -= value; }
             }
+
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
             public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
             {

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -50,9 +50,14 @@ namespace BitFaster.Caching.Lru
         private readonly P itemPolicy;
         private bool isWarm = false;
 
-        // Since T is a struct, making it readonly will force the runtime to make defensive copies
-        // if mutate methods are called. Therefore, field must be mutable to maintain count.
-        private T telemetryPolicy;
+        /// <summary>
+        /// The telemetry policy.
+        /// </summary>
+        /// <remarks>
+        /// Since T is a struct, making it readonly will force the runtime to make defensive copies
+        /// if mutate methods are called. Therefore, field must be mutable to maintain count.
+        /// </remarks>
+        protected T telemetryPolicy;
 
         /// <summary>
         /// Initializes a new instance of the ConcurrentLruCore class with the specified concurrencyLevel, capacity, equality comparer, item policy and telemetry policy.
@@ -281,7 +286,9 @@ namespace BitFaster.Caching.Lru
                         V oldValue = existing.Value;
                         existing.Value = value;
                         this.itemPolicy.Update(existing);
+#if NETCOREAPP3_0_OR_GREATER
                         this.telemetryPolicy.OnItemUpdated(existing.Key, oldValue, existing.Value);
+#endif
                         Disposer<V>.Dispose(oldValue);
 
                         return true;
@@ -368,7 +375,11 @@ namespace BitFaster.Caching.Lru
             }
         }
 
-        private int TrimAllDiscardedItems()
+        /// <summary>
+        /// Trim discarded items from all queues.
+        /// </summary>
+        /// <returns>The number of items removed.</returns>
+        protected int TrimAllDiscardedItems()
         {
             int itemsRemoved = 0;
 
@@ -703,8 +714,9 @@ namespace BitFaster.Caching.Lru
 
             public long Evicted => lru.telemetryPolicy.Evicted;
 
+#if NETCOREAPP3_0_OR_GREATER
             public long Updated => lru.telemetryPolicy.Updated;
-
+#endif
             public int Capacity => lru.Capacity;
 
             public TimeSpan TimeToLive => lru.itemPolicy.TimeToLive;
@@ -714,13 +726,13 @@ namespace BitFaster.Caching.Lru
                 add { this.lru.telemetryPolicy.ItemRemoved += value; }
                 remove { this.lru.telemetryPolicy.ItemRemoved -= value; }
             }
-
+#if NETCOREAPP3_0_OR_GREATER
             public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
             {
                 add { this.lru.telemetryPolicy.ItemUpdated += value; }
                 remove { this.lru.telemetryPolicy.ItemUpdated -= value; }
             }
-
+#endif
             public void Trim(int itemCount)
             {
                 lru.Trim(itemCount);

--- a/BitFaster.Caching/Lru/ConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentTLru.cs
@@ -7,11 +7,7 @@ namespace BitFaster.Caching.Lru
     ///<inheritdoc/>
     [DebuggerTypeProxy(typeof(CacheDebugView<,>))]
     [DebuggerDisplay("Count = {Count}/{Capacity}")]
-//#if NETCOREAPP3_0_OR_GREATER
-//    public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruTickCount64Policy<K, V>, TelemetryPolicy<K, V>>
-//#else
     public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, TelemetryPolicy<K, V>>
-//#endif
     {
         /// <summary>
         /// Initializes a new instance of the ConcurrentTLru class with the specified capacity and time to live that has the default 
@@ -20,11 +16,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="capacity">The maximum number of elements that the ConcurrentTLru can contain.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int capacity, TimeSpan timeToLive)
-//#if NETCOREAPP3_0_OR_GREATER
-//            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruTickCount64Policy<K, V>(timeToLive), default)
-//#else
             : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), default)
-//#endif
         {
         }
 
@@ -37,11 +29,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-//#if NETCOREAPP3_0_OR_GREATER
-//            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
-//#else
             : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
-//#endif
         {
         }
 
@@ -54,11 +42,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int concurrencyLevel, ICapacityPartition capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-//#if NETCOREAPP3_0_OR_GREATER
-//            : base(concurrencyLevel, capacity, comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
-//#else
             : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
-//#endif
         {
         }
     }

--- a/BitFaster.Caching/Lru/ConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/ConcurrentTLru.cs
@@ -7,11 +7,11 @@ namespace BitFaster.Caching.Lru
     ///<inheritdoc/>
     [DebuggerTypeProxy(typeof(CacheDebugView<,>))]
     [DebuggerDisplay("Count = {Count}/{Capacity}")]
-#if NETCOREAPP3_0_OR_GREATER
-    public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruTickCount64Policy<K, V>, TelemetryPolicy<K, V>>
-#else
-    public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, TelemetryPolicy<K, V>>
-#endif
+//#if NETCOREAPP3_0_OR_GREATER
+//    public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruTickCount64Policy<K, V>, TelemetryPolicy<K, V>>
+//#else
+    public sealed class ConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, TelemetryPolicy<K, V>>
+//#endif
     {
         /// <summary>
         /// Initializes a new instance of the ConcurrentTLru class with the specified capacity and time to live that has the default 
@@ -20,11 +20,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="capacity">The maximum number of elements that the ConcurrentTLru can contain.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int capacity, TimeSpan timeToLive)
-#if NETCOREAPP3_0_OR_GREATER
-            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruTickCount64Policy<K, V>(timeToLive), default)
-#else
-            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TlruStopwatchPolicy<K, V>(timeToLive), default)
-#endif
+//#if NETCOREAPP3_0_OR_GREATER
+//            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruTickCount64Policy<K, V>(timeToLive), default)
+//#else
+            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+//#endif
         {
         }
 
@@ -37,11 +37,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-#if NETCOREAPP3_0_OR_GREATER
-            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
-#else
-            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
-#endif
+//#if NETCOREAPP3_0_OR_GREATER
+//            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
+//#else
+            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+//#endif
         {
         }
 
@@ -54,11 +54,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public ConcurrentTLru(int concurrencyLevel, ICapacityPartition capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-#if NETCOREAPP3_0_OR_GREATER
-            : base(concurrencyLevel, capacity, comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
-#else
-            : base(concurrencyLevel, capacity, comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
-#endif
+//#if NETCOREAPP3_0_OR_GREATER
+//            : base(concurrencyLevel, capacity, comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
+//#else
+            : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+//#endif
         {
         }
     }

--- a/BitFaster.Caching/Lru/FastConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/FastConcurrentTLru.cs
@@ -7,11 +7,11 @@ namespace BitFaster.Caching.Lru
     ///<inheritdoc/>
     [DebuggerTypeProxy(typeof(CacheDebugView<,>))]
     [DebuggerDisplay("Count = {Count}/{Capacity}")]
-#if NETCOREAPP3_0_OR_GREATER
-    public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruTickCount64Policy<K, V>, NoTelemetryPolicy<K, V>>
-#else
-    public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TlruStopwatchPolicy<K, V>, NoTelemetryPolicy<K, V>>
-#endif
+//#if NETCOREAPP3_0_OR_GREATER
+//    public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruTickCount64Policy<K, V>, NoTelemetryPolicy<K, V>>
+//#else
+    public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, NoTelemetryPolicy<K, V>>
+//#endif
     {
         /// <summary>
         /// Initializes a new instance of the FastConcurrentTLru class with the specified capacity and time to live that has the default 
@@ -20,11 +20,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="capacity">The maximum number of elements that the FastConcurrentTLru can contain.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int capacity, TimeSpan timeToLive)
-#if NETCOREAPP3_0_OR_GREATER
-            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruTickCount64Policy<K, V>(timeToLive), default)
-#else
-            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TlruStopwatchPolicy<K, V>(timeToLive), default)
-#endif
+//#if NETCOREAPP3_0_OR_GREATER
+//            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruTickCount64Policy<K, V>(timeToLive), default)
+//#else
+            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+//#endif
         {
         }
 
@@ -37,11 +37,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-#if NETCOREAPP3_0_OR_GREATER
-            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
-#else
-            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
-#endif
+//#if NETCOREAPP3_0_OR_GREATER
+//            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
+//#else
+            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+//#endif
         {
         }
 
@@ -54,11 +54,11 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int concurrencyLevel, ICapacityPartition capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-#if NETCOREAPP3_0_OR_GREATER
-             : base(concurrencyLevel, capacity, comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
-#else
-             : base(concurrencyLevel, capacity, comparer, new TlruStopwatchPolicy<K, V>(timeToLive), default)
-#endif
+//#if NETCOREAPP3_0_OR_GREATER
+//             : base(concurrencyLevel, capacity, comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
+//#else
+             : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
+//#endif
         {
         }
     }

--- a/BitFaster.Caching/Lru/FastConcurrentTLru.cs
+++ b/BitFaster.Caching/Lru/FastConcurrentTLru.cs
@@ -7,11 +7,7 @@ namespace BitFaster.Caching.Lru
     ///<inheritdoc/>
     [DebuggerTypeProxy(typeof(CacheDebugView<,>))]
     [DebuggerDisplay("Count = {Count}/{Capacity}")]
-//#if NETCOREAPP3_0_OR_GREATER
-//    public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruTickCount64Policy<K, V>, NoTelemetryPolicy<K, V>>
-//#else
     public sealed class FastConcurrentTLru<K, V> : ConcurrentLruCore<K, V, LongTickCountLruItem<K, V>, TLruLongTicksPolicy<K, V>, NoTelemetryPolicy<K, V>>
-//#endif
     {
         /// <summary>
         /// Initializes a new instance of the FastConcurrentTLru class with the specified capacity and time to live that has the default 
@@ -20,11 +16,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="capacity">The maximum number of elements that the FastConcurrentTLru can contain.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int capacity, TimeSpan timeToLive)
-//#if NETCOREAPP3_0_OR_GREATER
-//            : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruTickCount64Policy<K, V>(timeToLive), default)
-//#else
             : base(Defaults.ConcurrencyLevel, new FavorWarmPartition(capacity), EqualityComparer<K>.Default, new TLruLongTicksPolicy<K, V>(timeToLive), default)
-//#endif
         {
         }
 
@@ -37,11 +29,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-//#if NETCOREAPP3_0_OR_GREATER
-//            : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
-//#else
             : base(concurrencyLevel, new FavorWarmPartition(capacity), comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
-//#endif
         {
         }
 
@@ -54,11 +42,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="comparer">The IEqualityComparer implementation to use when comparing keys.</param>
         /// <param name="timeToLive">The time to live for cached values.</param>
         public FastConcurrentTLru(int concurrencyLevel, ICapacityPartition capacity, IEqualityComparer<K> comparer, TimeSpan timeToLive)
-//#if NETCOREAPP3_0_OR_GREATER
-//             : base(concurrencyLevel, capacity, comparer, new TLruTickCount64Policy<K, V>(timeToLive), default)
-//#else
              : base(concurrencyLevel, capacity, comparer, new TLruLongTicksPolicy<K, V>(timeToLive), default)
-//#endif
         {
         }
     }

--- a/BitFaster.Caching/Lru/ITelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/ITelemetryPolicy.cs
@@ -26,6 +26,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="reason">The reason for removal.</param>
         void OnItemRemoved(K key, V value, ItemRemovedReason reason);
 
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
         /// <summary>
         /// Register the update of an item.

--- a/BitFaster.Caching/Lru/ITelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/ITelemetryPolicy.cs
@@ -26,13 +26,15 @@ namespace BitFaster.Caching.Lru
         /// <param name="reason">The reason for removal.</param>
         void OnItemRemoved(K key, V value, ItemRemovedReason reason);
 
+#if NETCOREAPP3_0_OR_GREATER
         /// <summary>
         /// Register the update of an item.
         /// </summary>
         /// <param name="key">The key.</param>
         /// <param name="oldValue">The old value.</param>
         /// <param name="value">The new value.</param>
-        void OnItemUpdated(K key, V oldValue, V value);
+        void OnItemUpdated(K key, V oldValue, V value) {}
+#endif
 
         /// <summary>
         /// Set the event source for any events that are fired.

--- a/BitFaster.Caching/Lru/StopwatchTickConverter.cs
+++ b/BitFaster.Caching/Lru/StopwatchTickConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace BitFaster.Caching.Lru
+{
+    internal static class StopwatchTickConverter
+    {
+        // On some platforms (e.g. MacOS), stopwatch and timespan have different resolution
+        private static readonly double stopwatchAdjustmentFactor = Stopwatch.Frequency / (double)TimeSpan.TicksPerSecond;
+
+        internal static long ToTicks(TimeSpan timespan)
+        {
+            // mac adjustment factor is 100, giving lowest maximum TTL on mac platform - use same upper limit on all platforms for consistency
+            // this also avoids overflow when multipling long.MaxValue by 1.0
+            double maxTicks = long.MaxValue * 0.01d;
+
+            if (timespan <= TimeSpan.Zero || timespan.Ticks >= maxTicks)
+            {
+                TimeSpan maxRepresentable = TimeSpan.FromTicks((long)maxTicks);
+                Ex.ThrowArgOutOfRange(nameof(timespan), $"Value must be greater than zero and less than {maxRepresentable}");
+            }
+
+            return (long)(timespan.Ticks * stopwatchAdjustmentFactor);
+        }
+
+        internal static TimeSpan FromTicks(long ticks)
+        {
+            return TimeSpan.FromTicks((long)(ticks / stopwatchAdjustmentFactor));
+        }
+    }
+}

--- a/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
@@ -4,6 +4,8 @@ using System.Runtime.CompilerServices;
 
 namespace BitFaster.Caching.Lru
 {
+// backcompat: remove conditional compile
+#if !NETCOREAPP3_0_OR_GREATER
     /// <summary>
     /// Time aware Least Recently Used (TLRU) is a variant of LRU which discards the least 
     /// recently used items first, and any item that has expired.
@@ -12,10 +14,9 @@ namespace BitFaster.Caching.Lru
     /// This class measures time using Stopwatch.GetTimestamp() with a resolution of ~1us.
     /// </remarks>
     [DebuggerDisplay("TTL = {TimeToLive,nq})")]
+    // backcompat: rename to TlruStopwatchPolicy
     public readonly struct TLruLongTicksPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
     {
-        // On some platforms (e.g. MacOS), stopwatch and timespan have different resolution
-        private static readonly double stopwatchAdjustmentFactor = Stopwatch.Frequency / (double)TimeSpan.TicksPerSecond;
         private readonly long timeToLive;
 
         /// <summary>
@@ -128,17 +129,7 @@ namespace BitFaster.Caching.Lru
         /// <returns>The time represented as ticks.</returns>
         public static long ToTicks(TimeSpan timespan)
         {
-            // mac adjustment factor is 100, giving lowest maximum TTL on mac platform - use same upper limit on all platforms for consistency
-            // this also avoids overflow when multipling long.MaxValue by 1.0
-            double maxTicks = long.MaxValue * 0.01d;
-
-            if (timespan <= TimeSpan.Zero || timespan.Ticks >= maxTicks)
-            {
-                TimeSpan maxRepresentable = TimeSpan.FromTicks((long)maxTicks);
-                Ex.ThrowArgOutOfRange(nameof(timespan), $"Value must be greater than zero and less than {maxRepresentable}");
-            }
-
-            return (long)(timespan.Ticks * stopwatchAdjustmentFactor);
+            return StopwatchTickConverter.ToTicks(timespan);
         }
 
         /// <summary>
@@ -148,7 +139,8 @@ namespace BitFaster.Caching.Lru
         /// <returns>The time represented as a TimeSpan.</returns>
         public static TimeSpan FromTicks(long ticks)
         {
-            return TimeSpan.FromTicks((long)(ticks / stopwatchAdjustmentFactor));
+            return StopwatchTickConverter.FromTicks(ticks);
         }
     }
+#endif
 }

--- a/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
@@ -12,7 +12,7 @@ namespace BitFaster.Caching.Lru
     /// This class measures time using Stopwatch.GetTimestamp() with a resolution of ~1us.
     /// </remarks>
     [DebuggerDisplay("TTL = {TimeToLive,nq})")]
-    public readonly struct TlruStopwatchPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
+    public readonly struct TLruLongTicksPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
     {
         // On some platforms (e.g. MacOS), stopwatch and timespan have different resolution
         private static readonly double stopwatchAdjustmentFactor = Stopwatch.Frequency / (double)TimeSpan.TicksPerSecond;
@@ -22,7 +22,7 @@ namespace BitFaster.Caching.Lru
         /// Initializes a new instance of the TLruLongTicksPolicy class with the specified time to live.
         /// </summary>
         /// <param name="timeToLive">The time to live.</param>
-        public TlruStopwatchPolicy(TimeSpan timeToLive)
+        public TLruLongTicksPolicy(TimeSpan timeToLive)
         {
             this.timeToLive = ToTicks(timeToLive);
         }

--- a/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
+++ b/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace BitFaster.Caching.Lru
 {
+// backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
     /// <summary>
     /// Time aware Least Recently Used (TLRU) is a variant of LRU which discards the least 
@@ -13,7 +15,8 @@ namespace BitFaster.Caching.Lru
     /// than both Stopwatch.GetTimestamp and DateTime.UtcNow. However, resolution is lower (typically 
     /// between 10-16ms), vs 1us for Stopwatch.GetTimestamp.
     /// </remarks>
-    public readonly struct TLruTickCount64Policy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
+    // backcompat: rename to TLruTickCount64Policy
+    public readonly struct TLruLongTicksPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
     {
         private readonly long timeToLive;
 
@@ -24,7 +27,7 @@ namespace BitFaster.Caching.Lru
         /// Initializes a new instance of the TLruTicksPolicy class with the specified time to live.
         /// </summary>
         /// <param name="timeToLive">The time to live.</param>
-        public TLruTickCount64Policy(TimeSpan timeToLive)
+        public TLruLongTicksPolicy(TimeSpan timeToLive)
         {
             TimeSpan maxRepresentable = TimeSpan.FromTicks(9223372036854769664);
             if (timeToLive <= TimeSpan.Zero || timeToLive > maxRepresentable)
@@ -124,6 +127,28 @@ namespace BitFaster.Caching.Lru
             }
 
             return ItemDestination.Remove;
+        }
+
+        /// <summary>
+        /// Convert from TimeSpan to ticks.
+        /// </summary>
+        /// <param name="timespan">The time represented as a TimeSpan.</param>
+        /// <returns>The time represented as ticks.</returns>
+        // backcompat: remove method (exists only for compatibility with orignal TLruLongTicksPolicy)
+        public static long ToTicks(TimeSpan timespan)
+        {
+            return StopwatchTickConverter.ToTicks(timespan);
+        }
+
+        /// <summary>
+        /// Convert from ticks to a TimeSpan.
+        /// </summary>
+        /// <param name="ticks">The time represented as ticks.</param>
+        /// <returns>The time represented as a TimeSpan.</returns>
+        // backcompat: remove method (exists only for compatibility with orignal TLruLongTicksPolicy)
+        public static TimeSpan FromTicks(long ticks)
+        {
+            return StopwatchTickConverter.FromTicks(ticks);
         }
     }
 #endif


### PR DESCRIPTION
Package validation reveals a number of breaking changes since v2.0.0. Use v2.0.0 as the baseline since NServiceBus.RabbitMQ 8.0.2 is built against 2.0.0 and has reference constraint of [2.0.0 - 3.0.0]. Therefore, changes could break any consumer of NServiceBus who attempted to update to the latest version of BitFaster.Caching in their application.

Summary of changes:
- Reverted change to use different TLRU time policies. Now .NET standard uses the stopwatch based policy, and .NET3.1 and .NET6 use Environment.TickCount64 based policy. This is implemented as 2 classes that have the same name, with #ifdef compilation to select as appropriate.
- New interface members are now only provided on .NET3.1 and .NET6, with default no-op implementations.
    - This removes `ICacheEvents.ItemUpdated` for .NET standard
    - This removes `ICacheMetrics.Updated` for .NET standard
- Changed abstract member added to CacheEventProxyBase to virtual, added no-op impl.
- Revert changes making some fields and methods internal rather than protected. Added requisite API docs.

**Note:** this itself is a breaking change when compared to some of the intermediate versions. It is functionally equivalent for .NET Core 3.1 and .NET 6. For .NET Standard, the item updated event and metric are removed since there is no way to introduce the functionality as a non-breaking change.

BitFaster.Caching.DependencyInjection depends on v2.1.0, this will require a rebuild to depend on 2.1.4 going forward (which is guaranteed compatible with v2.0.0 and has the features introduced in v2.1.0).

All changes have a `// backcompat` comment so they can be easily corrected as part of v3.0.0 later.