### PR TITLE
Revert "Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0"

### DIFF
--- a/BitFaster.Caching.UnitTests/BitFaster.Caching.UnitTests.csproj
+++ b/BitFaster.Caching.UnitTests/BitFaster.Caching.UnitTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Reverts bitfaster/BitFaster.Caching#367

This results in one build leg having 0% code coverage, even though the build leg passes:
![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/7ebc069e-3bc6-4025-bba3-eb4cf010d198)

Revert until this is fixed.