### PR TITLE
Fix HitRateAnalysis OOM

### DIFF
--- a/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
@@ -16,14 +16,25 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
             this.config = config;
         }
 
-        public  async Task Run()
+        public async Task Run()
         {
             await this.config.File.DownloadIfNotExistsAsync();
 
             Console.WriteLine("Running...");
-            int count = 0;
+            
             var sw = Stopwatch.StartNew();
 
+            int count = this.config.Analysis.First().CacheSize >= 1_000_000 ? AnalyzeLarge() : AnalyzeSmall();
+
+            Console.WriteLine($"Tested {count} keys in {sw.Elapsed}");
+
+            this.config.Analysis.WriteToConsole();
+            Analysis<long>.WriteToFile(this.config.Name, this.config.Analysis);
+        }
+
+        private int AnalyzeSmall()
+        {
+            int count = 0;
             foreach (var key in this.config.File.EnumerateFileData())
             {
                 foreach (var a in this.config.Analysis)
@@ -37,10 +48,34 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
                 }
             }
 
-            Console.WriteLine($"Tested {count} keys in {sw.Elapsed}");
+            return count;
+        }
 
-            this.config.Analysis.WriteToConsole();
-            Analysis<long>.WriteToFile(this.config.Name, this.config.Analysis);
+        // for very large cache sizes do multiple passes of the data,
+        // else not everything can fit in memory.
+        private int AnalyzeLarge()
+        {
+            int count = 0;
+
+            foreach (var a in this.config.Analysis)
+            {
+                Console.WriteLine($"Analyzing cache size {a.CacheSize}");
+
+                foreach (var key in this.config.File.EnumerateFileData())
+                {
+                    a.TestKey(key);
+
+                    if (++count % 100000 == 0)
+                    {
+                        Console.WriteLine($"Processed {count} keys...");
+                        GC.Collect();
+                    }
+                }
+
+                GC.Collect(2, GCCollectionMode.Forced, true);
+            }
+
+            return count;
         }
     }
 }


### PR DESCRIPTION
Running the hit rate analysis Arc OLTP scenario causes a machine with 32gb ram to run out of memory and grind to a halt.

Introduce a different run order for large cache sizes to mitigate this. Running in dotMemory shows that MemoryCache is allocating a crazy amount of ValueTuples

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/f15ee9cb-31f6-42dd-82df-6908a7f4a68b)

Rough breakdown:
Blue: MemoryCache ~8.2 gb
Green: ConcurrentLfu ~102 mb
Yellow: ConcurrentLru ~43 mb
Red: ClassicLru ~71mb

ConcurrentLfu is allocating an Action on each drain: this should be cached.
