### PR TITLE
soak lfu add + fix detached nodes

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -111,6 +111,29 @@ namespace BitFaster.Caching.UnitTests.Lfu
             RunIntegrityCheck(lfu);
         }
 
+        [Theory]
+        [Repeat(iterations)]
+        public async Task WhenSoakConcurrentGetAndUpdateCacheEndsInConsistentState(int iteration)
+        {
+            var scheduler = new BackgroundThreadScheduler();
+            var lfu = new ConcurrentLfuBuilder<int, string>().WithCapacity(9).WithScheduler(scheduler).Build() as ConcurrentLfu<int, string>;
+
+            await Threaded.Run(4, () => {
+                for (int i = 0; i < 100000; i++)
+                {
+                    lfu.TryUpdate(i + 1, i.ToString());
+                    lfu.GetOrAdd(i + 1, i => i.ToString());
+                }
+            });
+
+            this.output.WriteLine($"iteration {iteration} keys={string.Join(" ", lfu.Keys)}");
+
+            scheduler.Dispose();
+            await scheduler.Completion;
+
+            RunIntegrityCheck(lfu);
+        }
+
         [Fact]
         public async Task ThreadedVerifyMisses()
         {

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
+using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using FluentAssertions;
@@ -16,6 +18,26 @@ namespace BitFaster.Caching.UnitTests.Lfu
         public ConcurrentLfuSoakTests(ITestOutputHelper testOutputHelper)
         {
             this.output = testOutputHelper;
+        }
+
+        [Theory]
+        [Repeat(10)]
+        public async Task WhenConcurrentGetCacheEndsInConsistentState(int iteration)
+        {
+            var lfu = new ConcurrentLfu<int, int>(9);
+
+            await Threaded.Run(4, () => {
+                for (int i = 0; i < 100000; i++)
+                {
+                    lfu.GetOrAdd(i + 1, i => i);
+                }
+            });
+
+            this.output.WriteLine($"iteration {iteration} keys={string.Join(" ", lfu.Keys)}");
+
+            // allow +/- 1 variance for capacity
+            lfu.Count.Should().BeInRange(7, 10);
+            RunIntegrityCheck(lfu);
         }
 
         [Fact]
@@ -45,6 +67,105 @@ namespace BitFaster.Caching.UnitTests.Lfu
             this.output.WriteLine($"Maintenance ops {cache.Scheduler.RunCount}");
 
             cache.Metrics.Value.Misses.Should().Be(iterations * threads);
+            RunIntegrityCheck(cache);
+        }
+
+        private void RunIntegrityCheck<K,V>(ConcurrentLfu<K,V> cache)
+        {
+            new ConcurrentLfuIntegrityChecker<K, V>(cache).Validate();
+        }
+    }
+
+    public class ConcurrentLfuIntegrityChecker<K, V>
+    {
+        private readonly ConcurrentLfu<K, V> cache;
+
+        private readonly LfuNodeList<K, V> windowLru;
+        private readonly LfuNodeList<K, V> probationLru;
+        private readonly LfuNodeList<K, V> protectedLru;
+
+        private readonly StripedMpscBuffer<LfuNode<K, V>> readBuffer;
+        private readonly MpscBoundedBuffer<LfuNode<K, V>> writeBuffer;
+
+        private static FieldInfo windowLruField = typeof(ConcurrentLfu<K, V>).GetField("windowLru", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo probationLruField = typeof(ConcurrentLfu<K, V>).GetField("probationLru", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo protectedLruField = typeof(ConcurrentLfu<K, V>).GetField("protectedLru", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        private static FieldInfo readBufferField = typeof(ConcurrentLfu<K, V>).GetField("readBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo writeBufferField = typeof(ConcurrentLfu<K, V>).GetField("writeBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
+
+        public ConcurrentLfuIntegrityChecker(ConcurrentLfu<K, V> cache)
+        {
+            this.cache = cache;
+
+            // get lrus via reflection
+            this.windowLru = (LfuNodeList<K, V>)windowLruField.GetValue(cache);
+            this.probationLru = (LfuNodeList<K, V>)probationLruField.GetValue(cache);
+            this.protectedLru = (LfuNodeList<K, V>)protectedLruField.GetValue(cache);
+
+            this.readBuffer = (StripedMpscBuffer<LfuNode<K, V>>)readBufferField.GetValue(cache);
+            this.writeBuffer = (MpscBoundedBuffer<LfuNode<K, V>>)writeBufferField.GetValue(cache);
+        }
+
+        public void Validate()
+        {
+            cache.DoMaintenance();
+
+            // buffers should be empty after maintenance
+            this.readBuffer.Count.Should().Be(0);
+            this.writeBuffer.Count.Should().Be(0);
+
+            // all the items in the LRUs must exist in the dictionary.
+            // no items should be marked as removed after maintenance has run
+            VerifyLruInDictionary(this.windowLru);
+            VerifyLruInDictionary(this.probationLru);
+            VerifyLruInDictionary(this.protectedLru);
+
+            // all the items in the dictionary must exist in the node list
+            VerifyDictionaryInLrus();
+
+            // cache must be within capacity
+            cache.Count.Should().BeLessThanOrEqualTo(cache.Capacity, "capacity out of valid range");
+        }
+
+        private void VerifyLruInDictionary(LfuNodeList<K, V> lfuNodes)
+        {
+            var node = lfuNodes.First;
+
+            while (node != null) 
+            {
+                node.WasRemoved.Should().BeFalse();
+                node.WasDeleted.Should().BeFalse();
+                cache.TryGet(node.Key, out _).Should().BeTrue();
+
+                node = node.Next;
+            }
+        }
+
+        private void VerifyDictionaryInLrus()
+        {
+            foreach (var kvp in this.cache)
+            {
+                var exists = Exists(kvp, this.windowLru) || Exists(kvp, this.probationLru) || Exists(kvp, this.protectedLru);
+                exists.Should().BeTrue();
+            }
+        }
+
+        private static bool Exists(KeyValuePair<K, V> kvp, LfuNodeList<K, V> lfuNodes)
+        {
+            var node = lfuNodes.First;
+
+            while (node != null)
+            {
+                if (EqualityComparer<K>.Default.Equals(node.Key, kvp.Key))
+                {
+                    return true;
+                }
+
+                node = node.Next;
+            }
+
+            return false;
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -89,8 +89,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Theory]
-        [Repeat(10)]
-        public async Task WhenSoakConcurrentGetAsyncWithArgCacheEndsInConsistentState(int iteration)
+        [Repeat(iterations)]
+        public async Task WhenConcurrentGetAsyncWithArgCacheEndsInConsistentState(int iteration)
         {
             var scheduler = new BackgroundThreadScheduler();
             var lfu = new ConcurrentLfuBuilder<int, string>().WithCapacity(9).WithScheduler(scheduler).Build() as ConcurrentLfu<int, string>;
@@ -110,7 +110,6 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             RunIntegrityCheck(lfu);
         }
-
 
         [Fact]
         public async Task ThreadedVerifyMisses()

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -109,12 +109,11 @@ namespace BitFaster.Caching.UnitTests.Lfu
             await scheduler.Completion;
 
             RunIntegrityCheck(lfu);
-<<<<<<< HEAD
         }
 
         [Theory]
         [Repeat(iterations)]
-        public async Task WhenSoakConcurrentGetAndUpdateCacheEndsInConsistentState(int iteration)
+        public async Task WhenConcurrentGetAndUpdateCacheEndsInConsistentState(int iteration)
         {
             var scheduler = new BackgroundThreadScheduler();
             var lfu = new ConcurrentLfuBuilder<int, string>().WithCapacity(9).WithScheduler(scheduler).Build() as ConcurrentLfu<int, string>;
@@ -133,8 +132,6 @@ namespace BitFaster.Caching.UnitTests.Lfu
             await scheduler.Completion;
 
             RunIntegrityCheck(lfu);
-=======
->>>>>>> main
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -1131,8 +1131,6 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(-8, valueFactory.Create);
             lru.GetOrAdd(-9, valueFactory.Create);
         }
-
-
     }
 
     public class ConcurrentLruIntegrityChecker<K, V, I, P, T>

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -688,6 +688,12 @@ namespace BitFaster.Caching.Lfu
 
         private void PromoteProbation(LfuNode<K, V> node)
         {
+            if (node.list == null)
+            {
+                // Ignore stale accesses for an entry that is no longer present
+                return;
+            }
+
             this.probationLru.Remove(node);
             this.protectedLru.AddLast(node);
             node.Position = Position.Protected;


### PR DESCRIPTION
This test exposed a bug - there was logic missing to handle nodes being removed while being read/updated.

In this case, the node was previously in probation, so Position=Probation, and the node's list is null (since it was removed). The debug assert attempts to verify that the probation node is attached to the list, which it is not.

```
Error Message:
   System.InvalidOperationException : Node is already attached to a different list.
  Stack Trace:
     at BitFaster.Caching.Throw.InvalidOp(String message) in /_/BitFaster.Caching/Throw.cs:line 29
   at BitFaster.Caching.Lfu.LfuNodeList`2.ValidateNode(LfuNode`2 node) in /_/BitFaster.Caching/Lfu/LfuNodeList.cs:line 140
   at BitFaster.Caching.Lfu.LfuNodeList`2.Remove(LfuNode`2 node) in /_/BitFaster.Caching/Lfu/LfuNodeList.cs:line 61
   at BitFaster.Caching.Lfu.ConcurrentLfu`2.PromoteProbation(LfuNode`2 node) in /_/BitFaster.Caching/Lfu/ConcurrentLfu.cs:line 691
   at BitFaster.Caching.Lfu.ConcurrentLfu`2.OnWrite(LfuNode`2 node) in /_/BitFaster.Caching/Lfu/ConcurrentLfu.cs:line 679
   at BitFaster.Caching.Lfu.ConcurrentLfu`2.Maintenance(LfuNode`2 droppedWrite) in /_/BitFaster.Caching/Lfu/ConcurrentLfu.cs:line 588
   at BitFaster.Caching.Lfu.ConcurrentLfu`2.AfterWrite(LfuNode`2 node) in /_/BitFaster.Caching/Lfu/ConcurrentLfu.cs:line 470
   at BitFaster.Caching.Lfu.ConcurrentLfu`2.TryAdd(K key, V value) in /_/BitFaster.Caching/Lfu/ConcurrentLfu.cs:line 205
   at BitFaster.Caching.Lfu.ConcurrentLfu`2.GetOrAdd(K key, Func`2 valueFactory) in /_/BitFaster.Caching/Lfu/ConcurrentLfu.cs:line 224
   at BitFaster.Caching.UnitTests.Lfu.ConcurrentLfuSoakTests.<>c__DisplayClass7_0.<WhenConcurrentGetAndUpdateCacheEndsInConsistentState>b__0() in D:\a\BitFaster.Caching\BitFaster.Caching\BitFaster.Caching.UnitTests\Lfu\ConcurrentLfuSoakTests.cs:line 125
```