### PR TITLE
Mark AfterAccess policy internal

### DIFF
--- a/BitFaster.Caching/Lru/AfterReadStopwatchPolicy.cs
+++ b/BitFaster.Caching/Lru/AfterReadStopwatchPolicy.cs
@@ -11,7 +11,7 @@ namespace BitFaster.Caching.Lru
     /// <remarks>
     /// This class measures time using Stopwatch.GetTimestamp() with a resolution of ~1us.
     /// </remarks>
-    public readonly struct AfterAccessLongTicksPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
+    internal readonly struct AfterAccessLongTicksPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
     {
         private readonly long timeToLive;
         private readonly Time time;

--- a/BitFaster.Caching/Lru/AfterReadTickCount64Policy.cs
+++ b/BitFaster.Caching/Lru/AfterReadTickCount64Policy.cs
@@ -13,7 +13,7 @@ namespace BitFaster.Caching.Lru
     /// than both Stopwatch.GetTimestamp and DateTime.UtcNow. However, resolution is lower (typically 
     /// between 10-16ms), vs 1us for Stopwatch.GetTimestamp.
     /// </remarks>
-    public readonly struct AfterAccessLongTicksPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
+    internal readonly struct AfterAccessLongTicksPolicy<K, V> : IItemPolicy<K, V, LongTickCountLruItem<K, V>>
     {
         private readonly long timeToLive;
         private readonly Time time;


### PR DESCRIPTION
This does not need to be part of the public API surface.