### PR TITLE
consistent use of volatile/lock

### DIFF
--- a/BitFaster.Caching/Atomic/AsyncAtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/AsyncAtomicFactory.cs
@@ -94,12 +94,12 @@ namespace BitFaster.Caching.Atomic
 
         private async ValueTask<V> CreateValueAsync<TFactory>(K key, TFactory valueFactory) where TFactory : struct, IAsyncValueFactory<K, V>
         {
-            var init = initializer;
+            var init = Volatile.Read(ref initializer);
 
             if (init != null)
             {
                 value = await init.CreateValueAsync(key, valueFactory).ConfigureAwait(false);
-                initializer = null;
+                Volatile.Write(ref initializer, null);
             }
 
             return value;
@@ -107,7 +107,6 @@ namespace BitFaster.Caching.Atomic
 
         private class Initializer
         {
-            private readonly object syncLock = new();
             private bool isInitialized;
             private Task<V> valueTask;
 
@@ -145,12 +144,12 @@ namespace BitFaster.Caching.Atomic
                     return valueTask;
                 }
 
-                lock (syncLock)
+                lock (this)
                 {
-                    if (!Volatile.Read(ref isInitialized))
+                    if (!isInitialized)
                     {
                         valueTask = value;
-                        Volatile.Write(ref isInitialized, true);
+                        isInitialized = true;
                     }
                 }
 

--- a/BitFaster.Caching/Atomic/AtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactory.cs
@@ -142,13 +142,13 @@ namespace BitFaster.Caching.Atomic
             {
                 lock (this)
                 {
-                    if (Volatile.Read(ref isInitialized))
+                    if (isInitialized)
                     {
                         return value;
                     }
 
                     value = valueFactory.Create(key);
-                    Volatile.Write(ref isInitialized, true);
+                    isInitialized = true;
                     return value;
                 }
             }


### PR DESCRIPTION
- Remove redundant use of Volatile.Read/Write inside lock statements. The lock inserts a memory barrier/full fence on entry and exit, so half fences are redundant.
- Use Volatile.Read/Write consistently for checking initializer classes.
- Initializer classes lock `this` instead of allocating an additional lock object. In general, this is a bad practice, but the initializer is a private class so it cannot be locked outside the control of the enclosing class.