### PR TITLE
Cache interface support for factory arg

### DIFF
--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedAsyncCacheTests.cs
@@ -47,21 +47,6 @@ namespace BitFaster.Caching.UnitTests.Atomic
         }
 
         [Fact]
-        public async Task WhenKeyDoesNotExistGetOrAddArgAddsValueWithArg()
-        {
-            // TODO: move to base when interface supports factory arg
-            var c = this.cache as AtomicFactoryScopedAsyncCache<int, Disposable>;
-
-            await c.ScopedGetOrAddAsync(
-                1,
-                (k, a) => Task.FromResult(new Scoped<Disposable>(new Disposable(a))),
-                2);
-
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-            lifetime.Value.State.Should().Be(2);
-        }
-
-        [Fact]
         public async Task GetOrAddAsyncDisposedScopeThrows()
         {
             var scope = new Scoped<Disposable>(new Disposable());

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedCacheTests.cs
@@ -46,20 +46,20 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
         }
 
-        [Fact]
-        public void WhenKeyDoesNotExistGetOrAddArgAddsValueWithArg()
-        {
-            // TODO: move to base when interface supports factory arg
-            var c = this.cache as AtomicFactoryScopedCache<int, Disposable>;
+        //[Fact]
+        //public void WhenKeyDoesNotExistGetOrAddArgAddsValueWithArg()
+        //{
+        //    // TODO: move to base when interface supports factory arg
+        //    var c = this.cache as AtomicFactoryScopedCache<int, Disposable>;
 
-            c.ScopedGetOrAdd(
-                1, 
-                (k, a) => new Scoped<Disposable>(new Disposable(a)), 
-                2);
+        //    c.ScopedGetOrAdd(
+        //        1, 
+        //        (k, a) => new Scoped<Disposable>(new Disposable(a)), 
+        //        2);
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-            lifetime.Value.State.Should().Be(2);
-        }
+        //    this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+        //    lifetime.Value.State.Should().Be(2);
+        //}
 
         [Fact]
         public void GetOrAddDisposedScopeThrows()

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedCacheTests.cs
@@ -46,21 +46,6 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
         }
 
-        //[Fact]
-        //public void WhenKeyDoesNotExistGetOrAddArgAddsValueWithArg()
-        //{
-        //    // TODO: move to base when interface supports factory arg
-        //    var c = this.cache as AtomicFactoryScopedCache<int, Disposable>;
-
-        //    c.ScopedGetOrAdd(
-        //        1, 
-        //        (k, a) => new Scoped<Disposable>(new Disposable(a)), 
-        //        2);
-
-        //    this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-        //    lifetime.Value.State.Should().Be(2);
-        //}
-
         [Fact]
         public void GetOrAddDisposedScopeThrows()
         {

--- a/BitFaster.Caching.UnitTests/CacheTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheTests.cs
@@ -80,7 +80,6 @@ namespace BitFaster.Caching.UnitTests
                 return lifetime;
             };
 
-            //Func<int, Func<int, Task<int>>, ValueTask<int>> evaluate = (k, f) => new ValueTask<int>(f(k));
             cache
                 .Setup(c => c.ScopedGetOrAddAsync(It.IsAny<int>(), It.IsAny<Func<int, Task<Scoped<Disposable>>>>()))
                 .Returns(evaluate);

--- a/BitFaster.Caching.UnitTests/CacheTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheTests.cs
@@ -1,17 +1,19 @@
 ﻿
 using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
 {
+    // Tests for interface default implementations.
     public class CacheTests
     {
 // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
         [Fact]
-        public void WhenInterfaceDefaultGetOrAddFallback()
+        public void WhenCacheInterfaceDefaultGetOrAddFallback()
         {
             var cache = new Mock<ICache<int, int>>();
             cache.CallBase = true;
@@ -23,6 +25,72 @@ namespace BitFaster.Caching.UnitTests
                 1, 
                 (k, a) => k + a, 
                 2).Should().Be(3);
+        }
+
+        [Fact]
+        public async Task WhenAsyncCacheInterfaceDefaultGetOrAddFallback()
+        {
+            var cache = new Mock<IAsyncCache<int, int>>();
+            cache.CallBase = true;
+
+            Func<int, Func<int, Task<int>>, ValueTask<int>> evaluate = (k, f) => new ValueTask<int>(f(k));
+            cache.Setup(c => c.GetOrAddAsync(It.IsAny<int>(), It.IsAny<Func<int, Task<int>>>())).Returns(evaluate);
+
+             var r = await cache.Object.GetOrAddAsync(
+                1,
+                (k, a) => Task.FromResult(k + a),
+                2);
+            
+            r.Should().Be(3);
+        }
+
+        [Fact]
+        public void WhenScopedCacheInterfaceDefaultGetOrAddFallback()
+        {
+            var cache = new Mock<IScopedCache<int, Disposable>>();
+            cache.CallBase = true;
+
+            Func<int, Func<int, Scoped<Disposable>>, Lifetime<Disposable>> evaluate = (k, f) =>
+                {
+                    var scope = f(k);
+                    scope.TryCreateLifetime(out var lifetime).Should().BeTrue();
+                    return lifetime;
+                };
+
+            cache.Setup(c => c.ScopedGetOrAdd(It.IsAny<int>(), It.IsAny<Func<int, Scoped<Disposable>>>())).Returns(evaluate);
+
+            var l = cache.Object.ScopedGetOrAdd(
+                1,
+                (k, a) => new Scoped<Disposable>(new Disposable(k + a)),
+                2);
+
+            l.Value.State.Should().Be(3);
+        }
+
+        [Fact]
+        public async Task WhenScopedAsyncCacheInterfaceDefaultGetOrAddFallback()
+        {
+            var cache = new Mock<IScopedAsyncCache<int, Disposable>>();
+            cache.CallBase = true;
+
+            Func<int, Func<int, Task<Scoped<Disposable>>>, ValueTask<Lifetime<Disposable>>> evaluate = async (k, f) =>
+            {
+                var scope = await f(k);
+                scope.TryCreateLifetime(out var lifetime).Should().BeTrue();
+                return lifetime;
+            };
+
+            //Func<int, Func<int, Task<int>>, ValueTask<int>> evaluate = (k, f) => new ValueTask<int>(f(k));
+            cache
+                .Setup(c => c.ScopedGetOrAddAsync(It.IsAny<int>(), It.IsAny<Func<int, Task<Scoped<Disposable>>>>()))
+                .Returns(evaluate);
+
+            var lifetime = await cache.Object.ScopedGetOrAddAsync(
+               1,
+               (k, a) => Task.FromResult(new Scoped<Disposable>(new Disposable(k + a))),
+               2);
+
+            lifetime.Value.State.Should().Be(3);
         }
 #endif
     }

--- a/BitFaster.Caching.UnitTests/CacheTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheTests.cs
@@ -1,0 +1,29 @@
+﻿
+using System;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public class CacheTests
+    {
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public void WhenInterfaceDefaultGetOrAddFallback()
+        {
+            var cache = new Mock<ICache<int, int>>();
+            cache.CallBase = true;
+
+            Func<int, Func<int, int>, int> evaluate = (k, f) => f(k);
+            cache.Setup(c => c.GetOrAdd(It.IsAny<int>(), It.IsAny<Func<int, int>>())).Returns(evaluate);
+
+            cache.Object.GetOrAdd(
+                1, 
+                (k, a) => k + a, 
+                2).Should().Be(3);
+        }
+#endif
+    }
+}

--- a/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
@@ -83,6 +83,20 @@ namespace BitFaster.Caching.UnitTests
             lifetime.Value.Should().Be(d);
         }
 
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public async Task WhenKeyDoesNotExistGetOrAddArgAddsValueWithArg()
+        {
+            await this.cache.ScopedGetOrAddAsync(
+                1,
+                (k, a) => Task.FromResult(new Scoped<Disposable>(new Disposable(a))),
+                2);
+
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            lifetime.Value.State.Should().Be(2);
+        }
+#endif
         [Fact]
         public void WhenKeyExistsAddOrUpdateUpdatesExistingItem()
         {

--- a/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;

--- a/BitFaster.Caching.UnitTests/ScopedAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedAsyncCacheTests.cs
@@ -51,5 +51,19 @@ namespace BitFaster.Caching.UnitTests
 
             await getOrAdd.Should().ThrowAsync<InvalidOperationException>();
         }
+
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public async Task GetOrAddAsyncArgDisposedScopeThrows()
+        {
+            var scope = new Scoped<Disposable>(new Disposable());
+            scope.Dispose();
+
+            Func<Task> getOrAdd = async () => { await this.cache.ScopedGetOrAddAsync(1, (k, a) => Task.FromResult(scope), 2); };
+
+            await getOrAdd.Should().ThrowAsync<InvalidOperationException>();
+        }
+#endif
     }
 }

--- a/BitFaster.Caching.UnitTests/ScopedCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTestBase.cs
@@ -81,6 +81,21 @@ namespace BitFaster.Caching.UnitTests
             lifetime.Value.Should().Be(d);
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public void WhenKeyDoesNotExistGetOrAddArgAddsValueWithArg()
+        {
+            this.cache.ScopedGetOrAdd(
+                1,
+                (k, a) => new Scoped<Disposable>(new Disposable(a)),
+                2);
+
+            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            lifetime.Value.State.Should().Be(2);
+        }
+#endif
+
         [Fact]
         public void WhenKeyExistsAddOrUpdateUpdatesExistingItem()
         {

--- a/BitFaster.Caching/IAsyncCache.cs
+++ b/BitFaster.Caching/IAsyncCache.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace BitFaster.Caching
@@ -66,7 +64,7 @@ namespace BitFaster.Caching
         /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
         /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
         /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
-        ValueTask<V> GetOrAddAsync<TArg>(K key, Func<K, TArg, Task<V>> valueFactory, TArg factoryArgument) { throw new NotImplementedException(); }
+        ValueTask<V> GetOrAddAsync<TArg>(K key, Func<K, TArg, Task<V>> valueFactory, TArg factoryArgument) => this.GetOrAddAsync(key, k => valueFactory(k, factoryArgument)); 
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/IAsyncCache.cs
+++ b/BitFaster.Caching/IAsyncCache.cs
@@ -55,6 +55,20 @@ namespace BitFaster.Caching
         /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
         ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
 
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
+        /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
+        /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
+        ValueTask<V> GetOrAddAsync<TArg>(K key, Func<K, TArg, Task<V>> valueFactory, TArg factoryArgument) { throw new NotImplementedException(); }
+#endif
+
         /// <summary>
         /// Attempts to remove the value that has the specified key.
         /// </summary>

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -56,6 +56,21 @@ namespace BitFaster.Caching
         /// in the cache, or the new value if the key was not in the cache.</returns>
         V GetOrAdd(K key, Func<K, V> valueFactory);
 
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
+        /// existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
+        /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
+        /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
+        /// in the cache, or the new value if the key was not in the cache.</returns>
+        V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument) { throw new NotImplementedException();  }
+#endif
+
         /// <summary>
         /// Attempts to remove the value that has the specified key.
         /// </summary>

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
@@ -68,7 +65,7 @@ namespace BitFaster.Caching
         /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
         /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
         /// in the cache, or the new value if the key was not in the cache.</returns>
-        V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument) { throw new NotImplementedException();  }
+        V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument) => this.GetOrAdd(key, k => valueFactory(k, factoryArgument));
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/IScopedAsyncCache.cs
+++ b/BitFaster.Caching/IScopedAsyncCache.cs
@@ -60,6 +60,20 @@ namespace BitFaster.Caching
         /// <returns>A task that represents the asynchronous ScopedGetOrAdd operation.</returns>
         ValueTask<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
 
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
+        /// the new value, or the existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to asynchronously generate a scoped value for the key.</param>
+        /// <param name="factoryArgument"></param>
+        /// <returns>A task that represents the asynchronous ScopedGetOrAdd operation.</returns>
+        ValueTask<Lifetime<V>> ScopedGetOrAddAsync<TArg>(K key, Func<K, TArg, Task<Scoped<V>>> valueFactory, TArg factoryArgument) { throw new NotImplementedException();  }
+#endif
+
         /// <summary>
         /// Attempts to remove the value that has the specified key.
         /// </summary>

--- a/BitFaster.Caching/IScopedAsyncCache.cs
+++ b/BitFaster.Caching/IScopedAsyncCache.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace BitFaster.Caching
@@ -71,7 +69,7 @@ namespace BitFaster.Caching
         /// <param name="valueFactory">The factory function used to asynchronously generate a scoped value for the key.</param>
         /// <param name="factoryArgument"></param>
         /// <returns>A task that represents the asynchronous ScopedGetOrAdd operation.</returns>
-        ValueTask<Lifetime<V>> ScopedGetOrAddAsync<TArg>(K key, Func<K, TArg, Task<Scoped<V>>> valueFactory, TArg factoryArgument) { throw new NotImplementedException();  }
+        ValueTask<Lifetime<V>> ScopedGetOrAddAsync<TArg>(K key, Func<K, TArg, Task<Scoped<V>>> valueFactory, TArg factoryArgument) => this.ScopedGetOrAddAsync(key, (k) => valueFactory(k, factoryArgument));
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -62,6 +62,22 @@ namespace BitFaster.Caching
         /// the cache.</returns>
         Lifetime<V> ScopedGetOrAdd(K key, Func<K, Scoped<V>> valueFactory);
 
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
+        /// the new value, or the existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to generate a scoped value for the key.</param>
+        /// <param name="factoryArgument"></param>
+        /// <returns>The lifetime for the value associated with the key. The lifetime will be either reference the 
+        /// existing value for the key if the key is already in the cache, or the new value if the key was not in 
+        /// the cache.</returns>
+        Lifetime<V> ScopedGetOrAdd<TArg>(K key, Func<K, TArg, Scoped<V>> valueFactory, TArg factoryArgument) { throw new NotImplementedException(); }
+#endif
+
         /// <summary>
         /// Attempts to remove the value that has the specified key.
         /// </summary>

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
@@ -75,7 +72,7 @@ namespace BitFaster.Caching
         /// <returns>The lifetime for the value associated with the key. The lifetime will be either reference the 
         /// existing value for the key if the key is already in the cache, or the new value if the key was not in 
         /// the cache.</returns>
-        Lifetime<V> ScopedGetOrAdd<TArg>(K key, Func<K, TArg, Scoped<V>> valueFactory, TArg factoryArgument) { throw new NotImplementedException(); }
+        Lifetime<V> ScopedGetOrAdd<TArg>(K key, Func<K, TArg, Scoped<V>> valueFactory, TArg factoryArgument) => this.ScopedGetOrAdd(key, k => valueFactory(k, factoryArgument));
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/ScopedAsyncCache.cs
+++ b/BitFaster.Caching/ScopedAsyncCache.cs
@@ -85,6 +85,40 @@ namespace BitFaster.Caching
             }
         }
 
+// backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
+        /// the new value, or the existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to asynchronously generate a scoped value for the key.</param>
+        /// <param name="factoryArgument"></param>
+        /// <returns>A task that represents the asynchronous ScopedGetOrAdd operation.</returns>
+        public async ValueTask<Lifetime<V>> ScopedGetOrAddAsync<TArg>(K key, Func<K, TArg, Task<Scoped<V>>> valueFactory, TArg factoryArgument)
+        {
+            int c = 0;
+            var spinwait = new SpinWait();
+            while (true)
+            {
+                var scope = await cache.GetOrAddAsync(key, valueFactory, factoryArgument);
+
+                if (scope.TryCreateLifetime(out var lifetime))
+                {
+                    return lifetime;
+                }
+
+                spinwait.SpinOnce();
+
+                if (c++ > ScopedCacheDefaults.MaxRetry)
+                {
+                    Throw.ScopedRetryFailure();
+                }
+            }
+        }
+#endif
+
         ///<inheritdoc/>
         public bool ScopedTryGet(K key, out Lifetime<V> lifetime)
         {

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -63,11 +63,32 @@ namespace BitFaster.Caching
         ///<inheritdoc/>
         public Lifetime<V> ScopedGetOrAdd(K key, Func<K, Scoped<V>> valueFactory)
         {
+            return ScopedGetOrAdd(key, new ValueFactory<K, Scoped<V>>(valueFactory));
+        }
+
+        /// <summary>
+        /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
+        /// the new value, or the existing value if the key already exists.
+        /// </summary>
+        /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
+        /// <param name="key">The key of the element to add.</param>
+        /// <param name="valueFactory">The factory function used to generate a scoped value for the key.</param>
+        /// <param name="factoryArgument"></param>
+        /// <returns>The lifetime for the value associated with the key. The lifetime will be either reference the 
+        /// existing value for the key if the key is already in the cache, or the new value if the key was not in 
+        /// the cache.</returns>
+        public Lifetime<V> ScopedGetOrAdd<TArg>(K key, Func<K, TArg, Scoped<V>> valueFactory, TArg factoryArgument)
+        {
+            return ScopedGetOrAdd(key, new ValueFactoryArg<K, TArg, Scoped<V>>(valueFactory, factoryArgument));
+        }
+
+        private Lifetime<V> ScopedGetOrAdd<TFactory>(K key, TFactory valueFactory) where TFactory : struct, IValueFactory<K, Scoped<V>>
+        {
             int c = 0;
             var spinwait = new SpinWait();
             while (true)
             {
-                var scope = cache.GetOrAdd(key, k => valueFactory(k));
+                var scope = cache.GetOrAdd(key, k => valueFactory.Create(k));
 
                 if (scope.TryCreateLifetime(out var lifetime))
                 {


### PR DESCRIPTION
Add support for factory methods that take an argument to `ICache`, `IAsyncCache`, `IScopedCache` and `IAsyncScopedCache`.

ScopedAsyncCache does have a partial dupe method - this is a similar situation to [ConcurrentDictionary.GetOrAdd](https://source.dot.net/#System.Collections.Concurrent/System/Collections/Concurrent/ConcurrentDictionary.cs,1162) which has dupe code for each method overload in .NET framework.