### PR TITLE
Increase timeout for background scheduler test

### DIFF
--- a/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
@@ -87,7 +87,7 @@ namespace BitFaster.Caching.UnitTests.Scheduler
 
             var completion = scheduler.Completion;
 
-            if (await Task.WhenAny(completion, Task.Delay(TimeSpan.FromSeconds(5))) != completion)
+            if (await Task.WhenAny(completion, Task.Delay(TimeSpan.FromSeconds(60))) != completion)
             {
                 throw new Exception("Failed to stop");
             }


### PR DESCRIPTION
Since switching to the default scheduler, this test has failed to stop twice. Async/await and time are not stable in xunit. As a first step to avoid intermittent failures, try to increase the timeout.

```
System.Exception : Failed to stop
   at BitFaster.Caching.UnitTests.Scheduler.BackgroundSchedulerTests.WhenDisposedRunsToCompletion() in D:\a\BitFaster.Caching\BitFaster.Caching\BitFaster.Caching.UnitTests\Scheduler\BackgroundSchedulerTests.cs:line 92
--- End of stack trace from previous location where exception was thrown ---
```
