### PR TITLE
Eliminate races during LRU warmup

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -562,11 +562,10 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruOfDisposable.GetOrAdd(i, disposableValueFactory.Create);
             }
 
-            disposableValueFactory.Items[0].IsDisposed.Should().BeFalse();
+            disposableValueFactory.Items[0].IsDisposed.Should().BeTrue();
+
             disposableValueFactory.Items[1].IsDisposed.Should().BeFalse();
-
-            disposableValueFactory.Items[2].IsDisposed.Should().BeTrue();
-
+            disposableValueFactory.Items[2].IsDisposed.Should().BeFalse();
             disposableValueFactory.Items[3].IsDisposed.Should().BeFalse();
             disposableValueFactory.Items[4].IsDisposed.Should().BeFalse();
             disposableValueFactory.Items[5].IsDisposed.Should().BeFalse();
@@ -598,8 +597,8 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             removedItems.Count.Should().Be(2);
 
-            removedItems[0].Key.Should().Be(3);
-            removedItems[0].Value.Should().Be(4);
+            removedItems[0].Key.Should().Be(1);
+            removedItems[0].Value.Should().Be(2);
             removedItems[0].Reason.Should().Be(ItemRemovedReason.Evicted);
 
             removedItems[1].Key.Should().Be(4);
@@ -1016,6 +1015,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         [InlineData(9, new int[] { })]
         public void WhenColdItemsExistTrimRemovesExpectedItemCount(int trimCount, int[] expected)
         {
+            Warmup();
+
             // initial state:
             // Hot = 9, 8, 7
             // Warm = 3, 2, 1
@@ -1109,6 +1110,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         [InlineData(9, new int[] { })]
         public void WhenColdItemsAreTouchedTrimRemovesExpectedItemCount(int trimCount, int[] expected)
         {
+            Warmup();
+
             // initial state:
             // Hot = 9, 8, 7
             // Warm = 3, 2, 1

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -92,8 +92,8 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             removedItems.Count.Should().Be(2);
 
-            removedItems[0].Key.Should().Be(3);
-            removedItems[0].Value.Should().Be(4);
+            removedItems[0].Key.Should().Be(1);
+            removedItems[0].Value.Should().Be(2);
             removedItems[0].Reason.Should().Be(ItemRemovedReason.Evicted);
 
             removedItems[1].Key.Should().Be(4);

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -555,12 +555,9 @@ namespace BitFaster.Caching.Lru
                     (dest, count) = CycleCold(count);
                 }
 
-                // If we get here, we have cycled the queues multiple times and still have not removed an item.
-                // This can happen if the cache is full of items that are not discardable. In this case, we simply
-                // discard the coldest item to avoid unbounded growth.
+                // If nothing was removed yet, constrain the size of warm and cold by discarding the coldest item.
                 if (dest != ItemDestination.Remove)
                 {
-                    // if an item was last moved into warm, move the last warm item to cold to prevent enlarging warm
                     if (dest == ItemDestination.Warm && count > this.capacity.Warm)
                     {
                         count = LastWarmToCold();
@@ -730,6 +727,7 @@ namespace BitFaster.Caching.Lru
         {
             if (coldCount > this.capacity.Cold && this.coldQueue.TryDequeue(out var item))
             {
+                Interlocked.Decrement(ref this.counter.cold);
                 this.Move(item, ItemDestination.Remove, removedReason);
             }
         }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -801,7 +801,12 @@ namespace BitFaster.Caching.Lru
         // it becomes immutable. However, this object is then somewhere else on the 
         // heap, which slows down the policies with hit counter logic in benchmarks. Likely
         // this approach keeps the structs data members in the same CPU cache line as the LRU.
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
         [DebuggerDisplay("Hit = {Hits}, Miss = {Misses}, Upd = {Updated}, Evict = {Evicted}")]
+#else
+        [DebuggerDisplay("Hit = {Hits}, Miss = {Misses}, Evict = {Evicted}")]
+#endif
         private class Proxy : ICacheMetrics, ICacheEvents<K, V>, IBoundedPolicy, ITimePolicy
         {
             private readonly ConcurrentLruCore<K, V, I, P, T> lru;

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -764,7 +764,7 @@ namespace BitFaster.Caching.Lru
 
                         this.telemetryPolicy.OnItemRemoved(item.Key, item.Value, removedReason);
 
-                        //lock (item)
+                        lock (item)
                         {
                             Disposer<V>.Dispose(item.Value);
                         }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -566,7 +566,7 @@ namespace BitFaster.Caching.Lru
                         LastWarmToCold();
                     }
 
-                    RemoveCold(ItemRemovedReason.Evicted);
+                    ConstrainCold(ItemRemovedReason.Evicted);
                 }
             }
             else
@@ -725,13 +725,13 @@ namespace BitFaster.Caching.Lru
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void RemoveCold(ItemRemovedReason removedReason) 
+        private void ConstrainCold(ItemRemovedReason removedReason)
         {
-            Interlocked.Decrement(ref this.counter.cold);
+            int cc = Interlocked.Decrement(ref this.counter.cold);
 
-            if (this.coldQueue.TryDequeue(out var item))
+            if (cc == this.capacity.Cold && this.coldQueue.TryDequeue(out var item))
             {
-                 this.Move(item, ItemDestination.Remove, removedReason);
+                this.Move(item, ItemDestination.Remove, removedReason);
             }
             else
             {


### PR DESCRIPTION
During warmup, remove the volatile read to determine warm count, and instead move directly to warm and use the result of the interlocked increment. This eliminates any possible race in the transition between cold and warm.

The sequence of items in the underlying queues during cache warmup now changes: the first item added to the cache will be pushed to the cold queue. Previously it would stay in warm. Hence, some tests that depend on item order require updating.