### PR TITLE
unbounded

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -522,7 +522,6 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.TryGet(0, out var value).Should().BeFalse();
         }
 
-        // logic change means that touched item can no longer return to warm from cold
         [Fact]
         public void WhenValueIsTouchedAndExpiresFromWarmValueIsBumpedBackIntoWarm()
         {

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -355,7 +355,9 @@ namespace BitFaster.Caching.UnitTests.Lru
             private readonly List<object[]> _data = new List<object[]>
             {
                 new object[] { new EqualCapacityPartition(hotCap + warmCap + coldCap) },
-                //new object[] { new FavorWarmPartition(128, 0.6) },
+                new object[] { new FavorWarmPartition(128) },
+                new object[] { new FavorWarmPartition(256) },
+                new object[] { new FavorWarmPartition(128, 0.6) },
                 new object[] { new FavorWarmPartition(256, 0.6) },
             };
 

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -522,7 +522,7 @@ namespace BitFaster.Caching.Lru
             {
                 (var dest, var count) = CycleHot(hotCount);
 
-                int maxAttempts = this.capacity.Cold + 1;
+                int maxAttempts = this.capacity.Cold + 2;
                 int attempts = 0;
 
                 while (attempts++ < maxAttempts)

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -522,7 +522,7 @@ namespace BitFaster.Caching.Lru
             {
                 (var dest, var count) = CycleHot(hotCount);
 
-                int maxAttempts = this.capacity.Cold + 2;
+                int maxAttempts = 5;
                 int attempts = 0;
 
                 while (attempts++ < maxAttempts)
@@ -555,6 +555,14 @@ namespace BitFaster.Caching.Lru
 
                         break;
                     }
+                }
+
+                if (attempts == maxAttempts && dest != ItemDestination.Remove)
+                {
+                    // If we get here, we have cycled the queues multiple times and still have not removed an item.
+                    // This can happen if the cache is full of items that are not discardable. In this case, we simply
+                    // discard the coldest item to avoid unbounded growth.
+                    TryRemoveCold(ItemRemovedReason.Evicted);
                 }
             }
             else

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -522,7 +522,7 @@ namespace BitFaster.Caching.Lru
             {
                 (var dest, var count) = CycleHot(hotCount);
 
-                const int maxAttempts = 5;
+                int maxAttempts = this.capacity.Cold + 1;
                 int attempts = 0;
 
                 while (attempts++ < maxAttempts)

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -563,7 +563,7 @@ namespace BitFaster.Caching.Lru
                 // discard the coldest item to avoid unbounded growth.
                 if (attempts == maxAttempts && dest != ItemDestination.Remove)
                 {
-                    // if an item was last moved into warm, move the last warm item to cold to prevent an infinite cycle
+                    // if an item was last moved into warm, move the last warm item to cold to prevent enlarging warm
                     if (dest == ItemDestination.Warm)
                     {
                         LastWarmToCold();

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -522,7 +522,7 @@ namespace BitFaster.Caching.Lru
             {
                 (var dest, var count) = CycleHot(hotCount);
 
-                int maxAttempts = 5;
+                const int maxAttempts = 5;
                 int attempts = 0;
 
                 while (attempts++ < maxAttempts)


### PR DESCRIPTION
Fix unbounded LRU growth when keys are requested in order. Added better parameterized tests to detect this.

I had introduced a bug in the cycle/tryremovecold method: when warm queue is full the last cold item should be discarded immediately.

When cache size is below 1000, element count is now constrained to capacity +1 (we allow warm queue to be capacity+1, enabling items to re-enter warm). When cache size is above 1000, element count is constrained to at worst capacity + 5. Experimentally, this matches the number of cycle attempts (which is currently 5). This is a bug that results in at most a 0.5% capacity overage, so much better than prior to the fix.