### PR TITLE
soak tests to increase code coverage

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -1127,6 +1127,26 @@ namespace BitFaster.Caching.UnitTests.Lru
             }
         }
 
+        [Fact]
+        public async Task WhenItemsAreScannedInParallel3()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await Threaded.Run(4, () => {
+                    for (int i = 0; i < 100000; i++)
+                    {
+                        lru.TryUpdate(i + 1, i.ToString());
+                        lru.GetOrAdd(i + 1, i => i.ToString());
+                    }
+                });
+
+                this.testOutputHelper.WriteLine($"{lru.HotCount} {lru.WarmCount} {lru.ColdCount}");
+                this.testOutputHelper.WriteLine(string.Join(" ", lru.Keys));
+
+                lru.Count.Should().BeLessThanOrEqualTo(9);
+            }
+        }
+
         private void Warmup()
         {
             lru.GetOrAdd(-1, valueFactory.Create);

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -1260,6 +1260,9 @@ namespace BitFaster.Caching.UnitTests.Lru
                 if (item.WasRemoved)
                 {
                     cache.TryGet(item.Key, out var value).Should().BeFalse($"{queueName} removed item {item.Key} was not removed");
+
+                    // TODO: it is possible for the queues to contain 2 instances of the same key/item. One that was removed, and one that was added after the other was removed.
+                    // In this case, the dictionary may contain the value.
                 }
                 else
                 {

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -1090,17 +1090,41 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public async Task WhenItemsAreScannedInParallelCapacityIsNotExceeded()
         {
-            await Threaded.Run(4, () => {
-                for (int i = 0; i < 100000; i++)
-                {
-                    lru.GetOrAdd(i + 1, i =>i.ToString());
-                }
-            });
+            for (int i = 0; i < 10; i++)
+            { 
+                await Threaded.Run(4, () => {
+                    for (int i = 0; i < 100000; i++)
+                    {
+                        lru.GetOrAdd(i + 1, i =>i.ToString());
+                    }
+                });
 
-            this.testOutputHelper.WriteLine($"{lru.HotCount} {lru.WarmCount} {lru.ColdCount}");
+                this.testOutputHelper.WriteLine($"{lru.HotCount} {lru.WarmCount} {lru.ColdCount}");
+                this.testOutputHelper.WriteLine(string.Join(" ", lru.Keys));
 
-            // allow +/- 1 variance for capacity
-            lru.Count.Should().BeCloseTo(9, 1);
+                // allow +/- 1 variance for capacity
+                lru.Count.Should().BeCloseTo(9, 1);
+            }
+        }
+
+        [Fact]
+        public async Task WhenItemsAreScannedInParallel2()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await Threaded.Run(4, () => {
+                    for (int i = 0; i < 100000; i++)
+                    {
+                        lru.TryRemove(i + 1);
+                        lru.GetOrAdd(i + 1, i => i.ToString());
+                    }
+                });
+
+                this.testOutputHelper.WriteLine($"{lru.HotCount} {lru.WarmCount} {lru.ColdCount}");
+                this.testOutputHelper.WriteLine(string.Join(" ", lru.Keys));
+
+                lru.Count.Should().BeLessThanOrEqualTo(9);
+            }
         }
 
         private void Warmup()

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -1245,25 +1245,25 @@ namespace BitFaster.Caching.UnitTests.Lru
             this.coldQueue.Count.Should().Be(cache.ColdCount, "cold queue has a corrupted count");
 
             // cache contents must be consistent with queued items
-            ValidateQueue(cache, this.hotQueue);
-            ValidateQueue(cache, this.warmQueue);
-            ValidateQueue(cache, this.coldQueue);
+            ValidateQueue(cache, this.hotQueue, "hot");
+            ValidateQueue(cache, this.warmQueue, "warm");
+            ValidateQueue(cache, this.coldQueue, "cold");
 
             // cache must be within capacity
             cache.Count.Should().BeLessThanOrEqualTo(cache.Capacity + 1, "capacity out of valid range");
         }
 
-        private static void ValidateQueue(ConcurrentLruCore<K, V, I, P, T> cache, ConcurrentQueue<I> queue)
+        private static void ValidateQueue(ConcurrentLruCore<K, V, I, P, T> cache, ConcurrentQueue<I> queue, string queueName)
         {
             foreach (var item in queue)
             {
                 if (item.WasRemoved)
                 {
-                    cache.TryGet(item.Key, out var value).Should().BeFalse();
+                    cache.TryGet(item.Key, out var value).Should().BeFalse($"{queueName} removed item {item.Key} was not removed");
                 }
                 else
                 {
-                    cache.TryGet(item.Key, out var value).Should().BeTrue();
+                    cache.TryGet(item.Key, out var value).Should().BeTrue($"{queueName} item {item.Key} was not present");
                 }
             }
         }

--- a/BitFaster.Caching.UnitTests/Threaded.cs
+++ b/BitFaster.Caching.UnitTests/Threaded.cs
@@ -33,5 +33,30 @@ namespace BitFaster.Caching.UnitTests
 
             await Task.WhenAll(tasks);
         }
+
+        public static Task RunAsync(int threadCount, Func<Task> action)
+        {
+            return Run(threadCount, i => action());
+        }
+
+        public static async Task RunAsync(int threadCount, Func<int, Task> action)
+        {
+            var tasks = new Task[threadCount];
+            ManualResetEvent mre = new ManualResetEvent(false);
+
+            for (int i = 0; i < threadCount; i++)
+            {
+                int run = i;
+                tasks[i] = Task.Run(async () =>
+                {
+                    mre.WaitOne();
+                    await action(run);
+                });
+            }
+
+            mre.Set();
+
+            await Task.WhenAll(tasks);
+        }
     }
 }


### PR DESCRIPTION
After updating the visual studio test runner package, code coverage has dropped. Try adding tests to cover race condition guard code that is hard to reach. 

These are now soak tests where we verify integrity at the end - should they be in a different file/different name?