### PR TITLE
Reset isWarm when clearing ConcurrentLru

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -869,6 +869,25 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenWarmThenClearedIsWarmIsReset()
+        {
+            for (int i = 0; i < 20; i++)
+            { 
+                lru.GetOrAdd(i, k => k.ToString()); 
+            }
+
+            lru.Clear();
+            lru.Count.Should().Be(0);
+
+            for (int i = 0; i < 20; i++)
+            { 
+                lru.GetOrAdd(i, k => k.ToString()); 
+            }
+
+            lru.Count.Should().Be(capacity.Hot + capacity.Warm + capacity.Cold);
+        }
+
+        [Fact]
         public void WhenItemsAreDisposableClearDisposesItemsOnRemove()
         {
             var lruOfDisposable = new ConcurrentLru<int, DisposableItem>(1, 6, EqualityComparer<int>.Default);

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -430,6 +430,8 @@ namespace BitFaster.Caching.Lru
                 CycleWarmUnchecked(ItemRemovedReason.Cleared);
                 TryRemoveCold(ItemRemovedReason.Cleared);
             }
+
+            Volatile.Write(ref this.isWarm, false);
         }
 
         /// <summary>


### PR DESCRIPTION
When ConcurrentLru is cleared, the isWarm flag was not reset. Consequently, items cannot enter the warm queue until they are requested a second time. This is confusing, because the cache behaves differently after it is cleared, and reduces effective capacity after clear reducing hit rate.