### PR TITLE
optimize LFU

### DIFF
--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -86,7 +86,7 @@ namespace BitFaster.Caching.Buffers
         public BufferStatus TryAdd(T item)
         {
             int head = Volatile.Read(ref headAndTail.Head);
-            int tail = Volatile.Read(ref headAndTail.Tail);
+            int tail = headAndTail.Tail;
             int size = tail - head;
 
             if (size >= buffer.Length)
@@ -117,7 +117,7 @@ namespace BitFaster.Caching.Buffers
         public BufferStatus TryTake(out T item)
         {
             int head = Volatile.Read(ref headAndTail.Head);
-            int tail = Volatile.Read(ref headAndTail.Tail);
+            int tail = headAndTail.Tail;
             int size = tail - head;
 
             if (size == 0)
@@ -136,7 +136,7 @@ namespace BitFaster.Caching.Buffers
                 return BufferStatus.Contended;
             }
 
-            Volatile.Write(ref buffer[index], null);
+            buffer[index] = null;
             Volatile.Write(ref this.headAndTail.Head, ++head);
             return BufferStatus.Success;
         }
@@ -190,7 +190,7 @@ namespace BitFaster.Caching.Buffers
 #endif
         {
             int head = Volatile.Read(ref headAndTail.Head);
-            int tail = Volatile.Read(ref headAndTail.Tail);
+            int tail = headAndTail.Tail;
             int size = tail - head;
 
             if (size == 0)
@@ -214,7 +214,7 @@ namespace BitFaster.Caching.Buffers
                     break;
                 }
 
-                Volatile.Write(ref localBuffer[index], null);
+                localBuffer[index] = null;
                 Write(output, outCount++, item);
                 head++;
             }

--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -220,7 +220,7 @@ namespace BitFaster.Caching.Buffers
             }
             while (head != tail && outCount < Length(output));
 
-            Volatile.Write(ref this.headAndTail.Head, head);
+            this.headAndTail.Head = head;
 
             return outCount;
         }

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -739,6 +739,7 @@ namespace BitFaster.Caching.Lfu
             public LfuNode<K, V> node;
             public int freq;
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public EvictIterator(CmSketch<K> sketch, LfuNode<K, V> node)
             {
                 this.sketch = sketch;
@@ -746,6 +747,7 @@ namespace BitFaster.Caching.Lfu
                 freq = node == null ? -1 : sketch.EstimateFrequency(node.Key);
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void Next()
             {
                 node = node.Next;

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -73,8 +73,6 @@ namespace BitFaster.Caching.Lfu
 
         private readonly LfuNode<K, V>[] drainBuffer;
 
-        private readonly Action drainBuffersAction;
-
         /// <summary>
         /// Initializes a new instance of the ConcurrentLfu class with the specified capacity.
         /// </summary>
@@ -114,11 +112,6 @@ namespace BitFaster.Caching.Lfu
             this.scheduler = scheduler;
 
             this.drainBuffer = new LfuNode<K, V>[this.readBuffer.Capacity];
-
-            drainBuffersAction = () =>
-                {
-                    this.DrainBuffers();
-                };
         }
 
         // No lock count: https://arbel.net/2013/02/03/best-practices-for-using-concurrentdictionary/
@@ -532,7 +525,7 @@ namespace BitFaster.Caching.Lfu
                     }
 
                     this.drainStatus.NonVolatileWrite(DrainStatus.ProcessingToIdle);
-                    scheduler.Run(drainBuffersAction);
+                    scheduler.Run(() => this.DrainBuffers());
                 }
             }
             finally

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -479,9 +479,10 @@ namespace BitFaster.Caching.Lfu
         private void ScheduleAfterWrite()
         {
             var spinner = new SpinWait();
+            int status = this.drainStatus.NonVolatileRead();
             while (true)
             {
-                switch (this.drainStatus.NonVolatileRead())
+                switch (status)
                 {
                     case DrainStatus.Idle:
                         this.drainStatus.Cas(DrainStatus.Idle, DrainStatus.Required);
@@ -495,6 +496,7 @@ namespace BitFaster.Caching.Lfu
                         {
                             return;
                         }
+                        status = this.drainStatus.VolatileRead();
                         break;
                     case DrainStatus.ProcessingToRequired:
                         return;


### PR DESCRIPTION
Optimizations:
- Successive buffer reads/writes don't need two volatile ops. They can piggyback.
- Closely match Caffeine volatile operations with regard to drain status.
- Inline drain status
- Inline EvictIterator

This is definitely faster, but less stable during the benchmark run - fluctuating between 23 ns/op - 33 ns/op. Gain is most consistent on the evict throughput.

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/90fe8eb8-fd6a-4047-a5da-bdcffe7d13c2)
![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/bd483b23-aefb-4870-9ce6-e3d701cf1764)

