### PR TITLE
Cache LFU drain buffers delegate

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -70,6 +70,7 @@ namespace BitFaster.Caching.Lfu
         private readonly object maintenanceLock = new();
 
         private readonly IScheduler scheduler;
+        private readonly Action drainBuffers;
 
         private readonly LfuNode<K, V>[] drainBuffer;
 
@@ -110,6 +111,7 @@ namespace BitFaster.Caching.Lfu
             this.capacity = new LfuCapacityPartition(capacity);
 
             this.scheduler = scheduler;
+            this.drainBuffers = () => this.DrainBuffers();
 
             this.drainBuffer = new LfuNode<K, V>[this.readBuffer.Capacity];
         }
@@ -532,7 +534,7 @@ namespace BitFaster.Caching.Lfu
                     }
 
                     this.drainStatus.VolatileWrite(DrainStatus.ProcessingToIdle);
-                    scheduler.Run(() => this.DrainBuffers());
+                    scheduler.Run(this.drainBuffers);
                 }
             }
             finally


### PR DESCRIPTION
Calling drain buffers via the scheduler requires allocating an `Action`. This shows up when memory profiling the hit rate analysis test:

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/8dd5b3f8-25e0-463f-9687-7a0b7fe4f731)
![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/8fae39e3-6d04-4c9f-bf49-59e9ef6acfdc)

Cache the delegate to avoid this allocation. The correct approach would be for `IScheduler` to accept `Action<T>`, but that is a breaking change.