### PR TITLE
Revise LRU eviction logic

### DIFF
--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -312,7 +312,7 @@ namespace BitFaster.Caching.Lru
                     if (((ICollection<KeyValuePair<K, I>>)this.dictionary).Remove(kvp))
 #endif
                     {
-                        OnRemove(item.Key, kvp.Value);
+                        OnRemove(item.Key, kvp.Value, ItemRemovedReason.Removed);
                         return true;
                     }
                 }
@@ -333,7 +333,7 @@ namespace BitFaster.Caching.Lru
         {
             if (this.dictionary.TryRemove(key, out var item))
             {
-                OnRemove(key, item);
+                OnRemove(key, item, ItemRemovedReason.Removed);
                 value = item.Value;
                 return true;
             }
@@ -349,7 +349,7 @@ namespace BitFaster.Caching.Lru
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void OnRemove(K key, I item)
+        private void OnRemove(K key, I item, ItemRemovedReason reason)
         {
             // Mark as not accessed, it will later be cycled out of the queues because it can never be fetched 
             // from the dictionary. Note: Hot/Warm/Cold count will reflect the removed item until it is cycled 
@@ -357,7 +357,7 @@ namespace BitFaster.Caching.Lru
             item.WasAccessed = false;
             item.WasRemoved = true;
 
-            this.telemetryPolicy.OnItemRemoved(key, item.Value, ItemRemovedReason.Removed);
+            this.telemetryPolicy.OnItemRemoved(key, item.Value, reason);
 
             // serialize dispose (common case dispose not thread safe)
             lock (item)
@@ -756,7 +756,7 @@ namespace BitFaster.Caching.Lru
                     if (((ICollection<KeyValuePair<K, I>>)this.dictionary).Remove(kvp))
 #endif
                     {
-                        OnRemove(item.Key, item);
+                        OnRemove(item.Key, item, removedReason);
                     }
                     break;
             }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -555,12 +555,9 @@ namespace BitFaster.Caching.Lru
                     (dest, count) = CycleCold(count);
                 }
 
-                // If we get here, we have cycled the queues multiple times and still have not removed an item.
-                // This can happen if the cache is full of items that are not discardable. In this case, we simply
-                // discard the coldest item to avoid unbounded growth.
+                // If nothing was removed yet, constrain the size of warm and cold by discarding the coldest item.
                 if (dest != ItemDestination.Remove)
                 {
-                    // if an item was last moved into warm, move the last warm item to cold to prevent enlarging warm
                     if (dest == ItemDestination.Warm && count > this.capacity.Warm)
                     {
                         count = LastWarmToCold();
@@ -730,6 +727,7 @@ namespace BitFaster.Caching.Lru
         {
             if (coldCount > this.capacity.Cold && this.coldQueue.TryDequeue(out var item))
             {
+                Interlocked.Decrement(ref this.counter.cold);
                 this.Move(item, ItemDestination.Remove, removedReason);
             }
         }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -801,7 +801,12 @@ namespace BitFaster.Caching.Lru
         // it becomes immutable. However, this object is then somewhere else on the 
         // heap, which slows down the policies with hit counter logic in benchmarks. Likely
         // this approach keeps the structs data members in the same CPU cache line as the LRU.
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [DebuggerDisplay("Hit = {Hits}, Miss = {Misses}, Upd = {Updated}, Evict = {Evicted}")]
+#else
+        [DebuggerDisplay("Hit = {Hits}, Miss = {Misses}, Evict = {Evicted}")]
+#endif
         private class Proxy : ICacheMetrics, ICacheEvents<K, V>, IBoundedPolicy, ITimePolicy
         {
             private readonly ConcurrentLruCore<K, V, I, P, T> lru;

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -764,7 +764,7 @@ namespace BitFaster.Caching.Lru
 
                         this.telemetryPolicy.OnItemRemoved(item.Key, item.Value, removedReason);
 
-                        //lock (item)
+                        lock (item)
                         {
                             Disposer<V>.Dispose(item.Value);
                         }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -546,15 +546,19 @@ namespace BitFaster.Caching.Lru
             {
                 (var dest, var count) = CycleHot(hotCount);
 
-                if (dest == ItemDestination.Warm)
+                int cycles = 0;
+                while (cycles++ < 3 && dest != ItemDestination.Remove)
                 {
-                    (dest, count) = CycleWarm(count);
+                    if (dest == ItemDestination.Warm)
+                    {
+                        (dest, count) = CycleWarm(count);
+                    }
+                    else if (dest == ItemDestination.Cold)
+                    {
+                        (dest, count) = CycleCold(count);
+                    }
                 }
-                else if (dest == ItemDestination.Cold)
-                {
-                    (dest, count) = CycleCold(count);
-                }
-
+                
                 // If nothing was removed yet, constrain the size of warm and cold by discarding the coldest item.
                 if (dest != ItemDestination.Remove)
                 {

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -566,7 +566,7 @@ namespace BitFaster.Caching.Lru
                         LastWarmToCold();
                     }
 
-                    RemoveCold(ItemRemovedReason.Evicted);
+                    ConstrainCold(ItemRemovedReason.Evicted);
                 }
             }
             else
@@ -725,13 +725,13 @@ namespace BitFaster.Caching.Lru
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void RemoveCold(ItemRemovedReason removedReason) 
+        private void ConstrainCold(ItemRemovedReason removedReason)
         {
-            Interlocked.Decrement(ref this.counter.cold);
+            int cc = Interlocked.Decrement(ref this.counter.cold);
 
-            if (this.coldQueue.TryDequeue(out var item))
+            if (cc == this.capacity.Cold && this.coldQueue.TryDequeue(out var item))
             {
-                 this.Move(item, ItemDestination.Remove, removedReason);
+                this.Move(item, ItemDestination.Remove, removedReason);
             }
             else
             {


### PR DESCRIPTION
- Simplify eviction logic: remove retry loop and simply discard the coldest item. Logic is now entirely based on the result of the preceding interlocked operation, so now there are no races.
- Inline helper methods
- Consolidate removal logic to always call into OnRemove

There is a marginal improvement in throughput for the eviction scenario for higher thread counts, likely because some volatile read calls have been eliminated.

MaxCycles = 3 was chosen because that is the threshold where the Arc OLTP scenario is closest to optimal. There is almost no difference in other scenarios.
