### PR TITLE
Use benchly

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -19,6 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Benchly" Version="0.6.0" />
     <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.10" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />

--- a/BitFaster.Caching.Benchmarks/Lfu/LfuJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/LfuJustGetOrAdd.cs
@@ -3,6 +3,7 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
+using Benchly;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -17,6 +18,7 @@ namespace BitFaster.Caching.Benchmarks
     [MemoryDiagnoser(displayGenColumns: false)]
     // [HardwareCounters(HardwareCounter.LlcMisses, HardwareCounter.CacheMisses)] // Requires Admin https://adamsitnik.com/Hardware-Counters-Diagnoser/
     // [ThreadingDiagnoser] // Requires .NET Core
+    [BoxPlot(Title = "LFU Read Latency")]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LfuJustGetOrAdd
     {

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -1,4 +1,5 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using Benchly;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
 using BitFaster.Caching.Lfu;
@@ -38,6 +39,7 @@ namespace BitFaster.Caching.Benchmarks
     // [HardwareCounters(HardwareCounter.LlcMisses, HardwareCounter.CacheMisses)] // Requires Admin https://adamsitnik.com/Hardware-Counters-Diagnoser/
     // [ThreadingDiagnoser] // Requires .NET Core
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
+    [ColumnChart(Output = OutputMode.PerJob, Colors = "black,royalblue,royalblue,royalblue,royalblue,royalblue,royalblue,royalblue,yellow,limegreen,firebrick,firebrick")]
     public class LruJustGetOrAdd
     {
         private static readonly ConcurrentDictionary<int, int> dictionary = new ConcurrentDictionary<int, int>(8, 9, EqualityComparer<int>.Default);


### PR DESCRIPTION
Hookup benchly to automate generating Benchmark test results.

# .NET6 latency:

![BitFaster Caching Benchmarks LruJustGetOrAdd- NET 6 0-columnchart](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/aba5015e-accb-4630-928a-5afc8e78c2fb)

# Box plot for LFU:

![BitFaster Caching Benchmarks LfuJustGetOrAdd-boxplot](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/68f83f5a-3192-4e1a-bda0-ce1899a758bc)
