### PR TITLE
Plot throughput charts with integer thread count

### DIFF
--- a/BitFaster.Caching.ThroughputAnalysis/CacheFactory.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/CacheFactory.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             this.capacity = capacity;
         }
 
-        public string Name => "FsTConcLRU";
+        public string Name => "FastConcurrentLru";
 
         public DataRow DataRow { get; set; }
 
@@ -46,7 +46,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             this.capacity = capacity;
         }
 
-        public string Name => "ConcurrLRU";
+        public string Name => "ConcurrentLru";
 
         public DataRow DataRow { get; set; }
 
@@ -67,7 +67,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             this.capacity = capacity;
         }
 
-        public string Name => "MemryCache";
+        public string Name => "MemoryCache";
 
         public DataRow DataRow { get; set; }
 
@@ -88,7 +88,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             this.capacity = capacity;
         }
 
-        public string Name => "ConcurrLFU";
+        public string Name => "ConcurrentLfu";
 
         public DataRow DataRow { get; set; }
 

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -73,11 +73,11 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public void ExportPlot(Mode mode, int cacheSize)
         {
-            var columns = new List<string>();
+            var columns = new List<int>();
 
             for(int i = 1; i < resultTable.Columns.Count; i++)
             {
-                columns.Add(resultTable.Columns[i].ColumnName);
+                columns.Add(int.Parse(resultTable.Columns[i].ColumnName));
             }
 
             List<GenericChart.GenericChart> charts = new List<GenericChart.GenericChart>();
@@ -91,7 +91,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     rowData.Add(double.Parse(row[i].ToString()) * 1_000_000);
                 }
 
-                var chart = Chart.Line<string, double, string>(columns, rowData, Name: name, MarkerColor: MapColor(name));
+                var chart = Chart.Line<int, double, string>(columns, rowData, Name: name, MarkerColor: MapColor(name));
                 charts.Add(chart);
 
                 var combined = Chart.Combine(charts);

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -109,13 +109,13 @@ namespace BitFaster.Caching.ThroughputAnalysis
             switch (mode)
             {
                 case Mode.Read:
-                    return $"Read throughput (100% cache hit) for size {cacheSize}";
+                    return $"Read throughput (100% cache hit)";
                 case Mode.ReadWrite:
-                    return $"Read + Write throughput for size {cacheSize}";
+                    return $"Read + Write throughput";
                 case Mode.Update:
-                    return $"Update throughput for size {cacheSize}";
+                    return $"Update throughput";
                 case Mode.Evict:
-                    return $"Eviction throughput (100% cache miss) for size {cacheSize}";
+                    return $"Eviction throughput (100% cache miss)";
                 default:
                     return $"{mode} {cacheSize}";
             }

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -127,13 +127,13 @@ namespace BitFaster.Caching.ThroughputAnalysis
             {
                 case "ClassicLru":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Limegreen);
-                case "MemryCache":
+                case "MemoryCache":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick);
-                case "FsTConcLRU":
+                case "FastConcurrentLru":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.Silver);
-                case "ConcurrLRU":
+                case "ConcurrentLru":
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.RoyalBlue);
-                case "ConcurrLFU":
+                case "ConcurrentLfu":
                     return Plotly.NET.Color.fromRGB(255, 192, 0);
                 default:
                     return Plotly.NET.Color.fromKeyword(Plotly.NET.ColorKeyword.FireBrick);

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -59,7 +59,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     (sched as IDisposable)?.Dispose();
 
                     cacheConfig.DataRow[tc.ToString()] = thru.ToString();
-                    Console.WriteLine($"{cacheConfig.Name} ({tc:00}) {FormatThroughput(thru)} million ops/sec");
+                    Console.WriteLine($"{cacheConfig.Name.PadRight(18)} ({tc:00}) {FormatThroughput(thru)} million ops/sec");
                 }
             }
 


### PR DESCRIPTION
X axis is a mess when there are > 100 threads. Instead, use an integer so that plotly automatically selects x axis increments.

Before:
![Results_Read_500](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/47a99905-a1df-4ca7-86fb-5d358a5dbf81)

After:
![Results_Read_500](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/4e495a85-666b-427b-b8d9-7741da06ae19)
