### PR TITLE
Automate plots

### DIFF
--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Build split asm
       run: dotnet build splitasm --configuration Release
     - name: Benchmark
-      run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter *LruAsyncGet*   
+      run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter '*'
     - name: Plot results
       run: dotnet run --project "Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Post process disassembly
@@ -60,12 +60,12 @@ jobs:
         dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
+        - name: Plot results
+      run: dotnet run --project "Tools/BenchPlot/Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark
       run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter '*'
-    - name: Plot results
-      run: dotnet run --project "Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Publish Results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project ${{ github.workspace }}/Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project ../Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -27,8 +27,6 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
-    - name: Plot results
-      run: dotnet run --project "Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Clone splitasm repo
       uses: actions/checkout@v3
       with:
@@ -39,6 +37,8 @@ jobs:
       run: dotnet build splitasm --configuration Release
     - name: Benchmark
       run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter *LruAsyncGet*   
+    - name: Plot results
+      run: dotnet run --project "Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Post process disassembly
       run: splitasm\splitasm\bin\Release\net6.0\splitasm.exe %GITHUB_WORKSPACE%\BenchmarkDotNet.Artifacts\results
       shell: cmd
@@ -64,6 +64,8 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark
       run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter '*'
+    - name: Plot results
+      run: dotnet run --project "Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Publish Results
       uses: actions/upload-artifact@v3
       with:
@@ -86,6 +88,8 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark
       run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter '*'
+    - name: Plot results
+      run: dotnet run --project "Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Publish Results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -60,12 +60,12 @@ jobs:
         dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
-    - name: Plot results
-      run: dotnet run --project Tools/BenchPlot/BenchPlot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark
       run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter '*'
+    - name: Plot results
+      run: dotnet run --project Tools/BenchPlot/BenchPlot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Publish Results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -27,6 +27,8 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --configuration Release --no-restore
+    - name: Plot results
+      run: dotnet run --project "\Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Clone splitasm repo
       uses: actions/checkout@v3
       with:
@@ -36,9 +38,7 @@ jobs:
     - name: Build split asm
       run: dotnet build splitasm --configuration Release
     - name: Benchmark
-      run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter *LruAsyncGet*
-    - name: Plot results
-      run: dotnet run --project "\Tools\BenchPlot\Benchplot" --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter *LruAsyncGet*   
     - name: Post process disassembly
       run: splitasm\splitasm\bin\Release\net6.0\splitasm.exe %GITHUB_WORKSPACE%\BenchmarkDotNet.Artifacts\results
       shell: cmd

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project "./Tools/BenchPlot/Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project ./Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -36,7 +36,9 @@ jobs:
     - name: Build split asm
       run: dotnet build splitasm --configuration Release
     - name: Benchmark
-      run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter *Lru*
+      run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter *LruAsyncGet*
+    - name: Plot results
+      run: dotnet run --project "\Tools\BenchPlot\Benchplot" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Post process disassembly
       run: splitasm\splitasm\bin\Release\net6.0\splitasm.exe %GITHUB_WORKSPACE%\BenchmarkDotNet.Artifacts\results
       shell: cmd

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project "Tools/BenchPlot/Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project "./Tools/BenchPlot/Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project ${{ github.workspace }}/../Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project Tools/BenchPlot/BenchPlot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark
@@ -89,7 +89,7 @@ jobs:
     - name: Benchmark
       run: dotnet run --project "BitFaster.Caching.Benchmarks" -f net6.0 -c Release --filter '*'
     - name: Plot results
-      run: dotnet run --project "Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project "Tools\BenchPlot\BenchPlot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Publish Results
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project ../Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project ${{ github.workspace }}/../Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project "Tools/BenchPlot/Benchplot" --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project "./Tools/BenchPlot/Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -60,7 +60,7 @@ jobs:
         dotnet-version: 6.0.x
     - name: Install dependencies
       run: dotnet restore
-        - name: Plot results
+    - name: Plot results
       run: dotnet run --project "Tools/BenchPlot/Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project ./Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project ~/Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project "./Tools/BenchPlot/Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project "Tools/BenchPlot/Benchplot" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install dependencies
       run: dotnet restore
     - name: Plot results
-      run: dotnet run --project ~/Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project ${{ github.workspace }}/Tools/BenchPlot/Benchplot.csproj --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Benchmark

--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Plot results
-      run: dotnet run --project "\Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
+      run: dotnet run --project "Tools\BenchPlot\Benchplot.csproj" --configuration Release "BenchmarkDotNet.Artifacts"
     - name: Clone splitasm repo
       uses: actions/checkout@v3
       with:

--- a/BitFaster.Caching.HitRateAnalysis/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Analysis.cs
@@ -64,7 +64,9 @@ namespace BitFaster.Caching.HitRateAnalysis
             var combined = Chart.Combine(new[] { classic, lru, lfu, memory });
             
             combined
-                .WithAxisTitles("Glimpse", "Cache Size", "Hit Rate (%)")
+                .WithLayout("Glimpse")
+                .WithoutVerticalGridlines()
+                .WithAxisTitles("Cache Size", "Hit Rate (%)")
                 .SaveSVG(Path.GetFileNameWithoutExtension(path), Width: 1000, Height:600);
         }
     }

--- a/BitFaster.Caching.HitRateAnalysis/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Analysis.cs
@@ -53,21 +53,6 @@ namespace BitFaster.Caching.HitRateAnalysis
             {
                 csv.WriteRecords(results);
             }
-
-            //var xAxis = results.Select(x => x.CacheSize).ToArray();
-
-            //var classic = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ClassicLruHitRate), Name: "LRU", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Limegreen));
-            //var lru = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLruHitRate), Name: "ConcurrentLru", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.RoyalBlue));
-            //var lfu = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLfuHitRate), Name: "ConcurrentLfu", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Khaki));
-            //var memory = Chart.Line<int, double, string>(xAxis, results.Select(x => x.MemoryCacheHitRate), Name: "MemoryCache", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick));
-
-            //var combined = Chart.Combine(new[] { classic, lru, lfu, memory });
-            
-            //combined
-            //    .WithLayout("Glimpse")
-            //    .WithoutVerticalGridlines()
-            //    .WithAxisTitles("Cache Size", "Hit Rate (%)")
-            //    .SaveSVG(Path.GetFileNameWithoutExtension(path), Width: 1000, Height:600);
         }
 
         public static void Plot(string path, string title, IEnumerable<Analysis<K>> results)

--- a/BitFaster.Caching.HitRateAnalysis/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Analysis.cs
@@ -54,6 +54,24 @@ namespace BitFaster.Caching.HitRateAnalysis
                 csv.WriteRecords(results);
             }
 
+            //var xAxis = results.Select(x => x.CacheSize).ToArray();
+
+            //var classic = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ClassicLruHitRate), Name: "LRU", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Limegreen));
+            //var lru = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLruHitRate), Name: "ConcurrentLru", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.RoyalBlue));
+            //var lfu = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLfuHitRate), Name: "ConcurrentLfu", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Khaki));
+            //var memory = Chart.Line<int, double, string>(xAxis, results.Select(x => x.MemoryCacheHitRate), Name: "MemoryCache", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick));
+
+            //var combined = Chart.Combine(new[] { classic, lru, lfu, memory });
+            
+            //combined
+            //    .WithLayout("Glimpse")
+            //    .WithoutVerticalGridlines()
+            //    .WithAxisTitles("Cache Size", "Hit Rate (%)")
+            //    .SaveSVG(Path.GetFileNameWithoutExtension(path), Width: 1000, Height:600);
+        }
+
+        public static void Plot(string path, string title, IEnumerable<Analysis<K>> results)
+        {
             var xAxis = results.Select(x => x.CacheSize).ToArray();
 
             var classic = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ClassicLruHitRate), Name: "LRU", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Limegreen));
@@ -62,12 +80,12 @@ namespace BitFaster.Caching.HitRateAnalysis
             var memory = Chart.Line<int, double, string>(xAxis, results.Select(x => x.MemoryCacheHitRate), Name: "MemoryCache", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick));
 
             var combined = Chart.Combine(new[] { classic, lru, lfu, memory });
-            
+
             combined
-                .WithLayout("Glimpse")
+                .WithLayout(title)
                 .WithoutVerticalGridlines()
                 .WithAxisTitles("Cache Size", "Hit Rate (%)")
-                .SaveSVG(Path.GetFileNameWithoutExtension(path), Width: 1000, Height:600);
+                .SaveSVG(Path.GetFileNameWithoutExtension(path), Width: 1000, Height: 600);
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Analysis.cs
@@ -48,7 +48,7 @@ namespace BitFaster.Caching.HitRateAnalysis
 
         public static void WriteToFile(string path, IEnumerable<Analysis<K>> results)
         {
-            using (var writer = new StreamWriter(path))
+            using (var writer = new StreamWriter(path))                                     
             using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
             {
                 csv.WriteRecords(results);
@@ -61,7 +61,7 @@ namespace BitFaster.Caching.HitRateAnalysis
 
             var classic = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ClassicLruHitRate), Name: "LRU", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Limegreen));
             var lru = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLruHitRate), Name: "ConcurrentLru", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.RoyalBlue));
-            var lfu = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLfuHitRate), Name: "ConcurrentLfu", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Khaki));
+            var lfu = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLfuHitRate), Name: "ConcurrentLfu", MarkerColor: Plotly.NET.Color.fromRGB(255, 192, 0));
             var memory = Chart.Line<int, double, string>(xAxis, results.Select(x => x.MemoryCacheHitRate), Name: "MemoryCache", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick));
 
             var combined = Chart.Combine(new[] { classic, lru, lfu, memory });

--- a/BitFaster.Caching.HitRateAnalysis/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Analysis.cs
@@ -1,11 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Scheduler;
 using CsvHelper;
+using Plotly.NET.CSharp;
+using Plotly.NET.ImageExport;
 
 namespace BitFaster.Caching.HitRateAnalysis
 {
@@ -49,6 +53,18 @@ namespace BitFaster.Caching.HitRateAnalysis
             {
                 csv.WriteRecords(results);
             }
+
+            var xAxis = results.Select(x => x.CacheSize).ToArray();
+
+            var classic = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ClassicLruHitRate), Name: "LRU", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Limegreen));
+            var lru = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLruHitRate), Name: "ConcurrentLru", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.RoyalBlue));
+            var lfu = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLfuHitRate), Name: "ConcurrentLfu", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Khaki));
+            var memory = Chart.Line<int, double, string>(xAxis, results.Select(x => x.MemoryCacheHitRate), Name: "MemoryCache", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick));
+
+            var y = Chart.Combine(new[] { classic, lru, lfu, memory });
+            
+
+            y.WithAxisTitles("Cache Size", "Hit Rate (%)").SaveSVG(Path.GetFileName(path));
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Analysis.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Analysis.cs
@@ -61,10 +61,11 @@ namespace BitFaster.Caching.HitRateAnalysis
             var lfu = Chart.Line<int, double, string>(xAxis, results.Select(x => x.ConcurrentLfuHitRate), Name: "ConcurrentLfu", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Khaki));
             var memory = Chart.Line<int, double, string>(xAxis, results.Select(x => x.MemoryCacheHitRate), Name: "MemoryCache", MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick));
 
-            var y = Chart.Combine(new[] { classic, lru, lfu, memory });
+            var combined = Chart.Combine(new[] { classic, lru, lfu, memory });
             
-
-            y.WithAxisTitles("Cache Size", "Hit Rate (%)").SaveSVG(Path.GetFileName(path));
+            combined
+                .WithAxisTitles("Glimpse", "Cache Size", "Hit Rate (%)")
+                .SaveSVG(Path.GetFileNameWithoutExtension(path), Width: 1000, Height:600);
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using BitFaster.Caching.HitRateAnalysis.Zipfian;
 
 namespace BitFaster.Caching.HitRateAnalysis.Arc
 {
@@ -30,6 +31,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
 
             this.config.Analysis.WriteToConsole();
             Analysis<long>.WriteToFile(this.config.Name, this.config.Analysis);
+            Analysis<long>.Plot(this.config.Name, this.config.Name, this.config.Analysis);
         }
 
         private int AnalyzeSmall()

--- a/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
@@ -31,7 +31,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
 
             this.config.Analysis.WriteToConsole();
             Analysis<long>.WriteToFile(this.config.Name, this.config.Analysis);
-            Analysis<long>.Plot(this.config.Name, this.config.Name, this.config.Analysis);
+            Analysis<long>.Plot(this.config.Title, this.config.Name, this.config.Analysis);
         }
 
         private int AnalyzeSmall()

--- a/BitFaster.Caching.HitRateAnalysis/Arc/RunnerConfig.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/RunnerConfig.cs
@@ -9,24 +9,28 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
     public class RunnerConfig
     {
         private readonly string name;
+        private readonly string title;
         private readonly List<Analysis<long>> analysis;
         private readonly ArcDataFile file;
 
-        public RunnerConfig(string name, int[] cacheSizes, Uri dataUri)
+        public RunnerConfig(string name, string title, int[] cacheSizes, Uri dataUri)
         {
             this.name = name;
+            this.title = title;
             this.analysis = cacheSizes.Select(s => new Analysis<long>(s)).ToList();
             this.file = new ArcDataFile(dataUri);
         }
 
         public string Name => this.name;
 
+        public string Title => this.title;
+
         public IEnumerable<Analysis<long>> Analysis => this.analysis;
 
         public ArcDataFile File => this.file;
 
-        public static RunnerConfig Database = new RunnerConfig("results.arc.database.csv", new[] { 1_000_000, 2_000_000, 3_000_000, 4_000_000, 5_000_000, 6_000_000, 7_000_000, 8_000_000 }, new Uri("https://github.com/bitfaster/cache-datasets/releases/download/v1.0/DS1.lis.gz"));
-        public static RunnerConfig Search = new RunnerConfig("results.arc.search.csv", new[] { 100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000 }, new Uri("https://github.com/bitfaster/cache-datasets/releases/download/v1.0/S3.lis.gz"));
-        public static RunnerConfig Oltp = new RunnerConfig("results.arc.oltp.csv", new[] { 250, 500, 750, 1000, 1250, 1500, 1750, 2000 }, new Uri("https://github.com/bitfaster/cache-datasets/releases/download/v1.0/OLTP.lis.gz"));
+        public static RunnerConfig Database = new RunnerConfig("results.arc.database.csv", "Arc Database", new[] { 1_000_000, 2_000_000, 3_000_000, 4_000_000, 5_000_000, 6_000_000, 7_000_000, 8_000_000 }, new Uri("https://github.com/bitfaster/cache-datasets/releases/download/v1.0/DS1.lis.gz"));
+        public static RunnerConfig Search = new RunnerConfig("results.arc.search.csv", "Arc Search (S3)", new[] { 100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000 }, new Uri("https://github.com/bitfaster/cache-datasets/releases/download/v1.0/S3.lis.gz"));
+        public static RunnerConfig Oltp = new RunnerConfig("results.arc.oltp.csv", "Arc OLTP", new[] { 250, 500, 750, 1000, 1250, 1500, 1750, 2000 }, new Uri("https://github.com/bitfaster/cache-datasets/releases/download/v1.0/OLTP.lis.gz"));
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/BitFaster.Caching.HitRateAnalysis.csproj
+++ b/BitFaster.Caching.HitRateAnalysis/BitFaster.Caching.HitRateAnalysis.csproj
@@ -25,6 +25,8 @@
     </PackageReference>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+      <PackageReference Include="Plotly.NET.CSharp" Version="0.11.1" />
+      <PackageReference Include="Plotly.NET.ImageExport" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BitFaster.Caching.HitRateAnalysis/Glimpse/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Glimpse/Runner.cs
@@ -36,6 +36,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Glimpse
             Console.WriteLine($"Tested {count} keys in {sw.Elapsed}");
             analysis.WriteToConsole();
             Analysis<long>.WriteToFile("results.glimpse.csv", analysis);
+            Analysis<long>.Plot("results.glimpse.csv", "Glimpse", analysis);
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/PlotExt.cs
+++ b/BitFaster.Caching.HitRateAnalysis/PlotExt.cs
@@ -7,16 +7,31 @@ using System.Threading.Tasks;
 using Microsoft.FSharp.Core;
 using Plotly.NET;
 using Plotly.NET.CSharp;
+using Plotly.NET.LayoutObjects;
 
 namespace BitFaster.Caching.HitRateAnalysis
 {
     public static class PlotExt
     {
-        public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string title, string xTitle, string yTitle)
+        public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string xTitle, string yTitle)
         {
             FSharpOption<string> xt = new FSharpOption<string>(xTitle);
             FSharpOption<string> yt = new FSharpOption<string>(yTitle);
-            return chart.WithTitle(title).WithXAxisStyle(Title.init(xt)).WithYAxisStyle(Title.init(yt));
+            return chart.WithXAxisStyle(Title.init(xt)).WithYAxisStyle(Title.init(yt));
+        }
+
+        public static GenericChart.GenericChart WithoutVerticalGridlines(this GenericChart.GenericChart chart)
+        {
+            var axis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(ShowGrid: new FSharpOption<bool>(false));
+            return chart.WithXAxis(axis);
+        }
+
+        public static GenericChart.GenericChart WithLayout(this GenericChart.GenericChart chart, string title)
+        {
+            FSharpOption<Title> t = Title.init(Text: title, X: 0.5);
+            FSharpOption <Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(Plotly.NET.ColorKeyword.WhiteSmoke));
+            Layout layout = Layout.init<IConvertible>(PlotBGColor: plotBGColor, Title: t);
+            return chart.WithLayout(layout);
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/PlotExt.cs
+++ b/BitFaster.Caching.HitRateAnalysis/PlotExt.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.FSharp.Core;
+using Plotly.NET;
+using Plotly.NET.CSharp;
+
+namespace BitFaster.Caching.HitRateAnalysis
+{
+    public static class PlotExt
+    {
+        public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string xTitle, string yTitle)
+        {
+            FSharpOption<string> xt = new FSharpOption<string>(xTitle);
+            FSharpOption<string> yt = new FSharpOption<string>(yTitle);
+            return chart.WithXAxisStyle(Title.init(xt)).WithYAxisStyle(Title.init(yt));
+        }
+    }
+}

--- a/BitFaster.Caching.HitRateAnalysis/PlotExt.cs
+++ b/BitFaster.Caching.HitRateAnalysis/PlotExt.cs
@@ -12,11 +12,11 @@ namespace BitFaster.Caching.HitRateAnalysis
 {
     public static class PlotExt
     {
-        public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string xTitle, string yTitle)
+        public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string title, string xTitle, string yTitle)
         {
             FSharpOption<string> xt = new FSharpOption<string>(xTitle);
             FSharpOption<string> yt = new FSharpOption<string>(yTitle);
-            return chart.WithXAxisStyle(Title.init(xt)).WithYAxisStyle(Title.init(yt));
+            return chart.WithTitle(title).WithXAxisStyle(Title.init(xt)).WithYAxisStyle(Title.init(yt));
         }
     }
 }

--- a/BitFaster.Caching.HitRateAnalysis/PlotExt.cs
+++ b/BitFaster.Caching.HitRateAnalysis/PlotExt.cs
@@ -1,9 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.FSharp.Core;
 using Plotly.NET;
 using Plotly.NET.CSharp;
@@ -15,22 +10,29 @@ namespace BitFaster.Caching.HitRateAnalysis
     {
         public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string xTitle, string yTitle)
         {
+            var font = new FSharpOption<Font>(Font.init(Size: new FSharpOption<double>(16)));
             FSharpOption<string> xt = new FSharpOption<string>(xTitle);
             FSharpOption<string> yt = new FSharpOption<string>(yTitle);
-            return chart.WithXAxisStyle(Title.init(xt)).WithYAxisStyle(Title.init(yt));
+            return chart.WithXAxisStyle(Title.init(xt, Font: font)).WithYAxisStyle(Title.init(yt, Font: font));
         }
 
         public static GenericChart.GenericChart WithoutVerticalGridlines(this GenericChart.GenericChart chart)
         {
+            var gridColor = new FSharpOption<Color>(Color.fromKeyword(ColorKeyword.Gainsboro));
+            var yaxis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(
+                GridColor: gridColor,
+                ZeroLineColor: gridColor);
+
             var axis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(ShowGrid: new FSharpOption<bool>(false));
-            return chart.WithXAxis(axis);
+            return chart.WithXAxis(axis).WithYAxis(yaxis);
         }
 
         public static GenericChart.GenericChart WithLayout(this GenericChart.GenericChart chart, string title)
         {
-            FSharpOption<Title> t = Title.init(Text: title, X: 0.5);
-            FSharpOption <Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(Plotly.NET.ColorKeyword.WhiteSmoke));
-            Layout layout = Layout.init<IConvertible>(PlotBGColor: plotBGColor, Title: t);
+            var font = new FSharpOption<Font>(Font.init(Size: new FSharpOption<double>(24)));
+            FSharpOption<Title> t = Title.init(Text: title, X: 0.5, Font: font);
+            FSharpOption <Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(ColorKeyword.WhiteSmoke));
+            Layout layout = Layout.init<IConvertible>(PaperBGColor: plotBGColor, PlotBGColor: plotBGColor, Title: t);
             return chart.WithLayout(layout);
         }
     }

--- a/BitFaster.Caching.HitRateAnalysis/Wikibench/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Wikibench/Runner.cs
@@ -47,6 +47,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Wikibench
             Console.WriteLine($"Tested {count} URIs in {sw.Elapsed}");
             analysis.WriteToConsole();
             Analysis<Uri>.WriteToFile("results.wikibench.csv", analysis);
+            Analysis<Uri>.Plot("results.wiki.csv", "Wikipedia, 45 million request URIs", analysis);
         }
     }
 }

--- a/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
+++ b/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -22,6 +22,8 @@
         <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
+    <PackageReference Include="Plotly.NET.CSharp" Version="0.11.1" />
+    <PackageReference Include="Plotly.NET.ImageExport" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -134,7 +134,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 case "ConcurrLRU":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.RoyalBlue);
                 case "ConcurrLFU":
-                    return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Khaki);
+                    return Plotly.NET.Color.fromRGB(255, 192, 0);
                 default:
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick);
             }
@@ -145,22 +145,29 @@ namespace BitFaster.Caching.ThroughputAnalysis
     {
         public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string xTitle, string yTitle)
         {
+            var font = new FSharpOption<Font>(Font.init(Size: new FSharpOption<double>(16)));
             FSharpOption<string> xt = new FSharpOption<string>(xTitle);
             FSharpOption<string> yt = new FSharpOption<string>(yTitle);
-            return chart.WithXAxisStyle(Title.init(xt)).WithYAxisStyle(Title.init(yt));
+            return chart.WithXAxisStyle(Title.init(xt, Font: font)).WithYAxisStyle(Title.init(yt, Font: font));
         }
 
         public static GenericChart.GenericChart WithoutVerticalGridlines(this GenericChart.GenericChart chart)
         {
+            var gridColor = new FSharpOption<Color>(Color.fromKeyword(ColorKeyword.Gainsboro));
+            var yaxis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(
+                GridColor: gridColor,
+                ZeroLineColor: gridColor);
+
             var axis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(ShowGrid: new FSharpOption<bool>(false));
-            return chart.WithXAxis(axis);
+            return chart.WithXAxis(axis).WithYAxis(yaxis);
         }
 
         public static GenericChart.GenericChart WithLayout(this GenericChart.GenericChart chart, string title)
         {
-            FSharpOption<Title> t = Title.init(Text: title, X: 0.5);
-            FSharpOption<Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(Plotly.NET.ColorKeyword.WhiteSmoke));
-            Layout layout = Layout.init<IConvertible>(PlotBGColor: plotBGColor, Title: t);
+            var font = new FSharpOption<Font>(Font.init(Size: new FSharpOption<double>(24)));
+            FSharpOption<Title> t = Title.init(Text: title, X: 0.5, Font: font);
+            FSharpOption<Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(ColorKeyword.WhiteSmoke));
+            Layout layout = Layout.init<IConvertible>(PaperBGColor: plotBGColor, PlotBGColor: plotBGColor, Title: t);
             return chart.WithLayout(layout);
         }
     }

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -92,7 +92,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     rowData.Add(double.Parse(row[i].ToString()));
                 }
 
-                var chart = Chart.Line<string, double, string>(columns, rowData, Name: name, MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick));
+                var chart = Chart.Line<string, double, string>(columns, rowData, Name: name, MarkerColor: MapColor(name));
                 charts.Add(chart);
 
                 var combined = Chart.Combine(charts);
@@ -119,6 +119,25 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     return $"Eviction throughput (100% cache miss) for size {cacheSize}";
                 default:
                     return $"{mode} {cacheSize}";
+            }
+        }
+
+        public Color MapColor(string name)
+        {
+            switch (name)
+            {
+                case "ClassicLru":
+                    return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Limegreen);
+                case "MemoryCache":
+                    return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick);
+                case "FastConcurrentLRU":
+                    return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Silver);
+                case "ConcurrentLRU":
+                    return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.RoyalBlue);
+                case "ConcurrentLFU":
+                    return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Khaki);
+                default:
+                    return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick);
             }
         }
     }

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -4,9 +4,13 @@ using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using CsvHelper;
+using Microsoft.FSharp.Core;
+using Plotly.NET;
+using Plotly.NET.ImageExport;
+using Plotly.NET.LayoutObjects;
+using static Plotly.NET.StyleParam.SubPlotId;
+using Chart = Plotly.NET.CSharp.Chart;
 
 namespace BitFaster.Caching.ThroughputAnalysis
 {
@@ -66,6 +70,80 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     csv.NextRecord();
                 }
             }
+        }
+
+        public void ExportPlot(Mode mode, int cacheSize)
+        {
+            var columns = new List<string>();
+
+            foreach (DataColumn column in resultTable.Columns)
+            {
+                columns.Add(column.ColumnName);
+            }
+
+            List<GenericChart.GenericChart> charts = new List<GenericChart.GenericChart>();
+
+            foreach (DataRow row in resultTable.Rows)
+            {
+                var rowData = new List<double>();
+                string name = row[0].ToString();
+                for (var i = 1; i < resultTable.Columns.Count; i++)
+                {
+                    rowData.Add(double.Parse(row[i].ToString()));
+                }
+
+                var chart = Chart.Line<string, double, string>(columns, rowData, Name: name, MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick));
+                charts.Add(chart);
+
+                var combined = Chart.Combine(charts);
+
+                combined
+                    .WithLayout(MapTitle(mode, cacheSize))
+                    .WithoutVerticalGridlines()
+                    .WithAxisTitles("Number of threads", "Ops/sec (millions)")
+                    .SaveSVG($"Results_{mode}_{cacheSize}", Width: 1000, Height: 600);
+            }
+        }
+
+        public string MapTitle(Mode mode, int cacheSize)
+        {
+            switch (mode)
+            {
+                case Mode.Read:
+                    return $"Read throughput (100% cache hit) for size {cacheSize}";
+                case Mode.ReadWrite:
+                    return $"Read + Write throughput for size {cacheSize}";
+                case Mode.Update:
+                    return $"Update throughput for size {cacheSize}";
+                case Mode.Evict:
+                    return $"Eviction throughput (100% cache miss) for size {cacheSize}";
+                default:
+                    return $"{mode} {cacheSize}";
+            }
+        }
+    }
+
+    public static class PlotExt
+    {
+        public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string xTitle, string yTitle)
+        {
+            FSharpOption<string> xt = new FSharpOption<string>(xTitle);
+            FSharpOption<string> yt = new FSharpOption<string>(yTitle);
+            return chart.WithXAxisStyle(Title.init(xt)).WithYAxisStyle(Title.init(yt));
+        }
+
+        public static GenericChart.GenericChart WithoutVerticalGridlines(this GenericChart.GenericChart chart)
+        {
+            var axis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(ShowGrid: new FSharpOption<bool>(false));
+            return chart.WithXAxis(axis);
+        }
+
+        public static GenericChart.GenericChart WithLayout(this GenericChart.GenericChart chart, string title)
+        {
+            FSharpOption<Title> t = Title.init(Text: title, X: 0.5);
+            FSharpOption<Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(Plotly.NET.ColorKeyword.WhiteSmoke));
+            Layout layout = Layout.init<IConvertible>(PlotBGColor: plotBGColor, Title: t);
+            return chart.WithLayout(layout);
         }
     }
 }

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -88,7 +88,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 string name = row[0].ToString();
                 for (var i = 1; i < resultTable.Columns.Count; i++)
                 {
-                    rowData.Add(double.Parse(row[i].ToString()));
+                    rowData.Add(double.Parse(row[i].ToString()) * 1_000_000);
                 }
 
                 var chart = Chart.Line<string, double, string>(columns, rowData, Name: name, MarkerColor: MapColor(name));
@@ -99,7 +99,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 combined
                     .WithLayout(MapTitle(mode, cacheSize))
                     .WithoutVerticalGridlines()
-                    .WithAxisTitles("Number of threads", "Ops/sec (millions)")
+                    .WithAxisTitles("Number of threads", "Ops/sec")
                     .SaveSVG($"Results_{mode}_{cacheSize}", Width: 1000, Height: 600);
             }
         }

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -128,13 +128,13 @@ namespace BitFaster.Caching.ThroughputAnalysis
             {
                 case "ClassicLru":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Limegreen);
-                case "MemoryCache":
+                case "MemryCache":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick);
-                case "FastConcurrentLRU":
+                case "FsTConcLRU":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Silver);
-                case "ConcurrentLRU":
+                case "ConcurrLRU":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.RoyalBlue);
-                case "ConcurrentLFU":
+                case "ConcurrLFU":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Khaki);
                 default:
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick);

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -9,7 +9,6 @@ using Microsoft.FSharp.Core;
 using Plotly.NET;
 using Plotly.NET.ImageExport;
 using Plotly.NET.LayoutObjects;
-using static Plotly.NET.StyleParam.SubPlotId;
 using Chart = Plotly.NET.CSharp.Chart;
 
 namespace BitFaster.Caching.ThroughputAnalysis
@@ -76,9 +75,9 @@ namespace BitFaster.Caching.ThroughputAnalysis
         {
             var columns = new List<string>();
 
-            foreach (DataColumn column in resultTable.Columns)
+            for(int i = 1; i < resultTable.Columns.Count; i++)
             {
-                columns.Add(column.ColumnName);
+                columns.Add(resultTable.Columns[i].ColumnName);
             }
 
             List<GenericChart.GenericChart> charts = new List<GenericChart.GenericChart>();

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -7,7 +7,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 {
     public class Runner
     {
-        private static readonly int maxThreads = Host.GetAvailableCoreCount();
+        private static readonly int maxThreads = Host.GetAvailableCoreCount() * 2;
 
         public static void Run(Mode mode, int cacheSize)
         {

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -7,7 +7,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 {
     public class Runner
     {
-        private static readonly int maxThreads = Host.GetAvailableCoreCount() * 2;
+        private static readonly int maxThreads = Host.GetAvailableCoreCount();
 
         public static void Run(Mode mode, int cacheSize)
         {
@@ -66,6 +66,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             exporter.CaptureRows(cachesToTest);
 
             exporter.ExportCsv(mode, cacheSize);
+            exporter.ExportPlot(mode, cacheSize);
 
             //ConsoleTable
             //    .From(resultTable)

--- a/Tools/BenchPlot/BenchPlot.csproj
+++ b/Tools/BenchPlot/BenchPlot.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
+    <PackageReference Include="Plotly.NET.CSharp" Version="0.11.1" />
+    <PackageReference Include="Plotly.NET.ImageExport" Version="5.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/Tools/BenchPlot/BenchmarkData.cs
+++ b/Tools/BenchPlot/BenchmarkData.cs
@@ -1,0 +1,34 @@
+﻿using CsvHelper.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BenchPlot
+{
+    public class BenchmarkData
+    {
+        public string Method { get; set; }
+
+        public string Job { get; set; }
+
+        public string Mean { get; set; }
+
+        public string StdDev { get; set; }
+
+        //public string Size { get; set; }
+    }
+
+    public class BenchMap : ClassMap<BenchmarkData>
+    {
+        public BenchMap()
+        {
+            Map(m => m.Method).Name("Method");
+            Map(m => m.Job).Name("Job");
+            Map(m => m.Mean).Name("Mean");
+            Map(m => m.StdDev).Name("StdDev");
+            //Map(m => m.Size).Name("Size");
+        }
+    }
+}

--- a/Tools/BenchPlot/BenchmarkData.cs
+++ b/Tools/BenchPlot/BenchmarkData.cs
@@ -1,21 +1,16 @@
 ﻿using CsvHelper.Configuration;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BenchPlot
 {
     public class BenchmarkData
     {
-        public string Method { get; set; }
+        public string Method { get; set; } = string.Empty;
 
-        public string Job { get; set; }
+        public string Job { get; set; } = string.Empty;
 
-        public string Mean { get; set; }
+        public string Mean { get; set; } = string.Empty;
 
-        public string StdDev { get; set; }
+        public string StdDev { get; set; } = string.Empty;
 
         //public string Size { get; set; }
     }

--- a/Tools/BenchPlot/PlotExt.cs
+++ b/Tools/BenchPlot/PlotExt.cs
@@ -8,21 +8,28 @@ namespace BenchPlot
     {
         public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string yTitle)
         {
+            var font = new FSharpOption<Font>(Font.init(Size: new FSharpOption<double>(16)));
             FSharpOption<string> yt = new FSharpOption<string>(yTitle);
-            return chart.WithYAxisStyle(Title.init(yt));
+            return chart.WithXAxisStyle(Title.init(Font: font)).WithYAxisStyle(Title.init(yt, Font: font));
         }
 
         public static GenericChart.GenericChart WithoutVerticalGridlines(this GenericChart.GenericChart chart)
         {
+            var gridColor = new FSharpOption<Color>(Color.fromKeyword(ColorKeyword.Gainsboro));
+            var yaxis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(
+                GridColor: gridColor,
+                ZeroLineColor: gridColor);
+
             var axis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(ShowGrid: new FSharpOption<bool>(false));
-            return chart.WithXAxis(axis);
+            return chart.WithXAxis(axis).WithYAxis(yaxis);
         }
 
         public static GenericChart.GenericChart WithLayout(this GenericChart.GenericChart chart, string title)
         {
-            FSharpOption<Title> t = Title.init(Text: title, X: 0.5);
-            FSharpOption<Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(Plotly.NET.ColorKeyword.WhiteSmoke));
-            Layout layout = Layout.init<IConvertible>(PlotBGColor: plotBGColor, Title: t);
+            var font = new FSharpOption<Font>(Font.init(Size: new FSharpOption<double>(24)));
+            FSharpOption<Title> t = Title.init(Text: title, X: 0.5, Font: font);
+            FSharpOption<Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(ColorKeyword.WhiteSmoke));
+            Layout layout = Layout.init<IConvertible>(PaperBGColor: plotBGColor, PlotBGColor: plotBGColor, Title: t);
             return chart.WithLayout(layout);
         }
     }

--- a/Tools/BenchPlot/PlotExt.cs
+++ b/Tools/BenchPlot/PlotExt.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.FSharp.Core;
+using Plotly.NET.LayoutObjects;
+using Plotly.NET;
+
+namespace BenchPlot
+{
+    public static class PlotExt
+    {
+        public static GenericChart.GenericChart WithAxisTitles(this GenericChart.GenericChart chart, string yTitle)
+        {
+            FSharpOption<string> yt = new FSharpOption<string>(yTitle);
+            return chart.WithYAxisStyle(Title.init(yt));
+        }
+
+        public static GenericChart.GenericChart WithoutVerticalGridlines(this GenericChart.GenericChart chart)
+        {
+            var axis = LinearAxis.init<IConvertible, IConvertible, IConvertible, IConvertible, IConvertible, IConvertible>(ShowGrid: new FSharpOption<bool>(false));
+            return chart.WithXAxis(axis);
+        }
+
+        public static GenericChart.GenericChart WithLayout(this GenericChart.GenericChart chart, string title)
+        {
+            FSharpOption<Title> t = Title.init(Text: title, X: 0.5);
+            FSharpOption<Color> plotBGColor = new FSharpOption<Color>(Color.fromKeyword(Plotly.NET.ColorKeyword.WhiteSmoke));
+            Layout layout = Layout.init<IConvertible>(PlotBGColor: plotBGColor, Title: t);
+            return chart.WithLayout(layout);
+        }
+    }
+}

--- a/Tools/BenchPlot/Program.cs
+++ b/Tools/BenchPlot/Program.cs
@@ -1,0 +1,107 @@
+﻿using BenchPlot;
+using CsvHelper;
+using Plotly.NET;
+using Plotly.NET.ImageExport;
+using System.Data;
+using System.Globalization;
+using Chart = Plotly.NET.CSharp.Chart;
+
+// TODO:
+// 1. path is an input arg
+// 2. enable override of title by benchname from a config file
+// 3. enable a way to process the size benches for the sketch tests?
+
+if (args.Length != 1)
+{
+    Console.WriteLine($"Invalid args");
+    return 1;
+}
+
+string inputPath = args[0]; //@"C:\Users\alexpeck\Downloads\Benchmark Artifacts (Windows)";
+string outputPath = Path.Combine(inputPath, "plots");
+
+Console.WriteLine($"Looking for results dir at {inputPath}");
+
+string[] files = System.IO.Directory.GetFiles(Path.Combine(inputPath, "results"), "*.csv");
+
+if (files.Length == 0)
+{
+    Console.WriteLine($"No benchmark results found");
+    return 2;
+}
+else
+{
+    Console.WriteLine($"Found {files.Length} benchmark results.");
+}
+
+if (!Directory.Exists(outputPath))
+{
+    Console.WriteLine($"Creating plots dir at {outputPath}");
+    Directory.CreateDirectory(outputPath);
+}
+
+foreach (string file in files)
+{
+    string benchName = Path.GetFileNameWithoutExtension(file).Replace("-report", string.Empty);
+
+    Console.WriteLine($"Processing {benchName}");
+
+    using (var reader = new StreamReader(file))
+    using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
+    {
+        csv.Context.RegisterClassMap<BenchMap>();
+        var records = csv.GetRecords<BenchmarkData>();
+
+        var jobs = records.GroupBy(r => r.Job).ToList();
+
+        // plot one column chart for each job
+        foreach (var job in jobs)
+        {
+            Console.WriteLine($"Plotting {job.Key}...");
+
+            var methods = job.Select(r => r.Method).ToArray();
+            var nanos = job.Select(r => TimeParser.Parse(r.Mean)).ToArray();
+            var stdDev = job.Select(r => TimeParser.Parse(r.StdDev)).ToArray();
+
+            var fn = $"{benchName} ({job.Key})";
+            var chart = Chart.Column<double, string, string>(nanos, methods, MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.IndianRed))
+                .WithYErrorStyle<double, IConvertible>(stdDev)
+                .WithAxisTitles("Time (ns)")
+                .WithLayout(fn);
+
+            chart.SaveSVG(Path.Combine(outputPath, fn), Width: 1000, Height: 600);
+        }
+
+        // plot a column chart with results grouped by job
+        if (jobs.Count() > 1)
+        {
+            Console.WriteLine($"Plotting combined jobs...");
+
+            List<ColorKeyword> colors = new List<ColorKeyword>() { ColorKeyword.IndianRed, ColorKeyword.Salmon };
+            List<GenericChart.GenericChart> charts = new List<GenericChart.GenericChart>();
+
+            int ind = 0;
+            foreach (var job in jobs)
+            {
+                var methods = job.Select(r => r.Method).ToArray();
+                var nanos = job.Select(r => TimeParser.Parse(r.Mean)).ToArray();
+                var stdDev = job.Select(r => TimeParser.Parse(r.StdDev)).ToArray();
+
+                var chart = Chart.Column<double, string, string>(nanos, methods, job.Key, MarkerColor: Plotly.NET.Color.fromKeyword(colors[ind++]))
+                    .WithYErrorStyle<double, IConvertible>(stdDev);
+
+                charts.Add(chart);
+            }
+
+            var combined = Chart.Combine(charts);
+
+            var fn = $"{benchName}";
+            combined
+                .WithAxisTitles("Time (ns)")
+                .WithLayout(fn)
+                .SaveSVG(Path.Combine(outputPath, fn), Width: 1000, Height: 600);
+        }
+    }
+}
+
+return 0;

--- a/Tools/BenchPlot/Program.cs
+++ b/Tools/BenchPlot/Program.cs
@@ -6,10 +6,6 @@ using System.Data;
 using System.Globalization;
 using Chart = Plotly.NET.CSharp.Chart;
 
-// TODO:
-// 1. enable override of title by benchname from a config file
-// 2. enable a way to process the size benches for the sketch tests?
-
 if (args.Length != 1)
 {
     Console.WriteLine($"Invalid args");

--- a/Tools/BenchPlot/Program.cs
+++ b/Tools/BenchPlot/Program.cs
@@ -7,9 +7,8 @@ using System.Globalization;
 using Chart = Plotly.NET.CSharp.Chart;
 
 // TODO:
-// 1. path is an input arg
-// 2. enable override of title by benchname from a config file
-// 3. enable a way to process the size benches for the sketch tests?
+// 1. enable override of title by benchname from a config file
+// 2. enable a way to process the size benches for the sketch tests?
 
 if (args.Length != 1)
 {
@@ -17,7 +16,7 @@ if (args.Length != 1)
     return 1;
 }
 
-string inputPath = args[0]; //@"C:\Users\alexpeck\Downloads\Benchmark Artifacts (Windows)";
+string inputPath = args[0];
 string outputPath = Path.Combine(inputPath, "plots");
 
 Console.WriteLine($"Looking for results dir at {inputPath}");

--- a/Tools/BenchPlot/Program.cs
+++ b/Tools/BenchPlot/Program.cs
@@ -62,6 +62,7 @@ foreach (string file in files)
             var chart = Chart.Column<double, string, string>(nanos, methods, MarkerColor: Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.IndianRed))
                 .WithYErrorStyle<double, IConvertible>(stdDev)
                 .WithAxisTitles("Time (ns)")
+                .WithoutVerticalGridlines()
                 .WithLayout(fn);
 
             chart.SaveSVG(Path.Combine(outputPath, fn), Width: 1000, Height: 600);
@@ -93,6 +94,7 @@ foreach (string file in files)
             var fn = $"{benchName}";
             combined
                 .WithAxisTitles("Time (ns)")
+                .WithoutVerticalGridlines()
                 .WithLayout(fn)
                 .SaveSVG(Path.Combine(outputPath, fn), Width: 1000, Height: 600);
         }

--- a/Tools/BenchPlot/TimeParser.cs
+++ b/Tools/BenchPlot/TimeParser.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BenchPlot
+{
+    public static class TimeParser
+    {
+        public static double Parse(string time)
+        {
+            var split = time.Split(' ');
+
+            if (time.EndsWith("μs"))
+            {
+                return double.Parse(split[0]) * 0.001;
+            }
+
+            if (time.EndsWith("ns"))
+            {
+                return double.Parse(split[0]);
+            }
+
+            if (time.EndsWith("ms"))
+            {
+                return double.Parse(split[0]) * 1_000_000;
+            }
+
+            if (time.EndsWith("NA"))
+            {
+                return 0;
+            }
+
+            if (time.EndsWith("?"))
+            {
+                return 0;
+            }
+
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/Tools/Tools.sln
+++ b/Tools/Tools.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.7.34202.233
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HashTableSize", "HashTableSize\HashTableSize.csproj", "{127B7B6D-ECE7-4056-87D2-5C2A4477BAEC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HashTableSize", "HashTableSize\HashTableSize.csproj", "{127B7B6D-ECE7-4056-87D2-5C2A4477BAEC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BenchPlot", "BenchPlot\BenchPlot.csproj", "{A3AA1ECB-E753-4E73-B2A8-09434FAF2664}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{127B7B6D-ECE7-4056-87D2-5C2A4477BAEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{127B7B6D-ECE7-4056-87D2-5C2A4477BAEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{127B7B6D-ECE7-4056-87D2-5C2A4477BAEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3AA1ECB-E753-4E73-B2A8-09434FAF2664}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3AA1ECB-E753-4E73-B2A8-09434FAF2664}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3AA1ECB-E753-4E73-B2A8-09434FAF2664}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3AA1ECB-E753-4E73-B2A8-09434FAF2664}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Use Plotly.NET:

- Hit rate analysis plots charts as part of output
- Throughput analysis plots charts as part of output
- Benchmarks plots are produced as a post processing step in the GitHub action via a command line application that processes the output .csv files

Examples:

![results glimpse](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/ff6f1ef4-25a4-4c50-8319-64bfe30ae603)

![BitFaster Caching Benchmarks LruJustGetOrAdd](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/4357dc22-2d36-4086-8aa8-a41a2a74e1ab)

![Results_Read_500](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/47a99905-a1df-4ca7-86fb-5d358a5dbf81)
