### PR TITLE
Use prime for ConcurrentDictionary initial size

### DIFF
--- a/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
+++ b/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
@@ -1,20 +1,117 @@
-﻿using BitFaster.Caching;
+﻿using System.Collections.Generic;
+using System;
+using BitFaster.Caching;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BitFaster.Caching.UnitTests
 {
     public class HashTablePrimesTests
     {
+        private readonly ITestOutputHelper testOutputHelper;
+
+        public HashTablePrimesTests(ITestOutputHelper testOutputHelper)
+        {
+            this.testOutputHelper = testOutputHelper;
+        }
+
         [Theory]
         [InlineData(3, 7)]
         [InlineData(8, 11)]
         [InlineData(12, 17)]
-        [InlineData(132, 131)]
-        [InlineData(500, 131)]
+        [InlineData(132, 137)]
+        [InlineData(500, 137)]
         public void NextPrimeGreaterThan(int input, int nextPrime)
         {
             HashTablePrimes.NextPrimeGreaterThan(input).Should().Be(nextPrime);
+        }
+
+        // This test method replicates the hash table sizes that will be computed by ConcurrentDictionary
+        // on earlier versions of .NET before prime numbers are used.
+        // 277 prime
+        // 557 prime
+        // 1117 prime
+        // 2237 prime
+        // 4477 has factors 11, 37, 121, 407
+        // 8957 has factors 13, 53, 169, 689
+        // 17917 has factors 19, 23, 41, 437, 779, 943
+        // 35837 prime
+        // 71677 has factors 229, 313
+        // 143357 prime
+        // 286717 has factors 163, 1759
+        // 573437 prime
+        // 1146877 prime
+        // 2293757 prime
+        // 4587517 has factors 11, 103, 1133, 4049, 44539, 417047
+        // 9175037 prime
+        // 18350077 has factors 701, 26177
+        // 36700157 has factors 13, 23, 299, 122743, 1595659, 2823089
+        // 73400317 has factors 4999, 14683
+        // 146800637 prime
+        // 293601277 has factors 6113, 48029
+        // 587202557 has factors 1877, 312841
+        // 1174405117 has factors 10687, 109891
+        [Fact(Skip="Not a functional test")]
+        public void ComputeHashTableSizes()
+        {
+            // candidates: 137, 151, 163, 211
+            int size = 137;
+            for (int i = 0; i < 23; i++)
+            {
+                int nextSize = NextTableSize(size);
+                this.testOutputHelper.WriteLine($"{nextSize} {GetFactorsString(nextSize)}");
+                size = nextSize;
+            }
+        }
+
+        private static int NextTableSize(int initial)
+        {
+            // Double the size of the buckets table and add one, so that we have an odd integer.
+            int newLength = initial * 2 + 1;
+
+            // Now, we only need to check odd integers, and find the first that is not divisible
+            // by 3, 5 or 7.
+            while (newLength % 3 == 0 || newLength % 5 == 0 || newLength % 7 == 0)
+            {
+                newLength += 2;
+            }
+
+            return newLength;
+        }
+
+        private static string GetFactorsString(int nextSize)
+        {
+            var factors = Factor(nextSize);
+
+            if (factors.Count == 0)
+            {
+                return "prime";
+            }
+
+            return $"has factors {string.Join(", ", factors)}";
+        }
+
+        private static List<int> Factor(int number)
+        {
+            var factors = new List<int>();
+            int max = (int)Math.Sqrt(number);  // Round down
+
+            for (int factor = 1; factor <= max; ++factor) // Test from 1 to the square root, or the int below it, inclusive.
+            {
+                if (number % factor == 0)
+                {
+                    factors.Add(factor);
+                    if (factor != number / factor) // Don't add the square root twice!  Thanks Jon
+                        factors.Add(number / factor);
+                }
+            }
+
+            factors.Remove(1);
+            factors.Remove(number);
+            factors.Sort();
+
+            return factors;
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
+++ b/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
@@ -65,6 +65,8 @@ namespace BitFaster.Caching.UnitTests
             }
         }
 
+        // Replicates .NET framework ConcurrentDictionary resize logic:
+        // https://github.com/microsoft/referencesource/blob/51cf7850defa8a17d815b4700b67116e3fa283c2/mscorlib/system/collections/Concurrent/ConcurrentDictionary.cs#L1828C29-L1828C29
         private static int NextTableSize(int initial)
         {
             // Double the size of the buckets table and add one, so that we have an odd integer.

--- a/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
+++ b/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
@@ -84,6 +84,10 @@ namespace BitFaster.Caching.UnitTests
         {
             var factors = Factor(nextSize);
 
+            factors.Remove(1);
+            factors.Remove(nextSize);
+            factors.Sort();
+
             if (factors.Count == 0)
             {
                 return "prime";
@@ -92,6 +96,7 @@ namespace BitFaster.Caching.UnitTests
             return $"has factors {string.Join(", ", factors)}";
         }
 
+        // https://stackoverflow.com/questions/239865/best-way-to-find-all-factors-of-a-given-number
         private static List<int> Factor(int number)
         {
             var factors = new List<int>();
@@ -106,10 +111,6 @@ namespace BitFaster.Caching.UnitTests
                         factors.Add(number / factor);
                 }
             }
-
-            factors.Remove(1);
-            factors.Remove(number);
-            factors.Sort();
 
             return factors;
         }

--- a/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
+++ b/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
@@ -29,33 +29,34 @@ namespace BitFaster.Caching.UnitTests
 
         // This test method replicates the hash table sizes that will be computed by ConcurrentDictionary
         // on earlier versions of .NET before prime numbers are used.
-        // 277 prime
-        // 557 prime
-        // 1117 prime
-        // 2237 prime
+        // 277 is prime
+        // 557 is prime
+        // 1117 is prime
+        // 2237 is prime
         // 4477 has factors 11, 37, 121, 407
         // 8957 has factors 13, 53, 169, 689
         // 17917 has factors 19, 23, 41, 437, 779, 943
-        // 35837 prime
+        // 35837 is prime
         // 71677 has factors 229, 313
-        // 143357 prime
+        // 143357 is prime
         // 286717 has factors 163, 1759
-        // 573437 prime
-        // 1146877 prime
-        // 2293757 prime
+        // 573437 is prime
+        // 1146877 is prime
+        // 2293757 is prime
         // 4587517 has factors 11, 103, 1133, 4049, 44539, 417047
-        // 9175037 prime
+        // 9175037 is prime
         // 18350077 has factors 701, 26177
         // 36700157 has factors 13, 23, 299, 122743, 1595659, 2823089
         // 73400317 has factors 4999, 14683
-        // 146800637 prime
+        // 146800637 is prime
         // 293601277 has factors 6113, 48029
         // 587202557 has factors 1877, 312841
         // 1174405117 has factors 10687, 109891
         [Fact(Skip="Not a functional test")]
         public void ComputeHashTableSizes()
         {
-            // candidates: 137, 151, 163, 211
+            // 137 gives a good balance of primes for smaller sizes, and few factors for larger sizes.
+            // Other good candidates: 131, 151, 163, 211
             int size = 137;
             for (int i = 0; i < 23; i++)
             {
@@ -92,7 +93,7 @@ namespace BitFaster.Caching.UnitTests
 
             if (factors.Count == 0)
             {
-                return "prime";
+                return "is prime";
             }
 
             return $"has factors {string.Join(", ", factors)}";

--- a/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
+++ b/BitFaster.Caching.UnitTests/HashTablePrimesTests.cs
@@ -1,0 +1,20 @@
+﻿using BitFaster.Caching;
+using FluentAssertions;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public class HashTablePrimesTests
+    {
+        [Theory]
+        [InlineData(3, 7)]
+        [InlineData(8, 11)]
+        [InlineData(12, 17)]
+        [InlineData(132, 131)]
+        [InlineData(500, 131)]
+        public void NextPrimeGreaterThan(int input, int nextPrime)
+        {
+            HashTablePrimes.NextPrimeGreaterThan(input).Should().Be(nextPrime);
+        }
+    }
+}

--- a/BitFaster.Caching/HashTablePrimes.cs
+++ b/BitFaster.Caching/HashTablePrimes.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BitFaster.Caching
+{
+    internal class HashTablePrimes
+    {
+#if NETSTANDARD2_0
+        internal static int[] Primes = new int[] {
+#else
+        internal static ReadOnlySpan<int> Primes => new int[] {
+#endif
+            7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107
+        };
+
+        internal static int NextPrimeGreaterThan(int min)
+        {
+            foreach (int prime in Primes)
+            {
+                if (prime > min)
+                { 
+                    return prime; 
+                }
+            }
+
+            return 131;
+        }
+    }
+}

--- a/BitFaster.Caching/HashTablePrimes.cs
+++ b/BitFaster.Caching/HashTablePrimes.cs
@@ -11,7 +11,7 @@ namespace BitFaster.Caching
 #else
         internal static ReadOnlySpan<int> Primes => new int[] {
 #endif
-            7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107
+            7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131
         };
 
         internal static int NextPrimeGreaterThan(int min)
@@ -24,7 +24,7 @@ namespace BitFaster.Caching
                 }
             }
 
-            return 131;
+            return 137;
         }
     }
 }

--- a/BitFaster.Caching/HashTablePrimes.cs
+++ b/BitFaster.Caching/HashTablePrimes.cs
@@ -1,26 +1,18 @@
 ﻿using System;
-using System.Buffers.Text;
-using System.Collections.Concurrent;
-using System.Collections;
-using System.Collections.Generic;
-using System.Drawing;
-using System.IO;
-using System.Reflection.Metadata;
-using System.Runtime.Intrinsics.X86;
-using System.Text;
-using static BitFaster.Caching.Buffers.MpmcBoundedBuffer<T>;
-using static System.Net.Mime.MediaTypeNames;
-using System.Text.RegularExpressions;
+
 namespace BitFaster.Caching
 {
-    // Using the capacity passed into the cache ctor to initialize the ConcurrentDictionary  has 2 problems:
+    // Using the capacity passed into the cache ctor to initialize the ConcurrentDictionary has 2 problems:
     //
-    // 1. By allocating up front, we eliminate resizing.However, if the capacity is very large and the cache is not used,
+    // 1. By allocating up front, we eliminate resizing. However, if the capacity is very large and the cache is not used,
     // we will waste a lot of memory.
     // 2. On earlier versions of .NET, ConcurrentDictionary uses the capacity arg to directly initialize the hash table
-    // size (as noted here). On resize, the hashtable is grown to 2x + 1 while avoiding factors of 3, 5, or 7 (but not larger). On newer versions of.NET, both initial size and resize is based the next prime number larger than capacity. Collisions are reduced when hash table size is prime, as noted here. Hence the change to use primes in all cases in newer versions of the framework.
+    // size. On resize, the hashtable is grown to 2x + 1 while avoiding factors of 3, 5, or 7 (but not larger). On
+    // newer versions of.NET, both initial size and resize is based the next prime number larger than capacity. Collisions
+    // are reduced when hash table size is prime. Hence the change to use primes in all cases in newer versions of the
+    // framework.
     //
-    // To mitigate these issues, adopt a simple scheme: find the next prime larger than the capacity arg, up to 137. If the
+    // To mitigate this, we adopt a simple scheme: find the next prime larger than the capacity arg, up to 137. If the
     // capacity is greater than 137, just set the initial size to 137, thereby bounding initial memory consumption for
     // large caches.
     // 

--- a/BitFaster.Caching/HashTablePrimes.cs
+++ b/BitFaster.Caching/HashTablePrimes.cs
@@ -1,9 +1,34 @@
 ﻿using System;
+using System.Buffers.Text;
+using System.Collections.Concurrent;
+using System.Collections;
 using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Runtime.Intrinsics.X86;
 using System.Text;
-
+using static BitFaster.Caching.Buffers.MpmcBoundedBuffer<T>;
+using static System.Net.Mime.MediaTypeNames;
+using System.Text.RegularExpressions;
 namespace BitFaster.Caching
 {
+    // Using the capacity passed into the cache ctor to initialize the ConcurrentDictionary  has 2 problems:
+    //
+    // 1. By allocating up front, we eliminate resizing.However, if the capacity is very large and the cache is not used,
+    // we will waste a lot of memory.
+    // 2. On earlier versions of .NET, ConcurrentDictionary uses the capacity arg to directly initialize the hash table
+    // size (as noted here). On resize, the hashtable is grown to 2x + 1 while avoiding factors of 3, 5, or 7 (but not larger). On newer versions of.NET, both initial size and resize is based the next prime number larger than capacity. Collisions are reduced when hash table size is prime, as noted here. Hence the change to use primes in all cases in newer versions of the framework.
+    //
+    // To mitigate these issues, adopt a simple scheme: find the next prime larger than the capacity arg, up to 137. If the
+    // capacity is greater than 137, just set the initial size to 137, thereby bounding initial memory consumption for
+    // large caches.
+    // 
+    // - Older.NET implementations: For smaller caches, we fix size at the next largest prime. For larger tables, we now
+    // start out with a larger prime (avoiding all factors up to 137, not just 3, 5 and 7). Above 137, some sizes will be
+    // prime and others have relatively few factors.The complete list is given as a comment in the unit test code.
+    // - Newer.NET implementations: as above for smaller caches. For larger caches, the resize will use successively larger
+    // primes.The duplicate prime computation added is only during construction and is effectively a no-op.
     internal class HashTablePrimes
     {
 #if NETSTANDARD2_0
@@ -13,14 +38,13 @@ namespace BitFaster.Caching
 #endif
             7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131
         };
-
         internal static int NextPrimeGreaterThan(int min)
         {
             foreach (int prime in Primes)
             {
                 if (prime > min)
-                { 
-                    return prime; 
+                {
+                    return prime;
                 }
             }
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -90,8 +90,8 @@ namespace BitFaster.Caching.Lfu
         /// <param name="comparer">The equality comparer.</param>
         public ConcurrentLfu(int concurrencyLevel, int capacity, IScheduler scheduler, IEqualityComparer<K> comparer)
         {
-            capacity = HashTablePrimes.NextPrimeGreaterThan(capacity);
-            this.dictionary = new ConcurrentDictionary<K, LfuNode<K, V>>(concurrencyLevel, capacity, comparer);
+            int dictionaryCapacity = HashTablePrimes.NextPrimeGreaterThan(capacity);
+            this.dictionary = new ConcurrentDictionary<K, LfuNode<K, V>>(concurrencyLevel, dictionaryCapacity, comparer);
 
             // cap concurrency at proc count * 2
             int readStripes = Math.Min(BitOps.CeilingPowerOfTwo(concurrencyLevel), BitOps.CeilingPowerOfTwo(Environment.ProcessorCount * 2));

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -90,6 +90,7 @@ namespace BitFaster.Caching.Lfu
         /// <param name="comparer">The equality comparer.</param>
         public ConcurrentLfu(int concurrencyLevel, int capacity, IScheduler scheduler, IEqualityComparer<K> comparer)
         {
+            capacity = HashTablePrimes.NextPrimeGreaterThan(capacity);
             this.dictionary = new ConcurrentDictionary<K, LfuNode<K, V>>(concurrencyLevel, capacity, comparer);
 
             // cap concurrency at proc count * 2

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -52,8 +52,8 @@ namespace BitFaster.Caching.Lru
                 Throw.ArgNull(ExceptionArgument.comparer);
 
             this.capacity = capacity;
-            int dcap = HashTablePrimes.NextPrimeGreaterThan(capacity);
-            this.dictionary = new ConcurrentDictionary<K, LinkedListNode<LruItem>>(concurrencyLevel, dcap, comparer);
+            int dictionaryCapacity = HashTablePrimes.NextPrimeGreaterThan(capacity);
+            this.dictionary = new ConcurrentDictionary<K, LinkedListNode<LruItem>>(concurrencyLevel, dictionaryCapacity, comparer);
             this.policy = new CachePolicy(new Optional<IBoundedPolicy>(this), Optional<ITimePolicy>.None());
         }
 

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -52,7 +52,8 @@ namespace BitFaster.Caching.Lru
                 Throw.ArgNull(ExceptionArgument.comparer);
 
             this.capacity = capacity;
-            this.dictionary = new ConcurrentDictionary<K, LinkedListNode<LruItem>>(concurrencyLevel, this.capacity + 1, comparer);
+            int dcap = HashTablePrimes.NextPrimeGreaterThan(capacity);
+            this.dictionary = new ConcurrentDictionary<K, LinkedListNode<LruItem>>(concurrencyLevel, dcap, comparer);
             this.policy = new CachePolicy(new Optional<IBoundedPolicy>(this), Optional<ITimePolicy>.None());
         }
 

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -88,7 +88,7 @@ namespace BitFaster.Caching.Lru
             this.warmQueue = new ConcurrentQueue<I>();
             this.coldQueue = new ConcurrentQueue<I>();
 
-            int dictionaryCapacity = this.Capacity + 1;
+            int dictionaryCapacity = HashTablePrimes.NextPrimeGreaterThan(this.Capacity);
 
             this.dictionary = new ConcurrentDictionary<K, I>(concurrencyLevel, dictionaryCapacity, comparer);
             this.itemPolicy = itemPolicy;


### PR DESCRIPTION
Today, the capacity passed into the cache ctor is used to initialize the `ConcurrentDictionary`. This has 2 problems:

1. By allocating up front, we eliminate resizing. However, if the capacity is very large and the cache is not used, we will waste a lot of memory.
2. On earlier versions of .NET, `ConcurrentDictionary` uses the capacity arg to directly initialize the hash table size (as noted [here](https://stackoverflow.com/questions/60005428/concurrentdictionary-proper-small-initial-capacity)). On resize, the hashtable is grown to [2x + 1 while avoiding factors of 3, 5, or 7 (but not larger)](https://github.com/microsoft/referencesource/blob/master/mscorlib/system/collections/Concurrent/ConcurrentDictionary.cs). On newer versions of .NET, both initial size and resize is based the next prime number larger than capacity. Collisions are reduced when hash table size is prime, as noted [here](https://cs.stackexchange.com/questions/11029/why-is-it-best-to-use-a-prime-number-as-a-mod-in-a-hashing-function). Hence the change to use primes in all cases in newer versions of the framework.

To mitigate these issues, adopt a simple scheme: find the next prime larger than the capacity arg, up to 137. If the capacity is greater than 137, just set the initial size to 137, thereby bounding initial memory consumption for large caches.

- Older .NET implementations: For smaller caches, we fix size at the next largest prime. For larger tables, we now start out with a larger prime (avoiding all factors up to 137, not just 3, 5 and 7). Above 137, some sizes will be prime and others have relatively few factors. The complete list is given below.
- Newer .NET implementations: as above for smaller caches. For larger caches, the resize will use successively larger primes. The duplicate prime computation added is only during construction and is effectively a no-op.

List of hash table sizes that will be selected as `ConcurrentDictionary` grows and their factors. The starting position of 137 was selected to size the most smaller tables as a prime number.
```
277 prime
557 prime
1117 prime
2237 prime
4477 has factors 11, 37, 121, 407
8957 has factors 13, 53, 169, 689
17917 has factors 19, 23, 41, 437, 779, 943
35837 prime
71677 has factors 229, 313
143357 prime
286717 has factors 163, 1759
573437 prime
1146877 prime
2293757 prime
4587517 has factors 11, 103, 1133, 4049, 44539, 417047
9175037 prime
18350077 has factors 701, 26177
36700157 has factors 13, 23, 299, 122743, 1595659, 2823089
73400317 has factors 4999, 14683
146800637 prime
293601277 has factors 6113, 48029
587202557 has factors 1877, 312841
1174405117 has factors 10687, 109891
```


