### PR TITLE
increase ttl

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -78,7 +78,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenValueEvictedItemRemovedEventIsFired()
         {
-            var lruEvents = CreateTLru<int, int>(new EqualCapacityPartition(6), timeToLive);
+            var lruEvents = CreateTLru<int, int>(new EqualCapacityPartition(6), TimeSpan.FromSeconds(10));
             lruEvents.Events.Value.ItemRemoved += OnLruItemRemoved;
 
             // First 6 adds


### PR DESCRIPTION
Items get removed due to exceeding TTL, causing test to fail. Set a higher TTL to avoid this (event test is not intended to verify time based expiry fires the event).

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/66d75928-1eb8-4b8d-900c-c34efdf1267f)
