### PR TITLE
debug coverage

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Debug --no-restore
 
     - name: Test (4.8)
       run: dotnet test --no-restore --verbosity normal -f net48 --logger "trx;LogFileName=results4.trx"
@@ -81,7 +81,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: NuGet package
-        path: BitFaster.Caching/bin/Release/
+        path: BitFaster.Caching/bin/Debug/
 
   mac:
 
@@ -99,7 +99,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Debug --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results.trx"
     - name: Publish coverage report to coveralls.io   

--- a/BitFaster.Caching/Throw.cs
+++ b/BitFaster.Caching/Throw.cs
@@ -9,8 +9,14 @@ namespace BitFaster.Caching
     {
         public static void ArgNull(ExceptionArgument arg) => throw CreateArgumentNullException(arg);
 
+#if NETCOREAPP3_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         public static void ArgOutOfRange(string paramName) => throw CreateArgumentOutOfRangeException(paramName);
 
+#if NETCOREAPP3_0_OR_GREATER
+        [DoesNotReturn]
+#endif
         public static void ArgOutOfRange(string paramName, string message) => throw CreateArgumentOutOfRangeException(paramName, message);
 
         [ExcludeFromCodeCoverage]


### PR DESCRIPTION
NOT FOR CHECK IN: this makes the NuGet package contain a debug build, which is bad.

Try switching to debug build to see if closing braces etc. are now classed as covered by code coverage. This was mentioned as needed in an issue with uncovered closing braces in the coverlet repo.