### PR TITLE
Align ICache.TryRemove overloads with ConcurrentDictionary

### DIFF
--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
@@ -72,8 +72,31 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.removedItems.First().Key.Should().Be(1);
         }
 
-// backcompat: remove conditional compile
+        // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public void WhenRemovedValueIsReturned()
+        {
+            this.cache.AddOrUpdate(1, 1);
+            this.cache.TryRemove(1, out var value);
+
+            value.Should().Be(1);
+        }
+
+        [Fact]
+        public void WhenRemoveKeyValueAndValueDoesntMatchDontRemove()
+        {
+            this.cache.AddOrUpdate(1, 1);
+            this.cache.TryRemove(new KeyValuePair<int, int>(1, 2)).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenRemoveKeyValueAndValueDoesMatchRemove()
+        {
+            this.cache.AddOrUpdate(1, 1);
+            this.cache.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
+        }
+
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
@@ -91,6 +91,15 @@ namespace BitFaster.Caching.UnitTests.Atomic
         }
 
         [Fact]
+        public void WhenNotRemovedValueIsDefault()
+        {
+            this.cache.AddOrUpdate(1, 1);
+            this.cache.TryRemove(2, out var value);
+
+            value.Should().Be(0);
+        }
+
+        [Fact]
         public void WhenRemoveKeyValueAndValueDoesntMatchDontRemove()
         {
             this.cache.AddOrUpdate(1, 1);

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryTests.cs
@@ -64,6 +64,58 @@ namespace BitFaster.Caching.UnitTests.Atomic
         }
 
         [Fact]
+        public void WhenValueNotCreatedHashCodeIsZero()
+        {
+            new AtomicFactory<int, int>()
+                .GetHashCode()
+                .Should().Be(0);
+        }
+
+        [Fact]
+        public void WhenValueCreatedHashCodeIsValueHashCode()
+        {
+            new AtomicFactory<int, int>(1)
+                .GetHashCode()
+                .Should().Be(1);
+        }
+
+        [Fact]
+        public void WhenValueNotCreatedEqualsFalse()
+        {
+            var a = new AtomicFactory<int, int>();
+            var b = new AtomicFactory<int, int>();
+
+            a.Equals(b).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenOtherValueNotCreatedEqualsFalse()
+        {
+            var a = new AtomicFactory<int, int>(1);
+            var b = new AtomicFactory<int, int>();
+
+            a.Equals(b).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenArgNullEqualsFalse()
+        {
+            new AtomicFactory<int, int>(1)
+                .Equals(null)
+                .Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenArgObjectValuesAreSameEqualsTrue()
+        {
+            object other = new AtomicFactory<int, int>(1);
+
+            new AtomicFactory<int, int>(1)
+                .Equals(other)
+                .Should().BeTrue();
+        }
+
+        [Fact]
         public async Task WhenCallersRunConcurrentlyResultIsFromWinner()
         {
             var enter = new ManualResetEvent(false);

--- a/BitFaster.Caching.UnitTests/CacheTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheTests.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
@@ -25,6 +26,28 @@ namespace BitFaster.Caching.UnitTests
                 1, 
                 (k, a) => k + a, 
                 2).Should().Be(3);
+        }
+
+        [Fact]
+        public void WhenCacheInterfaceDefaultTryRemoveKeyThrows()
+        {
+            var cache = new Mock<ICache<int, int>>();
+            cache.CallBase = true;
+
+            Action tryRemove = () => { cache.Object.TryRemove(1, out var value); };
+
+            tryRemove.Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void WhenCacheInterfaceDefaultTryRemoveKeyValueThrows()
+        {
+            var cache = new Mock<ICache<int, int>>();
+            cache.CallBase = true;
+
+            Action tryRemove = () => { cache.Object.TryRemove(new KeyValuePair<int, int>(1, 1)); };
+
+            tryRemove.Should().Throw<NotSupportedException>();
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -582,12 +582,12 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
-        public void WhenKeyIsRemovedItIsRemoved()
+        public void WhenKeyExistsTryRemoveRemovesItem()
         {
             cache.GetOrAdd(1, k => k);
 
             cache.TryRemove(1).Should().BeTrue();
-            cache.TryGet(1, out var value).Should().BeFalse();
+            cache.TryGet(1, out _).Should().BeFalse();
         }
 
         [Fact]
@@ -600,16 +600,16 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
-        public void WhenItemIsRemovedItIsRemoved()
+        public void WhenItemExistsTryRemoveRemovesItem()
         {
             cache.GetOrAdd(1, k => k);
 
             cache.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
-            cache.TryGet(1, out var value).Should().BeFalse();
+            cache.TryGet(1, out _).Should().BeFalse();
         }
 
         [Fact]
-        public void WhenItemDoesntMatchItIsNotRemoved()
+        public void WhenItemDoesntMatchTryRemoveDoesNotRemove()
         {
             cache.GetOrAdd(1, k => k);
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -582,12 +582,30 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
-        public void WhenItemIsRemovedItIsRemoved()
+        public void WhenKeyIsRemovedItIsRemoved()
         {
             cache.GetOrAdd(1, k => k);
 
             cache.TryRemove(1).Should().BeTrue();
             cache.TryGet(1, out var value).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenItemIsRemovedItIsRemoved()
+        {
+            cache.GetOrAdd(1, k => k);
+
+            cache.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
+            cache.TryGet(1, out var value).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenItemDoesntMatchItIsNotRemoved()
+        {
+            cache.GetOrAdd(1, k => k);
+
+            cache.TryRemove(new KeyValuePair<int, int>(1, 2)).Should().BeFalse();
+            cache.TryGet(1, out var value).Should().BeTrue();
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -591,6 +591,15 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
+        public void WhenKeyExistsTryRemoveReturnsValue()
+        {
+            cache.GetOrAdd(1, valueFactory.Create);
+
+            cache.TryRemove(1, out var value).Should().BeTrue();
+            value.Should().Be(1);
+        }
+
+        [Fact]
         public void WhenItemIsRemovedItIsRemoved()
         {
             cache.GetOrAdd(1, k => k);

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -363,6 +363,15 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenKeyExistsTryRemoveReturnsValue()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryRemove(1, out var value).Should().BeTrue();
+            value.Should().Be("1");
+        }
+
+        [Fact]
         public void WhenItemExistsTryRemovesItemAndReturnsTrue()
         {
             lru.GetOrAdd(1, valueFactory.Create);

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -363,6 +363,24 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenItemExistsTryRemovesItemAndReturnsTrue()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryRemove(new KeyValuePair<int, string>(1, "1")).Should().BeTrue();
+            lru.TryGet(1, out var value).Should().BeFalse();
+        }
+
+        [Fact]
+        public void WhenTryRemoveKvpDoesntMatchItemNotRemovedAndReturnsFalse()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryRemove(new KeyValuePair<int, string>(1, "2")).Should().BeFalse();
+            lru.TryGet(1, out var value).Should().BeTrue();
+        }
+
+        [Fact]
         public void WhenItemIsRemovedItIsDisposed()
         {
             var lruOfDisposable = new ClassicLru<int, DisposableItem>(1, 6, EqualityComparer<int>.Default);

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -1197,6 +1197,26 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public async Task WhenSoakConcurrentGetAndRemoveKvpCacheEndsInConsistentState()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await Threaded.Run(4, () => {
+                    for (int i = 0; i < 100000; i++)
+                    {
+                        lru.TryRemove(new KeyValuePair<int, string>(i + 1, (i + 1).ToString()));
+                        lru.GetOrAdd(i + 1, i => i.ToString());
+                    }
+                });
+
+                this.testOutputHelper.WriteLine($"{lru.HotCount} {lru.WarmCount} {lru.ColdCount}");
+                this.testOutputHelper.WriteLine(string.Join(" ", lru.Keys));
+
+                RunIntegrityCheck();
+            }
+        }
+
+        [Fact]
         public async Task WhenSoakConcurrentGetAndUpdateCacheEndsInConsistentState()
         {
             for (int i = 0; i < 10; i++)

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -637,6 +637,15 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenKeyExistsTryRemoveReturnsValue()
+        {
+            lru.GetOrAdd(1, valueFactory.Create);
+
+            lru.TryRemove(1, out var value).Should().BeTrue();
+            value.Should().Be("1");
+        }
+
+        [Fact]
         public void WhenItemIsRemovedItIsDisposed()
         {
             var lruOfDisposable = new ConcurrentLru<int, DisposableItem>(1, 6, EqualityComparer<int>.Default);

--- a/BitFaster.Caching/Atomic/AtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactory.cs
@@ -122,6 +122,17 @@ namespace BitFaster.Caching.Atomic
             return EqualityComparer<V>.Default.Equals(ValueIfCreated, other.ValueIfCreated);
         }
 
+        ///<inheritdoc/>
+        public override int GetHashCode()
+        {
+            if (!IsValueCreated)
+            {
+                return 0;
+            }
+
+            return ValueIfCreated.GetHashCode();
+        }
+
         private class Initializer
         {
             private readonly object syncLock = new();

--- a/BitFaster.Caching/Atomic/AtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
@@ -11,7 +12,7 @@ namespace BitFaster.Caching.Atomic
     /// <typeparam name="K">The type of the key.</typeparam>
     /// <typeparam name="V">The type of the value.</typeparam>
     [DebuggerDisplay("IsValueCreated={IsValueCreated}, Value={ValueIfCreated}")]
-    public sealed class AtomicFactory<K, V>
+    public sealed class AtomicFactory<K, V> : IEquatable<AtomicFactory<K, V>>
     {
         private Initializer initializer;
 
@@ -102,6 +103,23 @@ namespace BitFaster.Caching.Atomic
             }
 
             return value;
+        }
+
+        ///<inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as AtomicFactory<K, V>);
+        }
+
+        ///<inheritdoc/>
+        public bool Equals(AtomicFactory<K, V> other)
+        {
+            if (other is null || !IsValueCreated || !other.IsValueCreated)
+            {
+                return false;
+            }
+
+            return EqualityComparer<V>.Default.Equals(ValueIfCreated, other.ValueIfCreated);
         }
 
         private class Initializer

--- a/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
@@ -113,9 +113,7 @@ namespace BitFaster.Caching.Atomic
         ///</remarks>
         public bool TryRemove(KeyValuePair<K, V> item)
         {
-            // TODO: AtomicFactory must be comparable via EqualityComparer<V>.Default
             var kvp = new KeyValuePair<K, AtomicFactory<K, V>>(item.Key, new AtomicFactory<K, V>(item.Value));
-
             return cache.TryRemove(kvp);
         }
 

--- a/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq.Expressions;
 
 namespace BitFaster.Caching.Atomic
 {
@@ -103,6 +104,37 @@ namespace BitFaster.Caching.Atomic
             value = default;
             return false;
         }
+
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        ///<inheritdoc/>
+        ///<remarks>
+        ///If the value factory is still executing, returns false.
+        ///</remarks>
+        public bool TryRemove(KeyValuePair<K, V> item)
+        {
+            // TODO: AtomicFactory must be comparable via EqualityComparer<V>.Default
+            var kvp = new KeyValuePair<K, AtomicFactory<K, V>>(item.Key, new AtomicFactory<K, V>(item.Value));
+
+            return cache.TryRemove(kvp);
+        }
+
+        ///<inheritdoc/>
+        /// <remarks>
+        /// If the value factory is still executing, the default value will be returned.
+        /// </remarks>
+        public bool TryRemove(K key, out V value)
+        {
+            if (cache.TryRemove(key, out var atomic))
+            {
+                value = atomic.ValueIfCreated;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+#endif
 
         ///<inheritdoc/>
         public bool TryRemove(K key)

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -67,9 +67,9 @@ namespace BitFaster.Caching
         /// in the cache, or the new value if the key was not in the cache.</returns>
         V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument) => this.GetOrAdd(key, k => valueFactory(k, factoryArgument));
 
-        //bool TryRemove(K key, out V value);
+        bool TryRemove(K key, out V value);
 
-        //bool TryRemove(KeyValuePair<K, V> item);
+        bool TryRemove(KeyValuePair<K, V> item);
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -66,6 +66,10 @@ namespace BitFaster.Caching
         /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
         /// in the cache, or the new value if the key was not in the cache.</returns>
         V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument) => this.GetOrAdd(key, k => valueFactory(k, factoryArgument));
+
+        //bool TryRemove(K key, out V value);
+
+        //bool TryRemove(KeyValuePair<K, V> item);
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -67,9 +67,20 @@ namespace BitFaster.Caching
         /// in the cache, or the new value if the key was not in the cache.</returns>
         V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument) => this.GetOrAdd(key, k => valueFactory(k, factoryArgument));
 
-        bool TryRemove(K key, out V value);
+        /// <summary>
+        /// Attempts to remove and return the value that has the specified key.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <param name="value">When this method returns, contains the object removed, or the default value of the value type if key does not exist.</param>
+        /// <returns>true if the object was removed successfully; otherwise, false.</returns>
+        bool TryRemove(K key, out V value) => throw new NotSupportedException();
 
-        bool TryRemove(KeyValuePair<K, V> item);
+        /// <summary>
+        /// Attempts to remove 
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        bool TryRemove(KeyValuePair<K, V> item) => throw new NotSupportedException();
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -76,10 +76,10 @@ namespace BitFaster.Caching
         bool TryRemove(K key, out V value) => throw new NotSupportedException();
 
         /// <summary>
-        /// Attempts to remove 
+        /// Attempts to remove the specified key value pair.
         /// </summary>
-        /// <param name="item"></param>
-        /// <returns></returns>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>true if the item was removed successfully; otherwise, false.</returns>
         bool TryRemove(KeyValuePair<K, V> item) => throw new NotSupportedException();
 #endif
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -320,25 +320,42 @@ namespace BitFaster.Caching.Lfu
 
         public bool TryRemove(KeyValuePair<K, V> item)
         {
-            throw new NotImplementedException();
+            if (this.dictionary.TryGetValue(item.Key, out var node))
+            {
+                if (EqualityComparer<V>.Default.Equals(node.Value, item.Value))
+                {
+                    var kvp = new KeyValuePair<K, LfuNode<K,V>>(item.Key, node);
+
+                    if (this.dictionary.TryRemove(kvp))
+                    {
+                        node.WasRemoved = true;
+                        AfterWrite(node);
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         public bool TryRemove(K key, out V value)
-        {
-            throw new NotImplementedException();
-        }
-
-        ///<inheritdoc/>
-        public bool TryRemove(K key)
         {
             if (this.dictionary.TryRemove(key, out var node))
             {
                 node.WasRemoved = true;
                 AfterWrite(node);
+                value = node.Value;
                 return true;
             }
 
+            value = default;
             return false;
+        }
+
+        ///<inheritdoc/>
+        public bool TryRemove(K key)
+        {
+            return this.TryRemove(key, out var _);
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -318,6 +318,11 @@ namespace BitFaster.Caching.Lfu
             return false;
         }
 
+        /// <summary>
+        /// Attempts to remove the specified key value pair.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>true if the item was removed successfully; otherwise, false.</returns>
         public bool TryRemove(KeyValuePair<K, V> item)
         {
             if (this.dictionary.TryGetValue(item.Key, out var node))
@@ -342,6 +347,12 @@ namespace BitFaster.Caching.Lfu
             return false;
         }
 
+        /// <summary>
+        /// Attempts to remove and return the value that has the specified key.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <param name="value">When this method returns, contains the object removed, or the default value of the value type if key does not exist.</param>
+        /// <returns>true if the object was removed successfully; otherwise, false.</returns>
         public bool TryRemove(K key, out V value)
         {
             if (this.dictionary.TryRemove(key, out var node))

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -318,6 +318,16 @@ namespace BitFaster.Caching.Lfu
             return false;
         }
 
+        public bool TryRemove(KeyValuePair<K, V> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryRemove(K key, out V value)
+        {
+            throw new NotImplementedException();
+        }
+
         ///<inheritdoc/>
         public bool TryRemove(K key)
         {

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -326,7 +326,11 @@ namespace BitFaster.Caching.Lfu
                 {
                     var kvp = new KeyValuePair<K, LfuNode<K,V>>(item.Key, node);
 
+#if NET6_0_OR_GREATER
                     if (this.dictionary.TryRemove(kvp))
+#else
+                    if (((ICollection<KeyValuePair<K, LfuNode<K, V>>>)this.dictionary).Remove(kvp))
+#endif
                     {
                         node.WasRemoved = true;
                         AfterWrite(node);

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -334,6 +334,7 @@ namespace BitFaster.Caching.Lfu
 #if NET6_0_OR_GREATER
                     if (this.dictionary.TryRemove(kvp))
 #else
+                    // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
                     if (((ICollection<KeyValuePair<K, LfuNode<K, V>>>)this.dictionary).Remove(kvp))
 #endif
                     {

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -237,6 +237,11 @@ namespace BitFaster.Caching.Lru
             return await this.GetOrAddAsync(key, valueFactory, factoryArgument);
         }
 
+        /// <summary>
+        /// Attempts to remove the specified key value pair.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>true if the item was removed successfully; otherwise, false.</returns>
         public bool TryRemove(KeyValuePair<K, V> item)
         {
             if (this.dictionary.TryGetValue(item.Key, out var node))
@@ -260,6 +265,12 @@ namespace BitFaster.Caching.Lru
             return false;
         }
 
+        /// <summary>
+        /// Attempts to remove and return the value that has the specified key.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <param name="value">When this method returns, contains the object removed, or the default value of the value type if key does not exist.</param>
+        /// <returns>true if the object was removed successfully; otherwise, false.</returns>
         public bool TryRemove(K key, out V value)
         {
             if (dictionary.TryRemove(key, out var node))

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -245,7 +245,11 @@ namespace BitFaster.Caching.Lru
                 {
                     var kvp = new KeyValuePair<K, LinkedListNode<LruItem>>(item.Key, node);
 
+#if NET6_0_OR_GREATER
                     if (this.dictionary.TryRemove(kvp))
+#else
+                    if (((ICollection<KeyValuePair<K, LinkedListNode<LruItem>>>)this.dictionary).Remove(kvp))
+#endif
                     {
                         OnRemove(node);
                         return true;

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -253,6 +253,7 @@ namespace BitFaster.Caching.Lru
 #if NET6_0_OR_GREATER
                     if (this.dictionary.TryRemove(kvp))
 #else
+                    // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
                     if (((ICollection<KeyValuePair<K, LinkedListNode<LruItem>>>)this.dictionary).Remove(kvp))
 #endif
                     {

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -237,6 +237,16 @@ namespace BitFaster.Caching.Lru
             return await this.GetOrAddAsync(key, valueFactory, factoryArgument);
         }
 
+        public bool TryRemove(KeyValuePair<K, V> item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool TryRemove(K key, out V value)
+        {
+            throw new NotImplementedException();
+        }
+
         ///<inheritdoc/>
         public bool TryRemove(K key)
         {

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -292,7 +292,12 @@ namespace BitFaster.Caching.Lru
                 }
             }
         }
-        
+
+        /// <summary>
+        /// Attempts to remove the specified key value pair.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>true if the item was removed successfully; otherwise, false.</returns>
         public bool TryRemove(KeyValuePair<K, V> item)
         {
             if (this.dictionary.TryGetValue(item.Key, out var existing))
@@ -317,6 +322,12 @@ namespace BitFaster.Caching.Lru
             return false;
         }
 
+        /// <summary>
+        /// Attempts to remove and return the value that has the specified key.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <param name="value">When this method returns, contains the object removed, or the default value of the value type if key does not exist.</param>
+        /// <returns>true if the object was removed successfully; otherwise, false.</returns>
         public bool TryRemove(K key, out V value)
         {
             if (this.dictionary.TryRemove(key, out var item))

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -300,8 +300,11 @@ namespace BitFaster.Caching.Lru
                 if (EqualityComparer<V>.Default.Equals(existing.Value, item.Value))
                 {
                     var kvp = new KeyValuePair<K, I>(item.Key, existing);
-
+#if NET6_0_OR_GREATER
                     if (this.dictionary.TryRemove(kvp))
+#else
+                    if (((ICollection<KeyValuePair<K, I>>)this.dictionary).Remove(kvp))
+#endif
                     {
                         OnRemove(item.Key, kvp.Value);
                         return true;

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -308,6 +308,7 @@ namespace BitFaster.Caching.Lru
 #if NET6_0_OR_GREATER
                     if (this.dictionary.TryRemove(kvp))
 #else
+                    // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
                     if (((ICollection<KeyValuePair<K, I>>)this.dictionary).Remove(kvp))
 #endif
                     {


### PR DESCRIPTION
Provide functional parity with `ConcurrentDictionary` for `ICache.TryRemove`.

- Provide `bool TryRemove(K key, out V value)` and `bool TryRemove(KeyValuePair<K,V> item)`
- Underneath, use `ConcurrentDictionary TryRemove(key, out value)` for `ICache TryRemove(K key)` and `TryRemove(K key, out V value)` to avoid double dictionary lookup then remove.
- Use the old method of retrieve, check, then atomic delete for `TryRemove(KeyValuePair<K,V>)`
- `ICache` default implementations for backwards compatibility throw `NotSupportedException`. There is no way to correctly implement either new method, so it is better to throw than give the caller an incorrect result. This would only apply if a caller implements ICache themselves, upgrades the library, and doesn't have impls for these methods.
- Atomics implement `IEquatable` to compare wrapped values. Values that are not yet created are always not equal, similar to comparing null.
- AsyncAtomic family can follow a similar pattern, but this is not implemented in this PR.
- Defer support for scoped caches, less clear how to implement this.