### PR TITLE
ConcurrentLfu.Clear() polluted by removed items

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -426,7 +426,12 @@ namespace BitFaster.Caching.Lfu
 
             while (candidates.Count < itemCount && curr != null)
             {
-                candidates.Add(curr);
+                // LRUs can contain items that are already removed, skip those 
+                if (!curr.WasRemoved)
+                { 
+                    candidates.Add(curr); 
+                }
+
                 curr = curr.Next;
             }
         }


### PR DESCRIPTION
Calling `Clear()` with `BackgroundThreadScheduler` can result in a situation where window/probation/protected contains an item that was already removed. Since the clear logic trims n items, where n == cache.Count, the already removed items pollute the list of candidates resulting in non-removed items remaining in the cache.