### PR TITLE
Fix code coverage anomaly

### DIFF
--- a/BitFaster.Caching/Atomic/AtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactory.cs
@@ -174,9 +174,7 @@ namespace BitFaster.Caching.Atomic
                     // If a previous thread called the factory and failed, throw the same error instead
                     // of calling the factory again.
                     if (exceptionDispatch != null)
-                    {
                         exceptionDispatch.Throw();
-                    }
 
                     try
                     {


### PR DESCRIPTION
Not able to detect coverage for closing }, so delete braces in this case.

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/e6dcf999-0d91-40e3-9591-a8a996e13db6)
