### PR TITLE
Enable AOT trimming

### DIFF
--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -26,6 +26,7 @@
     <FileVersion>2.3.3.0</FileVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <IsTrimmable>true</IsTrimmable>
     <!--Package Validation-->
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>2.3.0</PackageValidationBaselineVersion>    

--- a/Tools/TrimVerification/BitFaster.Trimmed.sln
+++ b/Tools/TrimVerification/BitFaster.Trimmed.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34309.116
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BitFaster.Trimmed", "BitFaster.Trimmed\BitFaster.Trimmed.csproj", "{BDA6D44D-B26E-40A5-A5E7-E11649D88CCA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitFaster.Caching", "..\..\BitFaster.Caching\BitFaster.Caching.csproj", "{A4CECA54-D993-4498-8925-58C4C4F17B6B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{BDA6D44D-B26E-40A5-A5E7-E11649D88CCA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDA6D44D-B26E-40A5-A5E7-E11649D88CCA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDA6D44D-B26E-40A5-A5E7-E11649D88CCA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDA6D44D-B26E-40A5-A5E7-E11649D88CCA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4CECA54-D993-4498-8925-58C4C4F17B6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4CECA54-D993-4498-8925-58C4C4F17B6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4CECA54-D993-4498-8925-58C4C4F17B6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4CECA54-D993-4498-8925-58C4C4F17B6B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DC498DF5-2DDD-4D98-983A-D093BDB985AA}
+	EndGlobalSection
+EndGlobal

--- a/Tools/TrimVerification/BitFaster.Trimmed/BitFaster.Trimmed.csproj
+++ b/Tools/TrimVerification/BitFaster.Trimmed/BitFaster.Trimmed.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimmerDefaultAction>link</TrimmerDefaultAction>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\BitFaster.Caching\BitFaster.Caching.csproj" />
+    <TrimmerRootAssembly Include="BitFaster.Caching" />
+  </ItemGroup>
+
+</Project>

--- a/Tools/TrimVerification/BitFaster.Trimmed/Program.cs
+++ b/Tools/TrimVerification/BitFaster.Trimmed/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/Tools/TrimVerification/BitFaster.Trimmed/test.cmd
+++ b/Tools/TrimVerification/BitFaster.Trimmed/test.cmd
@@ -1,0 +1,1 @@
+dotnet publish -c Release -r win-x64


### PR DESCRIPTION
Based on:
https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?pivots=dotnet-6-0

Able to publish a trimmed console app with BitFaster.Caching as the root assembly without error. Test project included in the tools directory.