### PR TITLE
repeat tests to stabilize coverage

### DIFF
--- a/BitFaster.Caching.UnitTests/Buffers/MpmcBoundedBufferSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpmcBoundedBufferSoakTests.cs
@@ -21,9 +21,12 @@ namespace BitFaster.Caching.UnitTests.Buffers
             this.testOutputHelper = testOutputHelper;
         }
 
-        [Fact]
-        public async Task WhenAddIsContendedBufferCanBeFilled()
+        [Theory]
+        [Repeat(3)]
+        public async Task WhenAddIsContendedBufferCanBeFilled(int iteration)
         {
+            this.testOutputHelper.WriteLine($"Iteration {iteration}");
+            
             await Threaded.Run(4, () =>
             {
                 while (buffer.TryAdd("hello") != BufferStatus.Full)

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferSoakTests.cs
@@ -21,9 +21,12 @@ namespace BitFaster.Caching.UnitTests.Buffers
             this.testOutputHelper = testOutputHelper;
         }
 
-        [Fact]
-        public async Task WhenAddIsContendedBufferCanBeFilled()
+        [Theory]
+        [Repeat(3)]
+        public async Task WhenAddIsContendedBufferCanBeFilled(int iteration)
         {
+            this.testOutputHelper.WriteLine($"Iteration {iteration}");
+
             await Threaded.Run(4, () =>
             {
                 while (buffer.TryAdd("hello") != BufferStatus.Full)

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -9,7 +9,6 @@ using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using BitFaster.Caching.UnitTests.Lru;
 using FluentAssertions;
-using Microsoft.VisualBasic;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -753,12 +752,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
         //Elapsed 411.6918ms - 0.0004116918ns/op
         //Cache hits 1689839 (sampled 16.89839%)
         //Maintenance ops 31
-        [Theory]
-        [Repeat(3)]
-        public void VerifyHitsWithBackgroundScheduler(int iteration)
+        [Fact]
+        public void VerifyHitsWithBackgroundScheduler()
         {
-            this.output.WriteLine($"Iteration {iteration}");
-
             // when running all tests in parallel, sample count drops significantly: set low bar for stability.
             VerifyHits(iterations: 10_000_000, minSamples: 250_000);
         }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -9,6 +9,7 @@ using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using BitFaster.Caching.UnitTests.Lru;
 using FluentAssertions;
+using Microsoft.VisualBasic;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -752,9 +753,12 @@ namespace BitFaster.Caching.UnitTests.Lfu
         //Elapsed 411.6918ms - 0.0004116918ns/op
         //Cache hits 1689839 (sampled 16.89839%)
         //Maintenance ops 31
-        [Fact]
-        public void VerifyHitsWithBackgroundScheduler()
+        [Theory]
+        [Repeat(3)]
+        public void VerifyHitsWithBackgroundScheduler(int iteration)
         {
+            this.output.WriteLine($"Iteration {iteration}");
+
             // when running all tests in parallel, sample count drops significantly: set low bar for stability.
             VerifyHits(iterations: 10_000_000, minSamples: 250_000);
         }

--- a/BitFaster.Caching.UnitTests/RepeatAttribute.cs
+++ b/BitFaster.Caching.UnitTests/RepeatAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System.Linq;
+
+namespace BitFaster.Caching.UnitTests
+{
+    public sealed class RepeatAttribute : Xunit.Sdk.DataAttribute
+    {
+        private readonly int count;
+
+        public RepeatAttribute(int count)
+        {
+            if (count < 1)
+            {
+                throw new System.ArgumentOutOfRangeException(
+                    paramName: nameof(count),
+                    message: "Repeat count must be greater than 0."
+                    );
+            }
+            this.count = count;
+        }
+
+        public override System.Collections.Generic.IEnumerable<object[]> GetData(System.Reflection.MethodInfo testMethod)
+        {
+            foreach (var iterationNumber in Enumerable.Range(start: 1, count: this.count))
+            {
+                yield return new object[] { iterationNumber };
+            }
+        }
+    }
+}


### PR DESCRIPTION
Coverage of some cases is intermittent. Repeat soak tests to ensure coverage.

Repeat attribute taken from https://stackoverflow.com/questions/31873778/xunit-test-fact-multiple-times.

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/6f5e6ea5-2f03-4b80-a7be-821a0cabc1fd)
