### PR TITLE
Enable SkipLocalsInit for .NET6

### DIFF
--- a/BitFaster.Caching/AssemblyInfo.cs
+++ b/BitFaster.Caching/AssemblyInfo.cs
@@ -1,3 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 
+#if NET6_0_OR_GREATER
+[module: System.Runtime.CompilerServices.SkipLocalsInit]
+#endif
+
 [assembly: InternalsVisibleTo("BitFaster.Caching.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f55849315b02d525d40701eee5d8eba39e6a517644e8af3fa15141eab7058e76be808e36cfee8d7e071b5aac37bd5e45c67971602680f7bfc26d8c9ebca95dd33b4e3f17a4c28b01268ee6b110ad7e2106ab8ffd1c7be3143192527ce5f639395e46ab086518e881706c6ee9eb96f0263aa34e5152cf5aecf657d463fecf62ca")]


### PR DESCRIPTION
[SkipLocalsInit] can be used to improve performance - https://github.com/dotnet/roslyn/blob/master/docs/features/skiplocalsinit.md

Runtime applies this attribute on all their assemblies for 5.0 - https://github.com/dotnet/runtime/search?q=SkipLocalsInit