### PR TITLE
Mark LRU as cold during trim

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -954,6 +954,25 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Fact]
+        public void WhenWarmThenTrimIsWarmIsReset()
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                lru.GetOrAdd(i, k => k.ToString());
+            }
+
+            lru.Trim(6);
+            lru.Count.Should().Be(3);
+
+            for (int i = 0; i < 20; i++)
+            {
+                lru.GetOrAdd(i, k => k.ToString());
+            }
+
+            lru.Count.Should().Be(capacity.Hot + capacity.Warm + capacity.Cold);
+        }
+
+        [Fact]
         public void WhenItemsAreDisposableClearDisposesItemsOnRemove()
         {
             var lruOfDisposable = new ConcurrentLru<int, DisposableItem>(1, 6, EqualityComparer<int>.Default);

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -468,10 +468,9 @@ namespace BitFaster.Caching.Lru
         // backcompat: make internal
         protected int TrimAllDiscardedItems()
         {
-            int itemsRemoved = 0;
-
-            void RemoveDiscardableItems(ConcurrentQueue<I> q, ref int queueCounter)
+            int RemoveDiscardableItems(ConcurrentQueue<I> q, ref int queueCounter)
             {
+                int itemsRemoved = 0;
                 int localCount = queueCounter;
 
                 for (int i = 0; i < localCount; i++)
@@ -490,13 +489,20 @@ namespace BitFaster.Caching.Lru
                         }
                     }
                 }
+
+                return itemsRemoved;
             }
 
-            RemoveDiscardableItems(coldQueue, ref this.counter.cold);
-            RemoveDiscardableItems(warmQueue, ref this.counter.warm);
-            RemoveDiscardableItems(hotQueue, ref this.counter.hot);
+            int coldRem = RemoveDiscardableItems(coldQueue, ref this.counter.cold);
+            int warmRem = RemoveDiscardableItems(warmQueue, ref this.counter.warm);
+            int hotRem = RemoveDiscardableItems(hotQueue, ref this.counter.hot);
 
-            return itemsRemoved;
+            if (warmRem > 0)
+            {
+                Volatile.Write(ref this.isWarm, false);
+            }
+
+            return coldRem + warmRem + hotRem;
         }
 
         private void TrimLiveItems(int itemsRemoved, int itemCount, ItemRemovedReason reason)

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -423,7 +423,6 @@ namespace BitFaster.Caching.Lru
         public void Clear()
         {
             this.TrimLiveItems(itemsRemoved: 0, this.Count, ItemRemovedReason.Cleared);
-            Volatile.Write(ref this.isWarm, false);
         }
 
         /// <summary>
@@ -531,6 +530,11 @@ namespace BitFaster.Caching.Lru
                     TrimWarmOrHot(reason);
                     trimWarmAttempts++;
                 }
+            }
+
+            if (Volatile.Read(ref this.counter.warm) < this.capacity.Warm)
+            {
+                Volatile.Write(ref this.isWarm, false);
             }
         }
 


### PR DESCRIPTION
`TrimExpired()` and `TrimLiveItems()` can now mark `isWarm == false`.