### PR TITLE
cover switch expression

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -1,17 +1,28 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Atomic;
 using FluentAssertions;
 using Xunit;
+using System.Reflection;
+using BitFaster.Caching.Lru.Builder;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
     public class ConcurrentLruBuilderTests
     {
+        [Fact]
+        public void WhenLruInfoIsNull()
+        {
+            Type type = typeof(ConcurrentLruBuilder<int, int>);
+            
+            ConstructorInfo ctor = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(LruInfo<int>) }, null);
+            var builder = (ConcurrentLruBuilder<int, int>)ctor.Invoke(new object[] { null });
+
+            Action build = () => { builder.Build(); };
+
+            build.Should().Throw<NullReferenceException>();
+        }
+
         [Fact]
         public void TestFastLru()
         {


### PR DESCRIPTION
Slightly confused about how to cover this switch expression, the tests appear to cover all branches:

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/cad60950-3dd6-47e5-bec9-f456716e0b56)

This is the lowered code according to dotPeek:

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/e061abf5-666c-4fe7-abce-696dd9d2b3f8)