### PR TITLE
Scoped cache broken due to operator== ABA problem

### DIFF
--- a/BitFaster.Caching.UnitTests/ReferenceCountTests.cs
+++ b/BitFaster.Caching.UnitTests/ReferenceCountTests.cs
@@ -1,7 +1,4 @@
 ﻿using FluentAssertions;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -15,6 +12,15 @@ namespace BitFaster.Caching.UnitTests
             var b = a.IncrementCopy().DecrementCopy();
 
             a.Should().Be(b);
+        }
+
+        [Fact]
+        public void WhenOtherIsEqualReferenceEqualsReturnsFalse()
+        {
+            var a = new ReferenceCount<object>(new object());
+            var b = a.IncrementCopy().DecrementCopy();
+
+            a.Should().NotBeSameAs(b);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
@@ -54,5 +54,23 @@ namespace BitFaster.Caching.UnitTests
 
             getOrAdd.Should().Throw<InvalidOperationException>();
         }
+
+        [Fact]
+        public async Task WhenSoak2()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                await Threaded.Run(4, () => {
+                    for (int j = 0; j < 100000; j++)
+                    {
+                        using (var l = this.cache.ScopedGetOrAdd(j, k => new Scoped<Disposable>(new Disposable(k))))
+                        {
+                            // somehow, this is returning disposed!?!
+                            l.Value.IsDisposed.Should().BeFalse();
+                        }
+                    }
+                });
+            }
+        }
     }
 }

--- a/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
@@ -65,8 +65,7 @@ namespace BitFaster.Caching.UnitTests
                     {
                         using (var l = this.cache.ScopedGetOrAdd(j, k => new Scoped<Disposable>(new Disposable(k))))
                         {
-                            // somehow, this is returning disposed!?!
-                            l.Value.IsDisposed.Should().BeFalse();
+                            l.Value.IsDisposed.Should().BeFalse($"ref count {l.ReferenceCount}");
                         }
                     }
                 });

--- a/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
@@ -56,7 +56,7 @@ namespace BitFaster.Caching.UnitTests
         }
 
         [Fact]
-        public async Task WhenSoak2()
+        public async Task WhenSoakScopedGetOrAddValueIsAlwaysAlive()
         {
             for (int i = 0; i < 10; i++)
             {

--- a/BitFaster.Caching.UnitTests/ScopedTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedTests.cs
@@ -108,27 +108,9 @@ namespace BitFaster.Caching.UnitTests
 
                 scope.IsDisposed.Should().BeFalse();
                 scope.Dispose();
+                scope.TryCreateLifetime(out _).Should().BeFalse();
                 scope.IsDisposed.Should().BeTrue();
             }
         }
-
-        //[Fact]
-        //public async Task WhenSoak2()
-        //{
-        //    var lru = new ConcurrentLruBuilder<int, Disposable>().AsScopedCache().Build();
-
-        //    for (int i = 0; i < 10; i++)
-        //    {
-        //        await Threaded.Run(4, () => {
-        //            for (int i = 0; i < 100000; i++)
-        //            {
-        //                using (var l = lru.ScopedGetOrAdd(i, k => new Scoped<Disposable>(new Disposable(k))))
-        //                {
-        //                    l.Value.IsDisposed.Should().BeFalse();
-        //                }
-        //            }
-        //        });
-        //    }
-        //}
     }
 }

--- a/BitFaster.Caching.UnitTests/ScopedTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedTests.cs
@@ -90,13 +90,11 @@ namespace BitFaster.Caching.UnitTests
         }
 
         [Fact]
-        public async Task WhenSoak1()
+        public async Task WhenSoakCreateLifetimeScopeIsDisposedCorrectly()
         {
             for (int i = 0; i < 10; i++)
             {
                 var scope = new Scoped<Disposable>(new Disposable(i));
-
-                var l = scope.CreateLifetime();
 
                 await Threaded.Run(4, () => {
                     for (int i = 0; i < 100000; i++)
@@ -107,27 +105,30 @@ namespace BitFaster.Caching.UnitTests
                         }
                     }
                 });
+
+                scope.IsDisposed.Should().BeFalse();
+                scope.Dispose();
+                scope.IsDisposed.Should().BeTrue();
             }
         }
 
+        //[Fact]
+        //public async Task WhenSoak2()
+        //{
+        //    var lru = new ConcurrentLruBuilder<int, Disposable>().AsScopedCache().Build();
 
-        [Fact]
-        public async Task WhenSoak2()
-        {
-            var lru = new ConcurrentLruBuilder<int, Disposable>().AsScopedCache().Build();
-
-            for (int i = 0; i < 10; i++)
-            {
-                await Threaded.Run(4, () => {
-                    for (int i = 0; i < 100000; i++)
-                    {
-                        using (var l = lru.ScopedGetOrAdd(i, k => new Scoped<Disposable>(new Disposable(k))))
-                        {
-                            l.Value.IsDisposed.Should().BeFalse();
-                        }
-                    }
-                });
-            }
-        }
+        //    for (int i = 0; i < 10; i++)
+        //    {
+        //        await Threaded.Run(4, () => {
+        //            for (int i = 0; i < 100000; i++)
+        //            {
+        //                using (var l = lru.ScopedGetOrAdd(i, k => new Scoped<Disposable>(new Disposable(k))))
+        //                {
+        //                    l.Value.IsDisposed.Should().BeFalse();
+        //                }
+        //            }
+        //        });
+        //    }
+        //}
     }
 }

--- a/BitFaster.Caching/ReferenceCount.cs
+++ b/BitFaster.Caching/ReferenceCount.cs
@@ -93,10 +93,10 @@ namespace BitFaster.Caching
         }
 
         /// <summary>
-        /// Determines whether two ReferenceCount instances have the same value.
+        /// Determines whether two ReferenceCount instances are the exact same value via a reference equality check.
         /// </summary>
-        /// <param name="left">The left ReferernceCount to compare, or null.</param>
-        /// <param name="right">The right ReferernceCount to compare, or null.</param>
+        /// <param name="left">The left ReferenceCount to compare, or null.</param>
+        /// <param name="right">The right ReferenceCount to compare, or null.</param>
         /// <returns>true if the value of left is the same as the value of right; otherwise, false.</returns>
         public static bool operator ==(ReferenceCount<TValue> left, ReferenceCount<TValue> right)
         {
@@ -104,10 +104,10 @@ namespace BitFaster.Caching
         }
 
         /// <summary>
-        /// Determines whether two ReferenceCount instances have different values.
+        /// Determines whether two ReferenceCount instances are different via a reference equality check.
         /// </summary>
-        /// <param name="left">The left ReferernceCount to compare, or null.</param>
-        /// <param name="right">The right ReferernceCount to compare, or null.</param>
+        /// <param name="left">The left ReferenceCount to compare, or null.</param>
+        /// <param name="right">The right ReferenceCount to compare, or null.</param>
         /// <returns>true if the value of left is different from the value of right; otherwise, false.</returns>
         public static bool operator !=(ReferenceCount<TValue> left, ReferenceCount<TValue> right)
         {

--- a/BitFaster.Caching/ReferenceCount.cs
+++ b/BitFaster.Caching/ReferenceCount.cs
@@ -100,7 +100,7 @@ namespace BitFaster.Caching
         /// <returns>true if the value of left is the same as the value of right; otherwise, false.</returns>
         public static bool operator ==(ReferenceCount<TValue> left, ReferenceCount<TValue> right)
         {
-            return EqualityComparer<ReferenceCount<TValue>>.Default.Equals(left, right);
+            return object.ReferenceEquals(left, right);
         }
 
         /// <summary>

--- a/BitFaster.Caching/Scoped.cs
+++ b/BitFaster.Caching/Scoped.cs
@@ -82,6 +82,8 @@ namespace BitFaster.Caching
 
                 if (oldRefCount == Interlocked.CompareExchange(ref this.refCount, oldRefCount.DecrementCopy(), oldRefCount))
                 {
+                    // Note this.refCount may be stale.
+                    // Old count == 1, thus new ref count is 0, dispose the value.
                     if (oldRefCount.Count == 1)
                     {
                         oldRefCount.Value?.Dispose();

--- a/BitFaster.Caching/Scoped.cs
+++ b/BitFaster.Caching/Scoped.cs
@@ -16,7 +16,7 @@ namespace BitFaster.Caching
     public sealed class Scoped<T> : IScoped<T>, IDisposable where T : IDisposable
     {
         private ReferenceCount<T> refCount;
-        private bool isDisposed;
+        private int disposed = 0;
 
         /// <summary>
         /// Initializes a new Scoped value.
@@ -30,7 +30,7 @@ namespace BitFaster.Caching
         /// <summary>
         /// Gets a value indicating whether the scope is disposed.
         /// </summary>
-        public bool IsDisposed => isDisposed;
+        public bool IsDisposed => Volatile.Read(ref this.disposed) == 1;
 
         /// <summary>
         /// Attempts to create a lifetime for the scoped value. The lifetime guarantees the value is alive until 
@@ -45,7 +45,7 @@ namespace BitFaster.Caching
                 var oldRefCount = this.refCount;
 
                 // If old ref count is 0, the scoped object has been disposed and there was a race.
-                if (this.isDisposed || oldRefCount.Count == 0)
+                if (IsDisposed || oldRefCount.Count == 0)
                 {
                     lifetime = default;
                     return false;
@@ -98,10 +98,10 @@ namespace BitFaster.Caching
         /// </summary>
         public void Dispose()
         {
-            if (!this.isDisposed)
+            // Dispose exactly once, decrement via dispose exactly once
+            if (Interlocked.CompareExchange(ref this.disposed, 1, 0) == 0)
             {
-                this.DecrementReferenceCount();
-                this.isDisposed = true;
+                DecrementReferenceCount();
             }
         }
 

--- a/BitFaster.Caching/Scoped.cs
+++ b/BitFaster.Caching/Scoped.cs
@@ -82,9 +82,9 @@ namespace BitFaster.Caching
 
                 if (oldRefCount == Interlocked.CompareExchange(ref this.refCount, oldRefCount.DecrementCopy(), oldRefCount))
                 {
-                    if (this.refCount.Count == 0)
+                    if (oldRefCount.Count == 1)
                     {
-                        this.refCount.Value?.Dispose();
+                        oldRefCount.Value?.Dispose();
                     }
 
                     break;

--- a/BitFaster.Caching/ScopedCacheDefaults.cs
+++ b/BitFaster.Caching/ScopedCacheDefaults.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿
 namespace BitFaster.Caching
 {
     internal static class ScopedCacheDefaults
     {
-        internal const int MaxRetry = 5;
+        internal const int MaxRetry = 64;
         internal static readonly string RetryFailureMessage = $"Exceeded {MaxRetry} attempts to create a lifetime.";
     }
 }

--- a/BitFaster.Caching/Throw.cs
+++ b/BitFaster.Caching/Throw.cs
@@ -55,7 +55,7 @@ namespace BitFaster.Caching
         private static InvalidOperationException CreateScopedRetryFailure() => new InvalidOperationException(ScopedCacheDefaults.RetryFailureMessage);
         
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static ObjectDisposedException CreateObjectDisposedException<T>() => new ObjectDisposedException(nameof(T));
+        private static ObjectDisposedException CreateObjectDisposedException<T>() => new ObjectDisposedException(typeof(T).Name);
 
         [ExcludeFromCodeCoverage]
         private static string GetArgumentString(ExceptionArgument argument)


### PR DESCRIPTION
See the [wikipedia description for the ABA problem](https://en.wikipedia.org/wiki/ABA_problem).

At some point, ReferenceCount was updated to implement IEquatable (possibly because code analysis said this is a good idea). This changed `operator ==` from the default which tests whether two references of that type refer to the same object, to comparing for field equality. 

This broke the `Scoped` class. Specifically, [this line](https://github.com/bitfaster/BitFaster.Caching/blob/5ffc05a6317ad1af4874d59ad8a45c381b0c0f02/BitFaster.Caching/Scoped.cs#L54) and [this line](https://github.com/bitfaster/BitFaster.Caching/blob/5ffc05a6317ad1af4874d59ad8a45c381b0c0f02/BitFaster.Caching/Scoped.cs#L83) are now susceptible to the ABA problem because the equality operator is checking field values:

`if (oldRefCount == Interlocked.CompareExchange(ref this.refCount, oldRefCount.IncrementCopy(), oldRefCount))`

This issue does not affect SingletonCache, because it does not depend on `operator==` or `operator!=`.

There was a further bug in `Scoped.DecrementReferenceCount()` caused by reading a stale value of `this.refCount.Count` after it was replaced by a compare exchange call.

