### PR TITLE
remove coldest when full

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -364,7 +364,6 @@ namespace BitFaster.Caching.UnitTests.Lru
                 new object[] { new FavorWarmPartition(128, 0.6) },
                 new object[] { new FavorWarmPartition(256, 0.6) },
                 new object[] { new FavorWarmPartition(1024, 0.6) },
-               // new object[] { new FavorWarmPartition(16384, 0.6) },
             };
 
             public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -364,8 +364,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 new object[] { new FavorWarmPartition(128, 0.6) },
                 new object[] { new FavorWarmPartition(256, 0.6) },
                 new object[] { new FavorWarmPartition(1024, 0.6) },
-                new object[] { new FavorWarmPartition(10*1024, 0.6) },
-                //new object[] { new FavorWarmPartition(100*1024, 0.6) },
+                new object[] { new FavorWarmPartition(16384, 0.6) },
             };
 
             public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -364,7 +364,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 new object[] { new FavorWarmPartition(128, 0.6) },
                 new object[] { new FavorWarmPartition(256, 0.6) },
                 new object[] { new FavorWarmPartition(1024, 0.6) },
-                new object[] { new FavorWarmPartition(16384, 0.6) },
+               // new object[] { new FavorWarmPartition(16384, 0.6) },
             };
 
             public IEnumerator<object[]> GetEnumerator() => _data.GetEnumerator();

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -364,7 +364,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 new object[] { new FavorWarmPartition(128, 0.6) },
                 new object[] { new FavorWarmPartition(256, 0.6) },
                 new object[] { new FavorWarmPartition(1024, 0.6) },
-                //new object[] { new FavorWarmPartition(10*1024, 0.6) },
+                new object[] { new FavorWarmPartition(10*1024, 0.6) },
                 //new object[] { new FavorWarmPartition(100*1024, 0.6) },
             };
 
@@ -393,13 +393,9 @@ namespace BitFaster.Caching.UnitTests.Lru
                 {
                     lru.GetOrAdd(j, valueFactory.Create);
                 }
-            }
 
-            // For larger cache sizes, I have observed capacity + 5. This is linked to the number of attempts.
-            // This is clearly a bug that needs further investigation, but considered not harmful at this point
-            // since growth is bounded, we just allow 4 more items than we should in the absolute worst case.
-            testOutputHelper.WriteLine($"Total: {lru.Count} Hot: {lru.HotCount} Warm: {lru.WarmCount} Cold: {lru.ColdCount}");
-            lru.Count.Should().BeLessOrEqualTo(capacity + 1);
+                lru.Count.Should().BeLessOrEqualTo(capacity + 1, $"Total: {lru.Count} Hot: {lru.HotCount} Warm: {lru.WarmCount} Cold: {lru.ColdCount}");
+            }
         }
 
         [Fact]

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -561,7 +561,7 @@ namespace BitFaster.Caching.Lru
                 // If we get here, we have cycled the queues multiple times and still have not removed an item.
                 // This can happen if the cache is full of items that are not discardable. In this case, we simply
                 // discard the coldest item to avoid unbounded growth.
-                if (/*attempts == maxAttempts &&*/ dest != ItemDestination.Remove)
+                if (dest != ItemDestination.Remove)
                 {
                     // if an item was last moved into warm, move the last warm item to cold to prevent enlarging warm
                     if (dest == ItemDestination.Warm)

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -542,13 +542,13 @@ namespace BitFaster.Caching.Lru
                         // so this process has races that could reduce cache size below capacity. This manifests
                         // in 'off by one' which is considered harmless.
 
-                        (dest, count) = CycleWarm(Volatile.Read(ref counter.cold));
+                        (dest, count) = CycleCold(Volatile.Read(ref counter.cold));
                         if (dest != ItemDestination.Remove)
                         {
                             continue;
                         }
 
-                        (dest, count) = CycleCold(Volatile.Read(ref counter.warm));
+                        (dest, count) = CycleWarm(Volatile.Read(ref counter.warm));
                         if (dest != ItemDestination.Remove)
                         {
                             continue;

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -557,12 +557,40 @@ namespace BitFaster.Caching.Lru
                         break;
                     }
                 }
+
+                // If we get here, we have cycled the queues multiple times and still have not removed an item.
+                // This can happen if the cache is full of items that are not discardable. In this case, we simply
+                // discard the coldest item to avoid unbounded growth.
+                if (/*attempts == maxAttempts &&*/ dest != ItemDestination.Remove)
+                {
+                    // if an item was last moved into warm, move the last warm item to cold to prevent enlarging warm
+                    if (dest == ItemDestination.Warm)
+                    {
+                        LastWarmToCold();
+                    }
+
+                    RemoveCold(ItemRemovedReason.Evicted);
+                }
             }
             else
             {
                 // fill up the warm queue with new items until warm is full.
                 // else during warmup the cache will only use the hot + cold queues until any item is requested twice.
                 CycleDuringWarmup(hotCount);
+            }
+        }
+
+        private void LastWarmToCold()
+        {
+            Interlocked.Decrement(ref this.counter.warm);
+
+            if (this.hotQueue.TryDequeue(out var item))
+            {
+                this.Move(item, ItemDestination.Cold, ItemRemovedReason.Evicted);
+            }
+            else
+            {
+                Interlocked.Increment(ref this.counter.warm);
             }
         }
 
@@ -695,6 +723,20 @@ namespace BitFaster.Caching.Lru
             else
             {
                 return (ItemDestination.Cold, Interlocked.Increment(ref this.counter.cold));
+            }
+        }
+
+        private void RemoveCold(ItemRemovedReason removedReason) 
+        {
+            Interlocked.Decrement(ref this.counter.cold);
+
+            if (this.coldQueue.TryDequeue(out var item))
+            {
+                 this.Move(item, ItemDestination.Remove, removedReason);
+            }
+            else
+            {
+                Interlocked.Increment(ref this.counter.cold);
             }
         }
 

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -542,13 +542,13 @@ namespace BitFaster.Caching.Lru
                         // so this process has races that could reduce cache size below capacity. This manifests
                         // in 'off by one' which is considered harmless.
 
-                        (dest, count) = CycleCold(Volatile.Read(ref counter.cold));
+                        (dest, count) = CycleWarm(Volatile.Read(ref counter.cold));
                         if (dest != ItemDestination.Remove)
                         {
                             continue;
                         }
 
-                        (dest, count) = CycleWarm(Volatile.Read(ref counter.warm));
+                        (dest, count) = CycleCold(Volatile.Read(ref counter.warm));
                         if (dest != ItemDestination.Remove)
                         {
                             continue;


### PR DESCRIPTION
Fix cycle logic so that if all items are touched when a new item is added (thus the coldest is cycled back into warm) we simply discard the coldest cache item (last item in cold queue).