### PR TITLE
Add TrailingZeroCount and LongCeilingPowerOfTwo

### DIFF
--- a/BitFaster.Caching.UnitTests/BitOpsTests.cs
+++ b/BitFaster.Caching.UnitTests/BitOpsTests.cs
@@ -60,10 +60,24 @@ namespace BitFaster.Caching.UnitTests
         [InlineData(2, 1)]
         [InlineData(1_000_000, 6)]
         [InlineData(34359738368, 35)]
+        [InlineData(4611686018427387904, 62)]
+        [InlineData(long.MaxValue, 0)]
+
+        public void LongTrailingZeroCount(long input, int count)
+        {
+            BitOps.TrailingZeroCount(input).Should().Be(count);
+        }
+
+        [Theory]
+        [InlineData(0, 64)]
+        [InlineData(1, 0)]
+        [InlineData(2, 1)]
+        [InlineData(1_000_000, 6)]
+        [InlineData(34359738368, 35)]
         [InlineData(9223372036854775808, 63)]
         [InlineData(ulong.MaxValue, 0)]
 
-        public void LongTrailingZeroCount(ulong input, int count)
+        public void ULongTrailingZeroCount(ulong input, int count)
         {
             BitOps.TrailingZeroCount(input).Should().Be(count);
         }

--- a/BitFaster.Caching.UnitTests/BitOpsTests.cs
+++ b/BitFaster.Caching.UnitTests/BitOpsTests.cs
@@ -25,6 +25,7 @@ namespace BitFaster.Caching.UnitTests
         [InlineData(7, 8)]
         [InlineData(15, 16)]
         [InlineData(536870913, 1073741824)]
+        [InlineData(34359738368, 34359738368)]
         public void LongCeilingPowerOfTwo(long input, long power)
         {
             BitOps.CeilingPowerOfTwo(input).Should().Be(power);

--- a/BitFaster.Caching.UnitTests/BitOpsTests.cs
+++ b/BitFaster.Caching.UnitTests/BitOpsTests.cs
@@ -25,10 +25,46 @@ namespace BitFaster.Caching.UnitTests
         [InlineData(7, 8)]
         [InlineData(15, 16)]
         [InlineData(536870913, 1073741824)]
+        public void LongCeilingPowerOfTwo(long input, long power)
+        {
+            BitOps.CeilingPowerOfTwo(input).Should().Be(power);
+        }
+
+        [Theory]
+        [InlineData(3, 4)]
+        [InlineData(7, 8)]
+        [InlineData(15, 16)]
+        [InlineData(536870913, 1073741824)]
 
         public void UIntCeilingPowerOfTwo(uint input, uint power)
         {
             BitOps.CeilingPowerOfTwo(input).Should().Be(power);
+        }
+
+
+        [Theory]
+        [InlineData(3, 4)]
+        [InlineData(7, 8)]
+        [InlineData(15, 16)]
+        [InlineData(536870913, 1073741824)]
+
+        public void UlongCeilingPowerOfTwo(ulong input, ulong power)
+        {
+            BitOps.CeilingPowerOfTwo(input).Should().Be(power);
+        }
+
+        [Theory]
+        [InlineData(0, 64)]
+        [InlineData(1, 0)]
+        [InlineData(2, 1)]
+        [InlineData(1_000_000, 6)]
+        [InlineData(34359738368, 35)]
+        [InlineData(9223372036854775808, 63)]
+        [InlineData(ulong.MaxValue, 0)]
+
+        public void LongTrailingZeroCount(ulong input, int count)
+        {
+            BitOps.TrailingZeroCount(input).Should().Be(count);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/BitOpsTests.cs
+++ b/BitFaster.Caching.UnitTests/BitOpsTests.cs
@@ -42,12 +42,12 @@ namespace BitFaster.Caching.UnitTests
             BitOps.CeilingPowerOfTwo(input).Should().Be(power);
         }
 
-
         [Theory]
         [InlineData(3, 4)]
         [InlineData(7, 8)]
         [InlineData(15, 16)]
         [InlineData(536870913, 1073741824)]
+        [InlineData(34359738368, 34359738368)]
 
         public void UlongCeilingPowerOfTwo(ulong input, ulong power)
         {

--- a/BitFaster.Caching/BitOps.cs
+++ b/BitFaster.Caching/BitOps.cs
@@ -22,6 +22,16 @@ namespace BitFaster.Caching
         /// </summary>
         /// <param name="x">The input parameter.</param>
         /// <returns>Smallest power of two greater than or equal to x.</returns>
+        internal static long CeilingPowerOfTwo(long x)
+        {
+            return (long)CeilingPowerOfTwo((ulong)x);
+        }
+
+        /// <summary>
+        /// Calculate the smallest power of 2 greater than the input parameter.
+        /// </summary>
+        /// <param name="x">The input parameter.</param>
+        /// <returns>Smallest power of two greater than or equal to x.</returns>
         public static uint CeilingPowerOfTwo(uint x)
         {
 #if NETSTANDARD2_0
@@ -36,7 +46,53 @@ namespace BitFaster.Caching
 #else
             return 1u << -BitOperations.LeadingZeroCount(x - 1);
 #endif
+        }
 
+        /// <summary>
+        /// Calculate the smallest power of 2 greater than the input parameter.
+        /// </summary>
+        /// <param name="x">The input parameter.</param>
+        /// <returns>Smallest power of two greater than or equal to x.</returns>
+        internal static ulong CeilingPowerOfTwo(ulong x)
+        {
+#if NETSTANDARD2_0
+            // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            --x;
+            x |= x >> 1;
+            x |= x >> 2;
+            x |= x >> 4;
+            x |= x >> 8;
+            x |= x >> 16;
+            x |= x >> 32;
+            return x + 1;
+#else
+            return 1u << -BitOperations.LeadingZeroCount(x - 1);
+#endif
+        }
+
+        /// <summary>
+        /// Counts the number of trailing zero bits in the input parameter.
+        /// </summary>
+        /// <param name="x">The input parameter.</param>
+        /// <returns>The number of trailing zero bits.</returns>
+        internal static int TrailingZeroCount(long x)
+        {
+            return TrailingZeroCount((ulong)x);
+        }
+
+        /// <summary>
+        /// Counts the number of trailing zero bits in the input parameter.
+        /// </summary>
+        /// <param name="x">The input parameter.</param>
+        /// <returns>The number of trailing zero bits.</returns>
+        internal static int TrailingZeroCount(ulong x)
+        {
+#if NETSTANDARD2_0
+            // https://codereview.stackexchange.com/questions/288007/c-bit-utility-functions-popcount-trailing-zeros-count-reverse-all-bits
+            return BitCount(~x & (x - 1));
+#else
+            return BitOperations.TrailingZeroCount(x);
+#endif
         }
 
         /// <summary>

--- a/BitFaster.Caching/BitOps.cs
+++ b/BitFaster.Caching/BitOps.cs
@@ -66,7 +66,7 @@ namespace BitFaster.Caching
             x |= x >> 32;
             return x + 1;
 #else
-            return 1u << -BitOperations.LeadingZeroCount(x - 1);
+            return 1ul << -BitOperations.LeadingZeroCount(x - 1);
 #endif
         }
 


### PR DESCRIPTION
Required for TimerWheel in https://github.com/bitfaster/BitFaster.Caching/pull/516, keep internal for now.