### PR TITLE
Extend timeout for mpsc buffer test

### DIFF
--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -192,17 +192,10 @@ namespace BitFaster.Caching.UnitTests.Buffers
                 {
                     while (true)
                     {
-                        var status = buffer.TryAdd("hello");
-
-                        if (status == BufferStatus.Success)
+                        if (buffer.TryAdd("hello") == BufferStatus.Success)
                         {
                             break;
                         }
-                        else if (status == BufferStatus.Full) 
-                        {
-                            throw new InvalidOperationException("Buffer is full!");
-                        }
-
                         spin.SpinOnce();
                     }
                     count++;

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -1,20 +1,23 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BitFaster.Caching.UnitTests.Buffers
 {
     public class MpscBoundedBufferTests
     {
+        private readonly ITestOutputHelper testOutputHelper;
         private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
         private readonly MpscBoundedBuffer<string> buffer = new MpscBoundedBuffer<string>(10);
+
+        public MpscBoundedBufferTests(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
 
         [Fact]
         public void WhenSizeIsLessThan1CtorThrows()
@@ -177,6 +180,8 @@ namespace BitFaster.Caching.UnitTests.Buffers
         [Fact]
         public async Task WhileBufferIsFilledItemsCanBeTaken()
         {
+            this.testOutputHelper.WriteLine($"ProcessorCount={Environment.ProcessorCount}.");
+
             var buffer = new MpscBoundedBuffer<string>(1024);
 
             var fill = Threaded.Run(4, () =>
@@ -219,13 +224,15 @@ namespace BitFaster.Caching.UnitTests.Buffers
                 }
             });
 
-            await fill.TimeoutAfter(Timeout, $"fill timed out, ProcessorCount={Environment.ProcessorCount}.");
+            await fill.TimeoutAfter(Timeout, $"fill timed out");
             await take.TimeoutAfter(Timeout, "take timed out");
         }
 
         [Fact]
         public async Task WhileBufferIsFilledBufferCanBeDrained()
         {
+            this.testOutputHelper.WriteLine($"ProcessorCount={Environment.ProcessorCount}.");
+
             var buffer = new MpscBoundedBuffer<string>(1024);
 
             var fill = Threaded.Run(4, () =>

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -200,10 +200,14 @@ namespace BitFaster.Caching.UnitTests.Buffers
 
             while (taken < 1024)
             {
+                var spin = new SpinWait();
+
                 if (buffer.TryTake(out var _) == BufferStatus.Success) 
                 {
                     taken++;
                 }
+
+                spin.SpinOnce();
             }
 
             await fill;

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -202,12 +202,10 @@ namespace BitFaster.Caching.UnitTests.Buffers
             while (taken < 1024)
             {
                 var spin = new SpinWait();
-
                 if (buffer.TryTake(out var _) == BufferStatus.Success) 
                 {
                     taken++;
                 }
-
                 spin.SpinOnce();
             }
 

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -13,7 +13,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
 {
     public class MpscBoundedBufferTests
     {
-        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(1);
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
         private readonly MpscBoundedBuffer<string> buffer = new MpscBoundedBuffer<string>(10);
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -196,6 +196,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
                 }
             });
 
+            Thread.Yield();
             int taken = 0;
 
             while (taken < 1024)

--- a/BitFaster.Caching.UnitTests/TaskExtensions.cs
+++ b/BitFaster.Caching.UnitTests/TaskExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public static class TaskExtensions
+    {
+        public static async Task TimeoutAfter(this Task task, TimeSpan timeout, string message)
+        {
+            if (task == await Task.WhenAny(task, Task.Delay(timeout)))
+                await task;
+            else
+                throw new TimeoutException(message);
+        }
+    }
+}

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -2,7 +2,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using BitFaster.Caching.Lfu;
 
 namespace BitFaster.Caching.Buffers
 {
@@ -97,7 +96,7 @@ namespace BitFaster.Caching.Buffers
 
             if (Interlocked.CompareExchange(ref this.headAndTail.Tail, tail + 1, tail) == tail)
             {
-                int index = (int)(tail & mask);
+                int index = tail & mask;
                 Volatile.Write(ref buffer[index], item);
 
                 return BufferStatus.Success;


### PR DESCRIPTION
It seems like the core problem is that xunit will start to heavily parallelize test execution, and the github action runs on a 2 core machine. Previous bug fix PR added two more soak tests, which led to more severe thread starvation. Increasing the timeout makes this much more stable. Next step will be to break out soak tests and [not run them in parallel](https://xunit.net/docs/running-tests-in-parallel).

- Removed use of `[Fact(Timeout=x]` because it is documented as undefined behavior when tests are run in parallel
- Added `Task.TimeoutAfter` extension method. This is likely not better, because the real issue is xunit scheduling too many threads.
- Cleaned up using statement/redundant cast in `MpscBoundedBuffer`