### PR TITLE
rem braces

### DIFF
--- a/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
@@ -26,9 +26,7 @@ namespace BitFaster.Caching.Atomic
         public AtomicFactoryAsyncCache(ICache<K, AsyncAtomicFactory<K, V>> cache)
         {
             if (cache == null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
 

--- a/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
@@ -24,9 +24,7 @@ namespace BitFaster.Caching.Atomic
         public AtomicFactoryCache(ICache<K, AtomicFactory<K, V>> cache)
         {
             if (cache == null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
 

--- a/BitFaster.Caching/Atomic/AtomicFactoryScopedAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryScopedAsyncCache.cs
@@ -26,9 +26,7 @@ namespace BitFaster.Caching.Atomic
         public AtomicFactoryScopedAsyncCache(ICache<K, ScopedAsyncAtomicFactory<K, V>> cache)
         {
             if (cache == null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
             if (cache.Events.HasValue)
@@ -106,9 +104,7 @@ namespace BitFaster.Caching.Atomic
                 spinwait.SpinOnce();
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
-                {
                     Throw.ScopedRetryFailure();
-                }
             }
         }
 

--- a/BitFaster.Caching/Atomic/AtomicFactoryScopedCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryScopedCache.cs
@@ -25,9 +25,7 @@ namespace BitFaster.Caching.Atomic
         public AtomicFactoryScopedCache(ICache<K, ScopedAtomicFactory<K, V>> cache)
         {
             if (cache == null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
             
@@ -106,9 +104,7 @@ namespace BitFaster.Caching.Atomic
                 spinwait.SpinOnce();
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
-                {
                     Throw.ScopedRetryFailure();
-                }
             }
         }
 

--- a/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpmcBoundedBuffer.cs
@@ -24,9 +24,7 @@ namespace BitFaster.Caching.Buffers
         public MpmcBoundedBuffer(int boundedLength)
         {
             if (boundedLength < 0)
-            {
                 Throw.ArgOutOfRange(nameof(boundedLength));
-            }
 
             // must be power of 2 to use & slotsMask instead of %
             boundedLength = BitOps.CeilingPowerOfTwo(boundedLength);

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -26,9 +26,7 @@ namespace BitFaster.Caching.Buffers
         public MpscBoundedBuffer(int boundedLength)
         {
             if (boundedLength < 0)
-            {
                 Throw.ArgOutOfRange(nameof(boundedLength));
-            }
 
             // must be power of 2 to use & slotsMask instead of %
             boundedLength = BitOps.CeilingPowerOfTwo(boundedLength);

--- a/BitFaster.Caching/CacheDebugView.cs
+++ b/BitFaster.Caching/CacheDebugView.cs
@@ -12,9 +12,7 @@ namespace BitFaster.Caching
         public CacheDebugView(ICache<K, V> cache)
         {
             if (cache is null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
         }

--- a/BitFaster.Caching/Lfu/LfuCapacityPartition.cs
+++ b/BitFaster.Caching/Lfu/LfuCapacityPartition.cs
@@ -121,9 +121,7 @@ namespace BitFaster.Caching.Lfu
         private static (int window, int mainProtected, int mainProbation) ComputeQueueCapacity(int capacity, double mainPercentage)
         {
             if (capacity < 3)
-            {
                 Throw.ArgOutOfRange(nameof(capacity), "Capacity must be greater than or equal to 3.");
-            }
 
             int window = capacity - (int)(mainPercentage * capacity);
             int mainProtected = (int)(0.8 * (capacity - window));

--- a/BitFaster.Caching/Lfu/LfuNodeList.cs
+++ b/BitFaster.Caching/Lfu/LfuNodeList.cs
@@ -124,28 +124,20 @@ namespace BitFaster.Caching.Lfu
         internal static void ValidateNewNode(LfuNode<K, V> node)
         {
             if (node == null)
-            {
                 Throw.ArgNull(ExceptionArgument.node);
-            }
 
             if (node.list != null)
-            {
                 Throw.InvalidOp("Node is already attached to a list.");
-            }
         }
 
         [ExcludeFromCodeCoverage]
         internal void ValidateNode(LfuNode<K, V> node)
         {
             if (node == null)
-            {
                 Throw.ArgNull(ExceptionArgument.node);
-            }
 
             if (node.list != this)
-            {
                 Throw.InvalidOp("Node is already attached to a different list.");
-            }
         }
 #endif
 
@@ -172,9 +164,7 @@ namespace BitFaster.Caching.Lfu
                 get
                 {
                     if (index == 0 || (index == list.Count + 1))
-                    {
                         Throw.InvalidOp("Out of bounds");
-                    }
 
                     return Current;
                 }

--- a/BitFaster.Caching/Lru/CapacityPartitionExtensions.cs
+++ b/BitFaster.Caching/Lru/CapacityPartitionExtensions.cs
@@ -15,19 +15,13 @@ namespace BitFaster.Caching.Lru
         public static void Validate(this ICapacityPartition capacity)
         {
             if (capacity.Cold < 1)
-            { 
                 Throw.ArgOutOfRange(nameof(capacity.Cold));
-            }
 
             if (capacity.Warm < 1)
-            {
                 Throw.ArgOutOfRange(nameof(capacity.Warm));
-            }
 
             if (capacity.Hot < 1)
-            {
                 Throw.ArgOutOfRange(nameof(capacity.Hot));
-            }
         }
     }
 }

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -46,14 +46,10 @@ namespace BitFaster.Caching.Lru
         public ClassicLru(int concurrencyLevel, int capacity, IEqualityComparer<K> comparer)
         {
             if (capacity < 3)
-            {
                 Throw.ArgOutOfRange(nameof(capacity), "Capacity must be greater than or equal to 3.");
-            }
 
             if (comparer == null)
-            {
                 Throw.ArgNull(ExceptionArgument.comparer);
-            }
 
             this.capacity = capacity;
             this.dictionary = new ConcurrentDictionary<K, LinkedListNode<LruItem>>(concurrencyLevel, this.capacity + 1, comparer);

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Diagnostics.CodeAnalysis;
 using BitFaster.Caching.Lru.Builder;
 
 namespace BitFaster.Caching.Lru
@@ -37,6 +38,7 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
+        [ExcludeFromCodeCoverage]
         public override ICache<K, V> Build()
         {
             return info switch

--- a/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruBuilder.cs
@@ -38,7 +38,6 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
-        [ExcludeFromCodeCoverage]
         public override ICache<K, V> Build()
         {
             return info switch

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -76,14 +76,10 @@ namespace BitFaster.Caching.Lru
             T telemetryPolicy)
         {
             if (capacity == null)
-            {
                 Throw.ArgNull(ExceptionArgument.capacity);
-            }
 
             if (comparer == null)
-            {
                 Throw.ArgNull(ExceptionArgument.comparer);
-            }
 
             capacity.Validate();
             this.capacity = capacity;
@@ -418,9 +414,7 @@ namespace BitFaster.Caching.Lru
             int capacity = this.Capacity;
 
             if (itemCount < 1 || itemCount > capacity)
-            {
                 Throw.ArgOutOfRange(nameof(itemCount), "itemCount must be greater than or equal to one, and less than the capacity of the cache.");
-            }
 
             // clamp itemCount to number of items actually in the cache
             itemCount = Math.Min(itemCount, this.HotCount + this.WarmCount + this.ColdCount);

--- a/BitFaster.Caching/Lru/EqualCapacityPartition.cs
+++ b/BitFaster.Caching/Lru/EqualCapacityPartition.cs
@@ -37,9 +37,7 @@ namespace BitFaster.Caching.Lru
         private static (int hot, int warm, int cold) ComputeQueueCapacity(int capacity)
         {
             if (capacity < 3)
-            {
                 Throw.ArgOutOfRange(nameof(capacity), "Capacity must be greater than or equal to 3.");
-            }
 
             int hotCapacity = capacity / 3;
             int warmCapacity = capacity / 3;

--- a/BitFaster.Caching/Lru/FavorWarmPartition.cs
+++ b/BitFaster.Caching/Lru/FavorWarmPartition.cs
@@ -54,14 +54,10 @@ namespace BitFaster.Caching.Lru
         private static (int hot, int warm, int cold) ComputeQueueCapacity(int capacity, double warmRatio)
         {
             if (capacity < 3)
-            {
                 Throw.ArgOutOfRange(nameof(capacity), "Capacity must be greater than or equal to 3.");
-            }
 
             if (warmRatio <= 0.0 || warmRatio >= 1.0)
-            {
                 Throw.ArgOutOfRange(nameof(warmRatio), "warmRatio must be between 0.0 and 1.0");
-            }
 
             int warm2 = (int)(capacity * warmRatio);
             int hot2 = (capacity - warm2) / 2;

--- a/BitFaster.Caching/Lru/StopwatchTickConverter.cs
+++ b/BitFaster.Caching/Lru/StopwatchTickConverter.cs
@@ -12,13 +12,10 @@ namespace BitFaster.Caching.Lru
         {
             // mac adjustment factor is 100, giving lowest maximum TTL on mac platform - use same upper limit on all platforms for consistency
             // this also avoids overflow when multipling long.MaxValue by 1.0
-            double maxTicks = long.MaxValue * 0.01d;
+            const double maxTicks = long.MaxValue * 0.01d;
 
             if (timespan <= TimeSpan.Zero || timespan.Ticks >= maxTicks)
-            {
-                TimeSpan maxRepresentable = TimeSpan.FromTicks((long)maxTicks);
-                Throw.ArgOutOfRange(nameof(timespan), $"Value must be greater than zero and less than {maxRepresentable}");
-            }
+                Throw.ArgOutOfRange(nameof(timespan), $"Value must be greater than zero and less than {TimeSpan.FromTicks((long)maxTicks)}");
 
             return (long)(timespan.Ticks * stopwatchAdjustmentFactor);
         }

--- a/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
+++ b/BitFaster.Caching/Lru/TlruTickCount64Policy.cs
@@ -31,9 +31,7 @@ namespace BitFaster.Caching.Lru
         {
             TimeSpan maxRepresentable = TimeSpan.FromTicks(9223372036854769664);
             if (timeToLive <= TimeSpan.Zero || timeToLive > maxRepresentable)
-            {
                 Throw.ArgOutOfRange(nameof(timeToLive), $"Value must greater than zero and less than {maxRepresentable}");
-            }
 
             this.timeToLive = (long)timeToLive.TotalMilliseconds;
         }

--- a/BitFaster.Caching/Scoped.cs
+++ b/BitFaster.Caching/Scoped.cs
@@ -69,9 +69,7 @@ namespace BitFaster.Caching
         public Lifetime<T> CreateLifetime()
         {
             if (!TryCreateLifetime(out var lifetime))
-            {
                 Throw.Disposed<T>();
-            }
 
             return lifetime;
         }
@@ -126,9 +124,7 @@ namespace BitFaster.Caching
             public ScopedDebugView(Scoped<T> scoped)
             {
                 if (scoped is null)
-                {
                     Throw.ArgNull(ExceptionArgument.scoped);
-                }
 
                 this.scoped = scoped;
             }

--- a/BitFaster.Caching/ScopedAsyncCache.cs
+++ b/BitFaster.Caching/ScopedAsyncCache.cs
@@ -28,9 +28,7 @@ namespace BitFaster.Caching
         public ScopedAsyncCache(IAsyncCache<K, Scoped<V>> cache)
         {
             if (cache == null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
         }
@@ -79,9 +77,7 @@ namespace BitFaster.Caching
                 spinwait.SpinOnce();
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
-                {
                     Throw.ScopedRetryFailure();
-                }
             }
         }
 
@@ -112,9 +108,7 @@ namespace BitFaster.Caching
                 spinwait.SpinOnce();
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
-                {
                     Throw.ScopedRetryFailure();
-                }
             }
         }
 #endif

--- a/BitFaster.Caching/ScopedAsyncCacheDebugView.cs
+++ b/BitFaster.Caching/ScopedAsyncCacheDebugView.cs
@@ -12,9 +12,7 @@ namespace BitFaster.Caching
         public ScopedAsyncCacheDebugView(IScopedAsyncCache<K, V> cache)
         {
             if (cache is null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
         }

--- a/BitFaster.Caching/ScopedCache.cs
+++ b/BitFaster.Caching/ScopedCache.cs
@@ -26,9 +26,7 @@ namespace BitFaster.Caching
         public ScopedCache(ICache<K, Scoped<V>> cache)
         {
             if (cache == null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
         }
@@ -98,9 +96,7 @@ namespace BitFaster.Caching
                 spinwait.SpinOnce();
 
                 if (c++ > ScopedCacheDefaults.MaxRetry)
-                {
                     Throw.ScopedRetryFailure();
-                }
             }
         }
 

--- a/BitFaster.Caching/ScopedCacheDebugView.cs
+++ b/BitFaster.Caching/ScopedCacheDebugView.cs
@@ -12,9 +12,7 @@ namespace BitFaster.Caching
         public ScopedCacheDebugView(IScopedCache<K, V> cache)
         {
             if (cache is null)
-            {
                 Throw.ArgNull(ExceptionArgument.cache);
-            }
 
             this.cache = cache;
         }


### PR DESCRIPTION
Removing braces around `if(...) { throw; }` to eliminate the uncovered code:
![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/fafd92a0-0361-4072-a66c-5dccedff034f)
![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/eb535deb-9ccc-4e73-8438-1c6988a66f72)

There is a change to coverlet that states decorating the throw helper methods with `[DoesNotReturn]` should eliminate this (imlpemented in https://github.com/bitfaster/BitFaster.Caching/pull/386), but it doesn't work. Therefore, simply remove the braces to avoid artificially counting code coverage lower.
