### PR TITLE
fix atomic factory soak test

### DIFF
--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactorySoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactorySoakTests.cs
@@ -12,7 +12,11 @@ namespace BitFaster.Caching.UnitTests.Atomic
         [Fact]
         public async Task WhenGetOrAddIsConcurrentValuesCreatedAtomically()
         {
-            var cache = new ConcurrentLruBuilder<int, int>().WithAtomicGetOrAdd().WithCapacity(1024).Build();
+            var cache = new ConcurrentLruBuilder<int, int>()
+                .WithAtomicGetOrAdd()
+                .WithMetrics()
+                .WithCapacity(1024)
+                .Build();
 
             var counters = new int[4];
 
@@ -24,6 +28,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 }
             });
 
+            cache.Metrics.Value.Evicted.Should().Be(0);
             counters.Sum(x => x).Should().Be(1024);
         }
     }

--- a/BitFaster.Caching/Atomic/AtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactory.cs
@@ -14,7 +14,7 @@ namespace BitFaster.Caching.Atomic
     [DebuggerDisplay("IsValueCreated={IsValueCreated}, Value={ValueIfCreated}")]
     public sealed class AtomicFactory<K, V> : IEquatable<AtomicFactory<K, V>>
     {
-        private volatile Initializer initializer;
+        private Initializer initializer;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private V value;
@@ -94,12 +94,12 @@ namespace BitFaster.Caching.Atomic
 
         private V CreateValue<TFactory>(K key, TFactory valueFactory) where TFactory : struct, IValueFactory<K, V>
         {
-            var init = initializer;
+            var init = Volatile.Read(ref initializer);
 
             if (init != null)
             {
                 value = init.CreateValue(key, valueFactory);
-                initializer = null;
+                Volatile.Write(ref initializer, null);
             }
 
             return value;

--- a/BitFaster.Caching/Atomic/AtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactory.cs
@@ -74,7 +74,7 @@ namespace BitFaster.Caching.Atomic
         /// <summary>
         /// Gets a value indicating whether the value has been initialized.
         /// </summary>
-        public bool IsValueCreated => initializer == null;
+        public bool IsValueCreated => Volatile.Read(ref initializer) == null;
 
         /// <summary>
         /// Gets the value if it has been initialized, else default.
@@ -99,7 +99,7 @@ namespace BitFaster.Caching.Atomic
             if (init != null)
             {
                 value = init.CreateValue(key, valueFactory);
-                Volatile.Write(ref initializer, null);
+                Volatile.Write(ref initializer, null); // volatile write must occur after setting value
             }
 
             return value;
@@ -135,18 +135,12 @@ namespace BitFaster.Caching.Atomic
 
         private class Initializer
         {
-            private readonly object syncLock = new();
             private bool isInitialized;
             private V value;
 
             public V CreateValue<TFactory>(K key, TFactory valueFactory) where TFactory : struct, IValueFactory<K, V>
             {
-                if (Volatile.Read(ref isInitialized))
-                {
-                    return value;
-                }
-
-                lock (syncLock)
+                lock (this)
                 {
                     if (Volatile.Read(ref isInitialized))
                     {

--- a/BitFaster.Caching/Atomic/AtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactory.cs
@@ -14,7 +14,7 @@ namespace BitFaster.Caching.Atomic
     [DebuggerDisplay("IsValueCreated={IsValueCreated}, Value={ValueIfCreated}")]
     public sealed class AtomicFactory<K, V> : IEquatable<AtomicFactory<K, V>>
     {
-        private Initializer initializer;
+        private volatile Initializer initializer;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private V value;


### PR DESCRIPTION
Soak test for AtomicFactory fails intermittently:

```
[xUnit.net 00:00:59.66]     AtomicFactorySoakTests.WhenGetOrAddIsConcurrentValuesCreatedAtomically [FAIL]
  Failed Atomic.AtomicFactorySoakTests.WhenGetOrAddIsConcurrentValuesCreatedAtomically [26 ms]
  Error Message:
   Expected counters.Sum(x => x) to be 1024, but found 1071 (difference of 47).
```

This is due to items being evicted by `ConcurrentLru` (which is not expected given that item count falls within capacity). Switch to a pre-allocated `ConcurrentDictionary`, and investigate the warmup bug separately.

Also moved the volatile read in the AtomicFactory code.