### PR TITLE
LRU metrics and events should be optional

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/FastConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/FastConcurrentLruTests.cs
@@ -2,7 +2,6 @@
 using BitFaster.Caching.Lru;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -34,6 +33,22 @@ namespace BitFaster.Caching.UnitTests.Lru
             var x = new FastConcurrentLru<int, int>(1, new EqualCapacityPartition(3), EqualityComparer<int>.Default);
 
             x.Capacity.Should().Be(3);
+        }
+
+        [Fact]
+        public void MetricsHasValueIsFalse()
+        {
+            var x = new FastConcurrentLru<int, int>(3);
+
+            x.Metrics.HasValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void EventsHasValueIsFalse()
+        {
+            var x = new FastConcurrentLru<int, int>(3);
+
+            x.Events.HasValue.Should().BeFalse();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/FastConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/FastConcurrentTLruTests.cs
@@ -53,5 +53,21 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Count.Should().Be(0);
         }
+
+        [Fact]
+        public void MetricsHasValueIsFalse()
+        {
+            var x = new FastConcurrentTLru<int, int>(3, TimeSpan.FromSeconds(1));
+
+            x.Metrics.HasValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void EventsHasValueIsFalse()
+        {
+            var x = new FastConcurrentTLru<int, int>(3, TimeSpan.FromSeconds(1));
+
+            x.Events.HasValue.Should().BeFalse();
+        }
     }
 }

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -104,10 +104,10 @@ namespace BitFaster.Caching.Lru
         public int Capacity => this.capacity.Hot + this.capacity.Warm + this.capacity.Cold;
 
         ///<inheritdoc/>
-        public Optional<ICacheMetrics> Metrics => new(new Proxy(this));
+        public Optional<ICacheMetrics> Metrics => CreateMetrics(this);
 
         ///<inheritdoc/>
-        public Optional<ICacheEvents<K, V>> Events => new(new Proxy(this));
+        public Optional<ICacheEvents<K, V>> Events => CreateEvents(this);
 
         ///<inheritdoc/>
         public CachePolicy Policy => CreatePolicy(this);
@@ -780,6 +780,26 @@ namespace BitFaster.Caching.Lru
         { 
             var p = new Proxy(lru); 
             return new CachePolicy(new Optional<IBoundedPolicy>(p), lru.itemPolicy.CanDiscard() ? new Optional<ITimePolicy>(p) : Optional<ITimePolicy>.None()); 
+        }
+
+        private static Optional<ICacheMetrics> CreateMetrics(ConcurrentLruCore<K, V, I, P, T> lru)
+        {
+            if (typeof(T) == typeof(NoTelemetryPolicy<K, V>))
+            {
+                return Optional<ICacheMetrics>.None();
+            }
+
+            return new(new Proxy(lru));
+        }
+
+        private static Optional<ICacheEvents<K, V>> CreateEvents(ConcurrentLruCore<K, V, I, P, T> lru)
+        {
+            if (typeof(T) == typeof(NoTelemetryPolicy<K, V>))
+            {
+                return Optional<ICacheEvents<K, V>>.None();
+            }
+
+            return new(new Proxy(lru));
         }
 
         // To get JIT optimizations, policies must be structs.


### PR DESCRIPTION
Even when the metrics and events are not defined, `ConcurrentLruCore` returns the internal proxy class through the optional properties. This makes it look like those features are enabled when they are not.

Fix this so that the optional.HasValue returns false when features are disabled.