### PR TITLE
Consolidate maximum time to expire

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/AfterAccessPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/AfterAccessPolicyTests.cs
@@ -33,13 +33,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenTtlIsMaxSetAsMax()
         {
-#if NETFRAMEWORK
-            var maxRepresentable = TimeSpan.FromTicks((long)(long.MaxValue / 100.0d)) - TimeSpan.FromTicks(10);
-#else
-            var maxRepresentable = Time.MaxRepresentable;
-#endif
-            var policy = new AfterAccessPolicy<int, int>(maxRepresentable);
-            policy.TimeToLive.Should().BeCloseTo(maxRepresentable, TimeSpan.FromTicks(20));
+            var policy = new AfterAccessPolicy<int, int>(Duration.MaxRepresentable);
+            policy.TimeToLive.Should().BeCloseTo(Duration.MaxRepresentable, TimeSpan.FromMilliseconds(20));
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -32,9 +32,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenTtlIsMaxSetAsMax()
         {
-            var maxRepresentable = TimeSpan.FromTicks(9223372036854769664);
-            var policy = new TLruLongTicksPolicy<int, int>(maxRepresentable);
-            policy.TimeToLive.Should().Be(maxRepresentable);
+            var policy = new TLruLongTicksPolicy<int, int>(Duration.MaxRepresentable);
+            policy.TimeToLive.Should().BeCloseTo(Duration.MaxRepresentable, TimeSpan.FromMilliseconds(20));
         }
 
         [Fact]

--- a/BitFaster.Caching/Duration.cs
+++ b/BitFaster.Caching/Duration.cs
@@ -18,13 +18,11 @@ namespace BitFaster.Caching
     public readonly struct Duration
     {
         internal readonly long raw;
-#if NETCOREAPP3_0_OR_GREATER
-        internal static readonly TimeSpan MaxRepresentable = TimeSpan.FromTicks(9223372036854769664);
-#else
+
         // MacOS Stopwatch adjustment factor is 100, giving lowest maximum TTL on mac platform - use same upper limit on all platforms for consistency
         // this also avoids overflow when multipling long.MaxValue by 1.0
-        internal static readonly TimeSpan MaxRepresentable = TimeSpan.FromTicks((long)(long.MaxValue * 0.01d));
-#endif
+        internal static readonly TimeSpan MaxRepresentable = TimeSpan.FromTicks((long)(long.MaxValue / 100.0d)) - TimeSpan.FromTicks(10);
+
         internal Duration(long raw)
         { 
             this.raw = raw; 

--- a/BitFaster.Caching/Duration.cs
+++ b/BitFaster.Caching/Duration.cs
@@ -21,7 +21,7 @@ namespace BitFaster.Caching
 
         // MacOS Stopwatch adjustment factor is 100, giving lowest maximum TTL on mac platform - use same upper limit on all platforms for consistency
         // this also avoids overflow when multipling long.MaxValue by 1.0
-        internal static readonly TimeSpan MaxRepresentable = TimeSpan.FromTicks((long)(long.MaxValue / 100.0d)) - TimeSpan.FromTicks(10);
+        internal static readonly TimeSpan MaxRepresentable = TimeSpan.FromTicks((long)(long.MaxValue / 100.0d));
 
         internal Duration(long raw)
         { 

--- a/BitFaster.Caching/Lru/AfterAccessPolicy.cs
+++ b/BitFaster.Caching/Lru/AfterAccessPolicy.cs
@@ -20,8 +20,8 @@ namespace BitFaster.Caching.Lru
         /// <param name="timeToLive">The time to live.</param>
         public AfterAccessPolicy(TimeSpan timeToLive)
         {
-            if (timeToLive <= TimeSpan.Zero || timeToLive > Time.MaxRepresentable)
-                Throw.ArgOutOfRange(nameof(timeToLive), $"Value must greater than zero and less than {Time.MaxRepresentable}");
+            if (timeToLive <= TimeSpan.Zero || timeToLive > Duration.MaxRepresentable)
+                Throw.ArgOutOfRange(nameof(timeToLive), $"Value must greater than zero and less than {Duration.MaxRepresentable}");
 
             this.timeToLive = Duration.FromTimeSpan(timeToLive);
             this.time = new Time();

--- a/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
@@ -20,7 +20,7 @@ namespace BitFaster.Caching.Lru
         /// <param name="timeToLive">The time to live.</param>
         public TLruLongTicksPolicy(TimeSpan timeToLive)
         {
-            if (timeToLive <= TimeSpan.Zero || timeToLive > Time.MaxRepresentable)
+            if (timeToLive <= TimeSpan.Zero || timeToLive > Duration.MaxRepresentable)
                 Throw.ArgOutOfRange(nameof(timeToLive), $"Value must greater than zero and less than {Duration.MaxRepresentable}");
 
             this.timeToLive = Duration.FromTimeSpan(timeToLive);

--- a/BitFaster.Caching/Lru/Time.cs
+++ b/BitFaster.Caching/Lru/Time.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace BitFaster.Caching.Lru
+﻿namespace BitFaster.Caching.Lru
 {
     /// <summary>
     /// During reads, the policy evaluates ShouldDiscard and Touch. To avoid Getting the current time twice
@@ -9,8 +7,6 @@ namespace BitFaster.Caching.Lru
     /// </summary>
     internal class Time
     {
-        internal static readonly TimeSpan MaxRepresentable = TimeSpan.FromTicks(9223372036854769664);
-
         /// <summary>
         /// Gets or sets the last time.
         /// </summary>


### PR DESCRIPTION
Previously the maximum settable expiry time depended on the build target. Instead, use the maximum value determined to be settable on all tested platforms: MacOS using `Stopwatch.GetTimestamp` as the time source.