### PR TITLE
even faster zipf

### DIFF
--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
@@ -65,7 +65,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
             });
 
             List<AnalysisResult> results = new List<AnalysisResult>();
-            Func<long, int> func = x => (int)x;
+            int func(long x) => (int)x;
 
             foreach (var a in analysis)
             {

--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.ThroughputAnalysis;
-using MathNet.Numerics;
-using MathNet.Numerics.Distributions;
 
 namespace BitFaster.Caching.HitRateAnalysis.Zipfian
 {
@@ -65,7 +61,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
             });
 
             List<AnalysisResult> results = new List<AnalysisResult>();
-            int func(long x) => (int)x;
+            static int func(long x) => (int)x;
 
             foreach (var a in analysis)
             {

--- a/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Zipfian/Runner.cs
@@ -54,7 +54,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
                 }
             }
 
-            int[][] zipdfDistribution = new int[sValues.Length][];
+            long[][] zipdfDistribution = new long[sValues.Length][];
 
             Parallel.ForEach(sValuesIndex, index =>
             {
@@ -65,7 +65,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
             });
 
             List<AnalysisResult> results = new List<AnalysisResult>();
-            Func<int, int> func = x => x;
+            Func<long, int> func = x => (int)x;
 
             foreach (var a in analysis)
             {
@@ -73,15 +73,15 @@ namespace BitFaster.Caching.HitRateAnalysis.Zipfian
 
                 int cacheSize = (int)(a.N * a.CacheSizePercent);
 
-                var concurrentLru = new ConcurrentLru<int, int>(1, cacheSize, EqualityComparer<int>.Default);
-                var classicLru = new ClassicLru<int, int>(1, cacheSize, EqualityComparer<int>.Default);
-                var memCache = new MemoryCacheAdaptor<int, int>(cacheSize);
-                var concurrentLfu = new ConcurrentLfu<int, int>(cacheSize);
+                var concurrentLru = new ConcurrentLru<long, int>(1, cacheSize, EqualityComparer<long>.Default);
+                var classicLru = new ClassicLru<long, int>(1, cacheSize, EqualityComparer<long>.Default);
+                var memCache = new MemoryCacheAdaptor<long, int>(cacheSize);
+                var concurrentLfu = new ConcurrentLfu<long, int>(cacheSize);
 
-                var concurrentLruScan = new ConcurrentLru<int, int>(1, cacheSize, EqualityComparer<int>.Default);
-                var classicLruScan = new ClassicLru<int, int>(1, cacheSize, EqualityComparer<int>.Default);
-                var memCacheScan = new MemoryCacheAdaptor<int, int>(cacheSize);
-                var concurrentLfuScan = new ConcurrentLfu<int, int>(cacheSize);
+                var concurrentLruScan = new ConcurrentLru<long, int>(1, cacheSize, EqualityComparer<long>.Default);
+                var classicLruScan = new ClassicLru<long, int>(1, cacheSize, EqualityComparer<long>.Default);
+                var memCacheScan = new MemoryCacheAdaptor<long, int>(cacheSize);
+                var concurrentLfuScan = new ConcurrentLfu<long, int>(cacheSize);
 
                 var d = a.s == 0.5 ? 0 : 1;
 

--- a/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
+++ b/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="EasyConsole" Version="1.1.0">
         <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
   </ItemGroup>
 

--- a/BitFaster.Caching.ThroughputAnalysis/CacheFactory.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/CacheFactory.cs
@@ -1,9 +1,6 @@
-﻿using System;
+﻿
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Scheduler;
@@ -12,7 +9,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 {
     public interface ICacheFactory
     {
-        (IScheduler, ICache<int, int>) Create(int threadCount);
+        (IScheduler, ICache<long, int>) Create(int threadCount);
 
         public string Name { get; }
 
@@ -32,9 +29,9 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public DataRow DataRow { get; set; }
 
-        public (IScheduler, ICache<int, int>) Create(int threadCount)
+        public (IScheduler, ICache<long, int>) Create(int threadCount)
         {
-            var cache = new FastConcurrentLru<int, int>(threadCount, capacity, EqualityComparer<int>.Default);
+            var cache = new FastConcurrentLru<long, int>(threadCount, capacity, EqualityComparer<long>.Default);
 
             return (null, cache);
         }
@@ -53,9 +50,9 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public DataRow DataRow { get; set; }
 
-        public (IScheduler, ICache<int, int>) Create(int threadCount)
+        public (IScheduler, ICache<long, int>) Create(int threadCount)
         {
-            var cache = new ConcurrentLru<int, int>(threadCount, capacity, EqualityComparer<int>.Default);
+            var cache = new ConcurrentLru<long, int>(threadCount, capacity, EqualityComparer<long>.Default);
 
             return (null, cache);
         }
@@ -74,9 +71,9 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public DataRow DataRow { get; set; }
 
-        public (IScheduler, ICache<int, int>) Create(int threadCount)
+        public (IScheduler, ICache<long, int>) Create(int threadCount)
         {
-            var cache = new MemoryCacheAdaptor<int, int>(capacity);
+            var cache = new MemoryCacheAdaptor<long, int>(capacity);
 
             return (null, cache);
         }
@@ -95,14 +92,14 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public DataRow DataRow { get; set; }
 
-        public (IScheduler, ICache<int, int>) Create(int threadCount)
+        public (IScheduler, ICache<long, int>) Create(int threadCount)
         {
             var scheduler = new BackgroundThreadScheduler();
-            var cache = new ConcurrentLfu<int, int>(
+            var cache = new ConcurrentLfu<long, int>(
                 concurrencyLevel: threadCount, 
                 capacity: capacity, 
                 scheduler: scheduler, 
-                EqualityComparer<int>.Default);
+                EqualityComparer<long>.Default);
 
             return (scheduler, cache);
         }
@@ -121,9 +118,9 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public DataRow DataRow { get; set; }
 
-        public (IScheduler, ICache<int, int>) Create(int threadCount)
+        public (IScheduler, ICache<long, int>) Create(int threadCount)
         {
-            var cache = new ClassicLru<int, int>(threadCount, capacity, EqualityComparer<int>.Default);
+            var cache = new ClassicLru<long, int>(threadCount, capacity, EqualityComparer<long>.Default);
 
             return (null, cache);
         }

--- a/BitFaster.Caching.ThroughputAnalysis/CacheFactory.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/CacheFactory.cs
@@ -18,7 +18,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class FastConcurrentLruFactory : ICacheFactory
     {
-        private int capacity;
+        private readonly int capacity;
 
         public FastConcurrentLruFactory(int capacity)
         {
@@ -39,7 +39,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class ConcurrentLruFactory : ICacheFactory
     {
-        private int capacity;
+        private readonly int capacity;
 
         public ConcurrentLruFactory(int capacity)
         {
@@ -60,7 +60,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class MemoryCacheFactory : ICacheFactory
     {
-        private int capacity;
+        private readonly int capacity;
 
         public MemoryCacheFactory(int capacity)
         {
@@ -81,7 +81,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class ConcurrentLfuFactory : ICacheFactory
     {
-        private int capacity;
+        private readonly int capacity;
 
         public ConcurrentLfuFactory(int capacity)
         {
@@ -107,7 +107,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class ClassicLruFactory : ICacheFactory
     {
-        private int capacity;
+        private readonly int capacity;
 
         public ClassicLruFactory(int capacity)
         {

--- a/BitFaster.Caching.ThroughputAnalysis/ConfigFactory.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ConfigFactory.cs
@@ -51,7 +51,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             _ => cacheSize
         };
 
-        private static void EvictionInit(ICache<int, int> cache)
+        private static void EvictionInit(ICache<long, int> cache)
         {
             Parallel.ForEach(Enumerable.Range(0, cache.Policy.Eviction.Value.Capacity).Select(i => -i), i =>
             {

--- a/BitFaster.Caching.ThroughputAnalysis/ConfigFactory.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ConfigFactory.cs
@@ -22,7 +22,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     return (new ReadThroughputBenchmark(), new ZipfConfig(iterations, samples, s, n), cacheSize);
                 case Mode.ReadWrite:
                     // cache holds 10% of all items
-                    cacheSize = cacheSize / 10;
+                    cacheSize /= 10;
                     return (new ReadThroughputBenchmark(), new ZipfConfig(iterations, samples, s, n), cacheSize);
                 case Mode.Update:
                     return (new UpdateThroughputBenchmark(), new ZipfConfig(iterations, samples, s, n), cacheSize);

--- a/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
@@ -8,7 +8,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
     /// </summary>
     public class FastZipf
     {
-        static Random srandom = new Random(666);
+        private static readonly Random srandom = new(666);
 
         /// <summary>
         /// Generate a zipf distribution.

--- a/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
@@ -26,6 +26,13 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
             double num2 = 1.0 / SpecialFunctions.GeneralHarmonic(n, s);
 
+            // Precompute pow for all i, take reciprocal so that we can multiply instead of divide inside the loop
+            double[] rpows = new double[n+1];
+            for (int i = 0; i <= n; i++)
+            {
+                rpows[i] = 1.0d / Math.Pow(i, s);
+            }
+
             Parallel.ForEach(Enumerable.Range(0, samples.Length), (x, j) =>
             {
                 double num3 = 0.0;
@@ -33,7 +40,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
                 for (i = 1; i <= n; i++)
                 {
-                    num3 += num2 / Math.Pow(i, s);
+                    num3 += num2 * rpows[i]; // Math.Pow(i, s);
                     if (num3 >= num[x])
                     {
                         break;

--- a/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
@@ -1,61 +1,84 @@
 ﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using MathNet.Numerics;
 
 namespace BitFaster.Caching.ThroughputAnalysis
 {
-    // produces the same output as MathNet.Numerics Zipf.Samples(random, samples[], s, n)
-    // but about 20x faster.
+    /// <summary>
+    /// Generates an approximate Zipf distribution. Previous method was 20x faster than MathNet.Numerics, but could only generate 250 samples/sec.
+    /// This approximate method can generate > 1,000,000 samples/sec.
+    /// </summary>
     public class FastZipf
     {
         static Random srandom = new Random(666);
 
-        public static int[] Generate(Random random, int sampleCount, double s, int n)
+        /// <summary>
+        /// Generate a zipf distribution.
+        /// </summary>
+        /// <param name="random">The random number generator to use.</param>
+        /// <param name="sampleCount">The number of samples.</param>
+        /// <param name="s">The skew. s=0 is a uniform distribution. As s increases, high-rank items become rapidly more likely than the rare low-ranked items.</param>
+        /// <param name="n">N: the cardinality. The total number of items.</param>
+        /// <returns>A zipf distribution.</returns>
+        public static long[] Generate(Random random, int sampleCount, double s, int n)
         {
-            double[] num = new double[sampleCount];
-            int[] samples = new int[sampleCount];
+            ZipfRejectionSampler sampler = new ZipfRejectionSampler(random, n, s);
 
+            long[] samples = new long[sampleCount];
             for (int i = 0; i < sampleCount; i++)
             {
-                while (num[i] == 0.0)
-                {
-                    num[i] = random.NextDouble();
-                }
+                samples[i] = sampler.Sample();
             }
-
-            double num2 = 1.0 / SpecialFunctions.GeneralHarmonic(n, s);
-
-            // Precompute pow for all i, take reciprocal so that we can multiply instead of divide inside the loop
-            double[] rpows = new double[n+1];
-            for (int i = 0; i <= n; i++)
-            {
-                rpows[i] = 1.0d / Math.Pow(i, s);
-            }
-
-            Parallel.ForEach(Enumerable.Range(0, samples.Length), (x, j) =>
-            {
-                double num3 = 0.0;
-                int i;
-
-                for (i = 1; i <= n; i++)
-                {
-                    num3 += num2 * rpows[i]; // Math.Pow(i, s);
-                    if (num3 >= num[x])
-                    {
-                        break;
-                    }
-                }
-
-                samples[x] = i;
-            });
 
             return samples;
         }
 
-        public static int[] Generate(int sampleCount, double s, int n)
+        /// <summary>
+        /// Generate a zipf distribution.
+        /// </summary>
+        /// <param name="sampleCount">The number of samples.</param>
+        /// <param name="s">The skew. s=0 is a uniform distribution. As s increases, high-rank items become rapidly more likely than the rare low-ranked items.</param>
+        /// <param name="n">N: the cardinality. The total number of items.</param>
+        /// <returns>A zipf distribution.</returns>
+        public static long[] Generate(int sampleCount, double s, int n)
         {
             return Generate(srandom, sampleCount, s, n);
+        }
+    }
+
+    // https://jasoncrease.medium.com/rejection-sampling-the-zipf-distribution-6b359792cffa
+    public class ZipfRejectionSampler
+    {
+        private readonly Random _rand;
+        private readonly double _skew;
+        private readonly double _t;
+
+        public ZipfRejectionSampler(Random random, long N, double skew)
+        {
+            _rand = random;
+            _skew = skew;
+            _t = (Math.Pow(N, 1 - skew) - skew) / (1 - skew);
+        }
+
+        public long Sample()
+        {
+            while (true)
+            {
+                double invB = bInvCdf(_rand.NextDouble());
+                long sampleX = (long)(invB + 1);
+                double yRand = _rand.NextDouble();
+                double ratioTop = Math.Pow(sampleX, -_skew);
+                double ratioBottom = sampleX <= 1 ? 1 / _t : Math.Pow(invB, -_skew) / _t;
+                double rat = (ratioTop) / (ratioBottom * _t);
+
+                if (yRand < rat)
+                    return sampleX;
+            }
+        }
+        private double bInvCdf(double p)
+        {
+            if (p * _t <= 1)
+                return p * _t;
+            else
+                return Math.Pow((p * _t) * (1 - _skew) + _skew, 1 / (1 - _skew));
         }
     }
 }

--- a/BitFaster.Caching.ThroughputAnalysis/Program.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Program.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using BitFaster.Caching.ThroughputAnalysis;
-using Iced.Intel;
-using MathNet.Numerics.Distributions;
 
 Host.PrintInfo();
 

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -29,12 +29,14 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
             var (bench, dataConfig, capacity) = ConfigFactory.Create(mode, cacheSize, maxThreads);
 
-            var cachesToTest = new List<ICacheFactory>();
-            cachesToTest.Add(new ClassicLruFactory(capacity));
-            cachesToTest.Add(new MemoryCacheFactory(capacity));
-            cachesToTest.Add(new FastConcurrentLruFactory(capacity));
-            cachesToTest.Add(new ConcurrentLruFactory(capacity));
-            cachesToTest.Add(new ConcurrentLfuFactory(capacity));
+            var cachesToTest = new List<ICacheFactory>
+            {
+                new ClassicLruFactory(capacity),
+                new MemoryCacheFactory(capacity),
+                new FastConcurrentLruFactory(capacity),
+                new ConcurrentLruFactory(capacity),
+                new ConcurrentLfuFactory(capacity)
+            };
 
             var exporter = new Exporter(maxThreads);
             exporter.Initialize(cachesToTest);
@@ -57,7 +59,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     (sched as IDisposable)?.Dispose();
 
                     cacheConfig.DataRow[tc.ToString()] = thru.ToString();
-                    Console.WriteLine($"{cacheConfig.Name} ({tc.ToString("00")}) {FormatThroughput(thru)} million ops/sec");
+                    Console.WriteLine($"{cacheConfig.Name} ({tc:00}) {FormatThroughput(thru)} million ops/sec");
                 }
             }
 

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
@@ -18,8 +18,8 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class ZipfConfig : IThroughputBenchConfig
     {
-        private int iterations;
-        private long[] samples;
+        private readonly int iterations;
+        private readonly long[] samples;
 
         public ZipfConfig(int iterations, int sampleCount, double s, int n)
         {
@@ -40,9 +40,9 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class EvictionConfig : IThroughputBenchConfig
     {
-        private int iterations;
+        private readonly int iterations;
 
-        private long[][] samples;
+        private readonly long[][] samples;
 
         const int maxSamples = 10_000_000;
 
@@ -50,7 +50,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
         {
             if (sampleCount > maxSamples)
             {
-                throw new ArgumentOutOfRangeException("Sample count too large, will result in overlap");
+                throw new ArgumentOutOfRangeException(nameof(sampleCount), "Sample count too large, will result in overlap");
             }
 
             this.iterations = iterations;

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using MathNet.Numerics.Distributions;
 
 namespace BitFaster.Caching.ThroughputAnalysis
 {

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
@@ -13,13 +13,13 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         int Samples { get; }
 
-        int[] GetTestData(int threadId);
+        long[] GetTestData(int threadId);
     }
 
     public class ZipfConfig : IThroughputBenchConfig
     {
         private int iterations;
-        private int[] samples;
+        private long[] samples;
 
         public ZipfConfig(int iterations, int sampleCount, double s, int n)
         {
@@ -32,7 +32,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public int Samples => samples.Length;
 
-        public int[] GetTestData(int threadId)
+        public long[] GetTestData(int threadId)
         {
             return samples;
         }
@@ -42,7 +42,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
     {
         private int iterations;
 
-        private int[][] samples;
+        private long[][] samples;
 
         const int maxSamples = 10_000_000;
 
@@ -54,11 +54,11 @@ namespace BitFaster.Caching.ThroughputAnalysis
             }
 
             this.iterations = iterations;
-            samples = new int[threadCount][];
+            samples = new long[threadCount][];
 
             Parallel.ForEach(Enumerable.Range(0, threadCount), i =>
             {
-                samples[i] = Enumerable.Range(i * maxSamples, sampleCount).ToArray();
+                samples[i] = Enumerable.Range(i * maxSamples, sampleCount).Cast<long>().ToArray();
             });
         }
 
@@ -66,7 +66,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public int Samples => samples[0].Length;
 
-        public int[] GetTestData(int threadId)
+        public long[] GetTestData(int threadId)
         {
             return samples[threadId];
         }

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
@@ -58,7 +58,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
             Parallel.ForEach(Enumerable.Range(0, threadCount), i =>
             {
-                samples[i] = Enumerable.Range(i * maxSamples, sampleCount).Cast<long>().ToArray();
+                samples[i] = Enumerable.Range(i * maxSamples, sampleCount).Select(i => (long)i).ToArray();
             });
         }
 

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -49,10 +49,10 @@ namespace BitFaster.Caching.ThroughputAnalysis
     {
         protected override double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
-            Action<int> action = index => 
+            void action(int index)
             {
                 long[] samples = config.GetTestData(index);
-                Func<long, int> func = x => (int)x;
+                int func(long x) => (int)x;
 
                 for (int i = 0; i < config.Iterations; i++)
                 {
@@ -61,7 +61,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                         cache.GetOrAdd(samples[s], func);
                     }
                 }
-            };
+            }
 
             var time = ParallelBenchmark.Run(action, threads);
 
@@ -74,7 +74,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
     {
         protected override double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
-            Action<int> action = index =>
+            void action(int index)
             {
                 long[] samples = config.GetTestData(index);
 
@@ -85,7 +85,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                         cache.AddOrUpdate(samples[s], (int)samples[s]);
                     }
                 }
-            };
+            }
 
             var time = ParallelBenchmark.Run(action, threads);
 

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -13,9 +13,9 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public abstract class ThroughputBenchmarkBase
     {
-        public Action<ICache<int, int>> Initialize { get; set; }
+        public Action<ICache<long, int>> Initialize { get; set; }
 
-        public double Run(int warmup, int runs, int threads, IThroughputBenchConfig config, ICache<int, int> cache)
+        public double Run(int warmup, int runs, int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
             double[] results = new double[warmup + runs];
 
@@ -31,7 +31,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             return AverageLast(results, runs) / oneMillion;
         }
 
-        protected abstract double Run(int threads, IThroughputBenchConfig config, ICache<int, int> cache);
+        protected abstract double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache);
 
         private static double AverageLast(double[] results, int count)
         {
@@ -47,12 +47,12 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class ReadThroughputBenchmark : ThroughputBenchmarkBase
     {
-        protected override double Run(int threads, IThroughputBenchConfig config, ICache<int, int> cache)
+        protected override double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
             Action<int> action = index => 
             {
-                int[] samples = config.GetTestData(index);
-                Func<int, int> func = x => x;
+                long[] samples = config.GetTestData(index);
+                Func<long, int> func = x => (int)x;
 
                 for (int i = 0; i < config.Iterations; i++)
                 {
@@ -72,17 +72,17 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class UpdateThroughputBenchmark : ThroughputBenchmarkBase
     {
-        protected override double Run(int threads, IThroughputBenchConfig config, ICache<int, int> cache)
+        protected override double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
             Action<int> action = index =>
             {
-                int[] samples = config.GetTestData(index);
+                long[] samples = config.GetTestData(index);
 
                 for (int i = 0; i < config.Iterations; i++)
                 {
                     for (int s = 0; s < samples.Length; s++)
                     {
-                        cache.AddOrUpdate(samples[s], samples[s]);
+                        cache.AddOrUpdate(samples[s], (int)samples[s]);
                     }
                 }
             };


### PR DESCRIPTION
With the original method when n == 100_000_000 my machine can compute about 250 zipf samples per second, so it would take about 4.6 days to compute all samples. The old method is n^2 complexity, so its very slow for large n.

Switched to this method:
https://jasoncrease.medium.com/zipf-54912d5651cc

Now 100_000_000 samples takes about 10-25 seconds running on a single thread. The output distribution is not identical so previous throughput results are not directly comparable: throughput measurements are about 5% lower, but have the same relative ranking.

Additional changes:
- Cache key is now long, since new code generates long values.
- Fixed various build warnings.