### PR TITLE
Stabilize tests

### DIFF
--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryTests.cs
@@ -172,7 +172,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             int count = 0, timesContended = 0;
 
-            while (count++ < 64)
+            while (count++ < 128)
             { 
                 var enter1 = new ManualResetEvent(false);
                 var enter2 = new ManualResetEvent(false);

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryTests.cs
@@ -172,7 +172,10 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             int count = 0, timesContended = 0;
 
-            while (count++ < 128)
+            // Overlapping the value factory calls is hard to achieve reliably.
+            // Therefore, try many times and verify it was possible to provoke
+            // at least once.
+            while (count++ < 256)
             { 
                 var enter1 = new ManualResetEvent(false);
                 var enter2 = new ManualResetEvent(false);

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruAfterAccessTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruAfterAccessTests.cs
@@ -96,14 +96,21 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenItemIsReadTtlIsExtended()
         {
-            Timed.Execute(
-                capacity,
-                cap =>
-                {
-                    var lru = new ConcurrentLruBuilder<int, string>()
-                        .WithCapacity(cap)
+            var lru = new ConcurrentLruBuilder<int, string>()
+                        .WithCapacity(capacity)
                         .WithExpireAfterAccess(TimeSpan.FromMilliseconds(100))
                         .Build();
+
+            // execute the method to ensure it is always jitted
+            lru.GetOrAdd(-1, valueFactory.Create);
+            lru.GetOrAdd(-2, valueFactory.Create);
+            lru.GetOrAdd(-3, valueFactory.Create);
+
+            Timed.Execute(
+                lru,
+                lru =>
+                {
+                    
 
                     lru.GetOrAdd(1, valueFactory.Create);
 


### PR DESCRIPTION
- AtomicFactoryTests: Repeat test and count the number of times the condition we are interested in occurred. 
- ConcurrentLfuAfterAccess: move cache creation out of the timed region, and execute the methods under test up front. Attempt to eliminate delays from JITting code or cold instruction cache.