### PR TITLE
Detect windows OS before native windows call in ThroughputAnalysis

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <!-- https://stackoverflow.com/a/59916801/131345 -->
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
     <IsMacOS Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsMacOS>

--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -4,6 +4,9 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 
+    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux>
+    <IsMacOS Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'true'">true</IsMacOS>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -25,5 +28,15 @@
   <ItemGroup>
     <ProjectReference Include="..\BitFaster.Caching\BitFaster.Caching.csproj" />
   </ItemGroup>
+
+    <PropertyGroup Condition="'$(IsWindows)'=='true'">
+        <DefineConstants>Windows</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(IsLinux)'=='true'">
+        <DefineConstants>Linux</DefineConstants>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(IsMacOS)'=='true'">
+        <DefineConstants>MacOS</DefineConstants>
+    </PropertyGroup>
 
 </Project>

--- a/BitFaster.Caching.Benchmarks/DataStructureBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DataStructureBenchmarks.cs
@@ -7,7 +7,9 @@ using System.Threading;
 
 namespace BitFaster.Caching.Benchmarks
 {
+#if Windows
     [SimpleJob(RuntimeMoniker.Net48)]
+#endif
     [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     public class DataStructureBenchmarks

--- a/BitFaster.Caching.Benchmarks/DisposerBench.cs
+++ b/BitFaster.Caching.Benchmarks/DisposerBench.cs
@@ -7,9 +7,11 @@ namespace BitFaster.Caching.Benchmarks
 {
     // Is it possible to write a class to eliminate the dispose code for types that are not IDisposable?
     // https://github.com/dotnet/runtime/issues/4920
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DisposerBench

--- a/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
@@ -6,9 +6,11 @@ using BitFaster.Caching.Buffers;
 
 namespace BitFaster.Caching.Benchmarks
 {
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DrainBenchmarks
     {

--- a/BitFaster.Caching.Benchmarks/Lfu/LfuJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/LfuJustGetOrAdd.cs
@@ -9,7 +9,9 @@ using System.Collections.Generic;
 
 namespace BitFaster.Caching.Benchmarks
 {
+#if Windows
     [SimpleJob(RuntimeMoniker.Net48)]
+#endif
     [SimpleJob(RuntimeMoniker.Net60)]
     //[DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
     [MemoryDiagnoser(displayGenColumns: false)]

--- a/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
@@ -9,7 +9,9 @@ namespace BitFaster.Caching.Benchmarks.Lru
     /// <summary>
     /// Verify 0 allocs for GetOrAddAsync cache hits.
     /// </summary>
+#if Windows
     [SimpleJob(RuntimeMoniker.Net48)]
+#endif
     [SimpleJob(RuntimeMoniker.Net60)]
     // [DisassemblyDiagnoser(printSource: true, maxDepth: 5)] // Unstable
     [MemoryDiagnoser(displayGenColumns: false)]

--- a/BitFaster.Caching.Benchmarks/Lru/LruCycleBench.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruCycleBench.cs
@@ -22,9 +22,11 @@ namespace BitFaster.Caching.Benchmarks.Lru
     //| FastConcurrentTLru | 31.70 us | 0.087 us | 0.077 us |  1.39 |      6 KB | 2.3193 |     10 KB |
     //|     ConcurrentTLru | 31.85 us | 0.080 us | 0.071 us |  1.39 |      6 KB | 2.3193 |     10 KB |
     //|         ClassicLru | 16.35 us | 0.091 us | 0.076 us |  0.72 |      4 KB | 3.2959 |     14 KB |
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]  
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruCycleBench

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -28,9 +28,11 @@ namespace BitFaster.Caching.Benchmarks
     //|               ClassicLru |  49.041 ns | 0.8575 ns | 0.8021 ns |  6.23 |    0.11 |   3,013 B |      - |         - |
     //|    RuntimeMemoryCacheGet | 107.769 ns | 1.1901 ns | 0.9938 ns | 13.69 |    0.15 |      49 B | 0.0074 |      32 B |
     //| ExtensionsMemoryCacheGet |  93.188 ns | 0.2321 ns | 0.2171 ns | 11.85 |    0.07 |      78 B | 0.0055 |      24 B |
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     // [HardwareCounters(HardwareCounter.LlcMisses, HardwareCounter.CacheMisses)] // Requires Admin https://adamsitnik.com/Hardware-Counters-Diagnoser/
     // [ThreadingDiagnoser] // Requires .NET Core

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustTryGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustTryGet.cs
@@ -19,9 +19,11 @@ namespace BitFaster.Caching.Benchmarks.Lru
     //| ConcurrentDictionary |  4.480 ns | 0.0230 ns | 0.0204 ns |  1.00 |    0.00 |     364 B |         - |
     //|    FastConcurrentLru |  7.705 ns | 0.0343 ns | 0.0286 ns |  1.72 |    0.01 |     448 B |         - |
     //|   FastConcurrentTLru | 25.350 ns | 0.3301 ns | 0.3088 ns |  5.66 |    0.08 |     546 B |         - |
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruJustTryGet

--- a/BitFaster.Caching.Benchmarks/Lru/LruMultiGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruMultiGet.cs
@@ -24,9 +24,11 @@ namespace BitFaster.Caching.Benchmarks.Lru
     //|       ConcurrentTLru |  33.733 ns | 0.6613 ns | 0.6791 ns |  4.02 |    0.09 |   3,539 B |      - |         - |
     //|           ClassicLru |  52.898 ns | 0.3079 ns | 0.2404 ns |  6.30 |    0.03 |   3,021 B |      - |         - |
     //|          MemoryCache | 117.075 ns | 1.7664 ns | 1.5658 ns | 13.96 |    0.18 |      94 B | 0.0073 |      32 B |
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruMultiGet

--- a/BitFaster.Caching.Benchmarks/Lru/LruZipDistribution.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruZipDistribution.cs
@@ -21,9 +21,11 @@ namespace BitFaster.Caching.Benchmarks.Lru
     //|      ConcurrentLru | 127.4 ns | 0.51 ns | 0.48 ns |  1.14 |    0.01 | 0.0093 |   5,107 B |      41 B |
     //| FastConcurrentTLru | 175.6 ns | 1.08 ns | 1.01 ns |  1.58 |    0.02 | 0.0100 |   5,911 B |      44 B |
     //|     ConcurrentTLru | 169.7 ns | 0.86 ns | 0.80 ns |  1.52 |    0.02 | 0.0098 |   5,982 B |      43 B |
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruZipDistribution

--- a/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
@@ -9,7 +9,9 @@ namespace BitFaster.Caching.Benchmarks.Lru
     /// <summary>
     /// Compare different implementations of the TLRU policy. In particular, which clock impl is fastest?
     /// </summary>
+#if Windows
     [SimpleJob(RuntimeMoniker.Net48)]
+#endif
     [SimpleJob(RuntimeMoniker.Net60)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class TLruTimeBenchmark

--- a/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
@@ -5,7 +5,9 @@ using BenchmarkDotNet.Jobs;
 
 namespace BitFaster.Caching.Benchmarks
 {
+#if Windows
     [SimpleJob(RuntimeMoniker.Net48)]
+#endif
     [SimpleJob(RuntimeMoniker.Net60)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class TimeBenchmarks
@@ -38,6 +40,12 @@ namespace BitFaster.Caching.Benchmarks
         public long StopWatchGetElapsed()
         {
             return sw.ElapsedTicks;
+        }
+
+        [Benchmark()]
+        public long StopWatchGetTimestamp()
+        {
+            return Stopwatch.GetTimestamp();
         }
     }
 }

--- a/BitFaster.Caching.Benchmarks/ValueFactoryBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/ValueFactoryBenchmarks.cs
@@ -5,9 +5,11 @@ using BenchmarkDotNet.Jobs;
 
 namespace BitFaster.Caching.Benchmarks
 {
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class ValueFactoryBenchmarks
@@ -45,9 +47,11 @@ namespace BitFaster.Caching.Benchmarks
     }
 
 
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class ValueFactoryArgBenchmarks
@@ -84,9 +88,11 @@ namespace BitFaster.Caching.Benchmarks
         }
     }
 
-    [SimpleJob(RuntimeMoniker.Net48)]
-    [SimpleJob(RuntimeMoniker.Net60)]
+#if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+    [SimpleJob(RuntimeMoniker.Net48)]
+#endif
+    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class ValueFactoryBigArgBenchmarks

--- a/BitFaster.Caching.ThroughputAnalysis/Host.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Host.cs
@@ -57,6 +57,12 @@ namespace BitFaster.Caching.ThroughputAnalysis
         /// </summary>
         public unsafe static int GetLogicalCoreCount()
         {
+            // don't crash
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Environment.ProcessorCount;
+            }
+
             uint len = 0;
             const int ERROR_INSUFFICIENT_BUFFER = 122;
 


### PR DESCRIPTION
Enable tools to run cleanly on Linux and MacOS:

- Detect windows OS before native windows call in ThroughputAnalysis
- Conditional compile for Benchmarks to avoid .NET Framework and DisassemblyDiagnoser