### PR TITLE
Optimize maintenance family of methods

### DIFF
--- a/BitFaster.Caching/Lfu/CmSketchCore.cs
+++ b/BitFaster.Caching/Lfu/CmSketchCore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 #if !NETSTANDARD2_0
 using System.Runtime.Intrinsics;
@@ -83,6 +84,7 @@ namespace BitFaster.Caching.Lfu
         /// Increment the count of the specified value.
         /// </summary>
         /// <param name="value">The value.</param>
+        [MethodImpl((MethodImplOptions)512)]
         public void Increment(T value)
         {
 #if NETSTANDARD2_0
@@ -269,6 +271,7 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private unsafe void IncrementAvx(T value)
         {
             int blockHash = Spread(comparer.GetHashCode(value));

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -570,6 +570,7 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private bool Maintenance(LfuNode<K, V> droppedWrite = null)
         {
             this.drainStatus.VolatileWrite(DrainStatus.ProcessingToIdle);
@@ -623,6 +624,7 @@ namespace BitFaster.Caching.Lfu
             return done;
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void OnAccess(LfuNode<K, V> node)
         {
             // there was a cache hit even if the item was removed or is not yet added.
@@ -648,6 +650,7 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void OnWrite(LfuNode<K, V> node)
         {
             // Nodes can be removed while they are in the write buffer, in which case they should
@@ -695,6 +698,7 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void PromoteProbation(LfuNode<K, V> node)
         {
             if (node.list == null)
@@ -718,12 +722,14 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void EvictEntries()
         {
             var candidate = EvictFromWindow();
             EvictFromMain(candidate);
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private LfuNode<K, V> EvictFromWindow()
         {
             LfuNode<K, V> first = null;
@@ -768,6 +774,7 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void EvictFromMain(LfuNode<K, V> candidateNode)
         {
             var victim = new EvictIterator(this.cmSketch, this.probationLru.First); // victims are LRU position in probation
@@ -827,6 +834,7 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private bool AdmitCandidate(K candidateKey, K victimKey)
         {
             int victimFreq = this.cmSketch.EstimateFrequency(victimKey);
@@ -838,6 +846,7 @@ namespace BitFaster.Caching.Lfu
             return candidateFreq > victimFreq;
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void Evict(LfuNode<K, V> evictee)
         {
             this.dictionary.TryRemove(evictee.Key, out var _);
@@ -846,6 +855,7 @@ namespace BitFaster.Caching.Lfu
             this.metrics.evictedCount++;
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void ReFitProtected()
         {
             // If hill climbing decreased protected, there may be too many items

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -512,6 +512,7 @@ namespace BitFaster.Caching.Lfu
             return ((ConcurrentLfu<K, V>)this).GetEnumerator();
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void TryScheduleDrain()
         {
             if (this.drainStatus.NonVolatileRead() >= DrainStatus.ProcessingToIdle)

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -565,6 +565,7 @@ namespace BitFaster.Caching.Lru
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private void Cycle(int hotCount)
         {
             if (isWarm)

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -631,6 +631,7 @@ namespace BitFaster.Caching.Lru
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private (ItemDestination, int) CycleHot(int hotCount)
         {
             if (hotCount > this.capacity.Hot)
@@ -658,6 +659,7 @@ namespace BitFaster.Caching.Lru
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private (ItemDestination, int) CycleWarm(int count)
         {
             if (count > this.capacity.Warm)
@@ -696,6 +698,7 @@ namespace BitFaster.Caching.Lru
             }
         }
 
+        [MethodImpl((MethodImplOptions)512)]
         private (ItemDestination, int) CycleCold(int count)
         {
             if (count > this.capacity.Cold)


### PR DESCRIPTION
Try applying aggressive optimization to the maintenance methods. This is a tiny bit better for LFU, appears to be noise for LRU.

This would likely need to be removed if building on NET7 or NET8, because it can cancel PGO.

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/8aac0c5b-2ffe-43e8-b0a7-b12a949e8485)

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/c82c7452-a910-49d5-86c8-16c87f9625e6)
