### PR TITLE
Throughput analysis v2.0

### DIFF
--- a/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
+++ b/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
@@ -23,7 +23,7 @@
         <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
-    <PackageReference Include="Plotly.NET.CSharp" Version="0.11.1" />
+    <PackageReference Include="Plotly.NET" Version="4.2.0" />
     <PackageReference Include="Plotly.NET.ImageExport" Version="5.0.1" />
   </ItemGroup>
 

--- a/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
+++ b/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>False</SignAssembly>
+    <Version>2.0.0</Version>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <RetainVMGarbageCollection>true</RetainVMGarbageCollection>

--- a/BitFaster.Caching.ThroughputAnalysis/ConfigFactory.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ConfigFactory.cs
@@ -12,37 +12,25 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
         public static (ThroughputBenchmarkBase, IThroughputBenchConfig, int) Create(Mode mode, int cacheSize, int maxThreads)
         {
-            int iterations = GetIterationCount(cacheSize);
             int samples = GetSampleCount(cacheSize);
             int n = cacheSize; // number of unique items for Zipf
 
             switch (mode)
             {
                 case Mode.Read:
-                    return (new ReadThroughputBenchmark(), new ZipfConfig(iterations, samples, s, n), cacheSize);
+                    return (new ReadThroughputBenchmark(), new ZipfConfig(samples, s, n), cacheSize);
                 case Mode.ReadWrite:
                     // cache holds 10% of all items
                     cacheSize /= 10;
-                    return (new ReadThroughputBenchmark(), new ZipfConfig(iterations, samples, s, n), cacheSize);
+                    return (new ReadThroughputBenchmark(), new ZipfConfig(samples, s, n), cacheSize);
                 case Mode.Update:
-                    return (new UpdateThroughputBenchmark(), new ZipfConfig(iterations, samples, s, n), cacheSize);
+                    return (new UpdateThroughputBenchmark(), new ZipfConfig(samples, s, n), cacheSize);
                 case Mode.Evict:
-                    return (new ReadThroughputBenchmark() { Initialize = c => EvictionInit(c) }, new EvictionConfig(iterations, samples, maxThreads), cacheSize);
+                    return (new ReadThroughputBenchmark() { Initialize = c => EvictionInit(c) }, new EvictionConfig(samples, maxThreads), cacheSize);
             }
 
             throw new InvalidOperationException();
         }
-
-        private static int GetIterationCount(int cacheSize) => cacheSize switch
-        {
-            < 500 => 400,
-            < 5_000 => 200,
-            < 10_000 => 100,
-            < 100_000 => 50,
-            < 1_000_000 => 25,
-            < 10_000_000 => 5,
-            _ => 1
-        };
 
         private static int GetSampleCount(int cacheSize) => cacheSize switch
         {

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -9,7 +9,6 @@ using Microsoft.FSharp.Core;
 using Plotly.NET;
 using Plotly.NET.ImageExport;
 using Plotly.NET.LayoutObjects;
-using Chart = Plotly.NET.CSharp.Chart;
 
 namespace BitFaster.Caching.ThroughputAnalysis
 {
@@ -26,7 +25,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
             resultTable.Clear();
             resultTable.Columns.Add("ThreadCount");
-            foreach (var tc in Enumerable.Range(minThreads, maxThreads- minThreads).ToArray())
+            foreach (var tc in Enumerable.Range(minThreads, maxThreads - (minThreads-1)).ToArray())
             {
                 resultTable.Columns.Add(tc.ToString());
             }
@@ -88,10 +87,12 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 string name = row[0].ToString();
                 for (var i = 1; i < resultTable.Columns.Count; i++)
                 {
-                    rowData.Add(double.Parse(row[i].ToString()));
+                    // convert back to millions
+                    rowData.Add(double.Parse(row[i].ToString()) * 1_000_000);
                 }
 
-                var chart = Chart.Line<int, double, string>(columns, rowData, Name: name, MarkerColor: MapColor(name));
+               // var chart = Chart.Line<int, double, string>(columns, rowData, Name: name, MarkerColor: MapColor(name));
+                var chart = Chart2D.Chart.Line<int, double, string>(columns, rowData, Name: name, MarkerColor: MapColor(name));
                 charts.Add(chart);
 
                 var combined = Chart.Combine(charts);

--- a/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Exporter.cs
@@ -17,7 +17,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
     {
         DataTable resultTable = new DataTable();
 
-        public Exporter(int maxThreads)
+        public Exporter(int minThreads, int maxThreads)
         {
             // output:
             // ThreadCount   1  2  3  4  5
@@ -26,7 +26,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
             resultTable.Clear();
             resultTable.Columns.Add("ThreadCount");
-            foreach (var tc in Enumerable.Range(1, maxThreads).ToArray())
+            foreach (var tc in Enumerable.Range(minThreads, maxThreads- minThreads).ToArray())
             {
                 resultTable.Columns.Add(tc.ToString());
             }
@@ -88,7 +88,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 string name = row[0].ToString();
                 for (var i = 1; i < resultTable.Columns.Count; i++)
                 {
-                    rowData.Add(double.Parse(row[i].ToString()) * 1_000_000);
+                    rowData.Add(double.Parse(row[i].ToString()));
                 }
 
                 var chart = Chart.Line<int, double, string>(columns, rowData, Name: name, MarkerColor: MapColor(name));

--- a/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/FastZipf.cs
@@ -8,7 +8,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
     /// </summary>
     public class FastZipf
     {
-        private static readonly Random srandom = new(666);
+        private static readonly Random srandom = new(42);
 
         /// <summary>
         /// Generate a zipf distribution.

--- a/BitFaster.Caching.ThroughputAnalysis/Format.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Format.cs
@@ -1,0 +1,12 @@
+﻿namespace BitFaster.Caching.ThroughputAnalysis
+{
+    internal class Format
+    {
+        public static string Throughput(double thru)
+        {
+            string dformat = "0.00;-0.00";
+            string raw = thru.ToString(dformat);
+            return raw.PadLeft(7, ' ');
+        }
+    }
+}

--- a/BitFaster.Caching.ThroughputAnalysis/Host.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Host.cs
@@ -8,6 +8,11 @@ namespace BitFaster.Caching.ThroughputAnalysis
     {
         public static void PrintInfo()
         {
+            var Reference = typeof(Host).Assembly;
+            var Version = Reference.GetName().Version;
+
+            Console.WriteLine($"Throughput Analysis {Version}");
+
             var hostinfo = HostEnvironmentInfo.GetCurrent();
 
             foreach (var segment in hostinfo.ToFormattedString())

--- a/BitFaster.Caching.ThroughputAnalysis/Host.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Host.cs
@@ -35,8 +35,6 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
                 Console.ResetColor();
             }
-
-            Console.WriteLine();
         }
 
         public static int GetAvailableCoreCount()

--- a/BitFaster.Caching.ThroughputAnalysis/MeasurementsStatistics.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/MeasurementsStatistics.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using Perfolizer.Mathematics.Common;
+using Perfolizer.Mathematics.OutlierDetection;
+
+namespace BitFaster.Caching.ThroughputAnalysis
+{
+    // https://github.com/dotnet/BenchmarkDotNet/blob/b4ac9df9f7890ca9669e2b9c8835af35c072a453/src/BenchmarkDotNet/Mathematics/MeasurementsStatistics.cs#L13
+    internal readonly ref struct MeasurementsStatistics
+    {
+        /// <summary>
+        /// Standard error in nanoseconds.
+        /// </summary>
+        public double StandardError { get; }
+
+        /// <summary>
+        /// Mean in nanoseconds.
+        /// </summary>
+        public double Mean { get; }
+
+        /// <summary>
+        /// 99.9% confidence interval in nanoseconds.
+        /// </summary>
+        public ConfidenceInterval ConfidenceInterval { get; }
+
+        private MeasurementsStatistics(double standardError, double mean, ConfidenceInterval confidenceInterval)
+        {
+            StandardError = standardError;
+            Mean = mean;
+            ConfidenceInterval = confidenceInterval;
+        }
+
+        public static MeasurementsStatistics Calculate(List<double> measurements, OutlierMode outlierMode)
+        {
+            int n = measurements.Count;
+            if (n == 0)
+                throw new InvalidOperationException("StatSummary: Sequence contains no elements");
+
+            double sum = Sum(measurements);
+            double mean = sum / n;
+
+            double variance = Variance(measurements, n, mean);
+            double standardDeviation = Math.Sqrt(variance);
+            double standardError = standardDeviation / Math.Sqrt(n);
+            var confidenceInterval = new ConfidenceInterval(mean, standardError, n);
+
+            if (outlierMode == OutlierMode.DontRemove) // most simple scenario is done without allocations! but this is not the default case
+                return new MeasurementsStatistics(standardError, mean, confidenceInterval);
+
+            measurements.Sort(); // sort in place
+
+            double q1, q3;
+
+            if (n == 1)
+                q1 = q3 = measurements[0];
+            else
+            {
+                q1 = GetQuartile(measurements, measurements.Count / 2);
+                q3 = GetQuartile(measurements, measurements.Count * 3 / 2);
+            }
+
+            double interquartileRange = q3 - q1;
+            double lowerFence = q1 - 1.5 * interquartileRange;
+            double upperFence = q3 + 1.5 * interquartileRange;
+
+            SumWithoutOutliers(outlierMode, measurements, lowerFence, upperFence, out sum, out n); // updates sum and N
+            mean = sum / n;
+
+            variance = VarianceWithoutOutliers(outlierMode, measurements, n, mean, lowerFence, upperFence);
+            standardDeviation = Math.Sqrt(variance);
+            standardError = standardDeviation / Math.Sqrt(n);
+            confidenceInterval = new ConfidenceInterval(mean, standardError, n);
+
+            return new MeasurementsStatistics(standardError, mean, confidenceInterval);
+        }
+
+        private static double Sum(List<double> measurements)
+        {
+            double sum = 0;
+            foreach (var m in measurements)
+                sum += m;
+            return sum;
+        }
+
+        private static void SumWithoutOutliers(OutlierMode outlierMode, List<double> measurements,
+            double lowerFence, double upperFence, out double sum, out int n)
+        {
+            sum = 0;
+            n = 0;
+
+            foreach (var m in measurements)
+                if (!IsOutlier(outlierMode, m, lowerFence, upperFence))
+                {
+                    sum += m;
+                    ++n;
+                }
+        }
+
+        private static double Variance(List<double> measurements, int n, double mean)
+        {
+            if (n == 1)
+                return 0;
+
+            double variance = 0;
+            foreach (var m in measurements)
+                variance += (m - mean) * (m - mean) / (n - 1);
+
+            return variance;
+        }
+
+        private static double VarianceWithoutOutliers(OutlierMode outlierMode, List<double> measurements, int n, double mean, double lowerFence, double upperFence)
+        {
+            if (n == 1)
+                return 0;
+
+            double variance = 0;
+            foreach (var m in measurements)
+                if (!IsOutlier(outlierMode, m, lowerFence, upperFence))
+                    variance += (m - mean) * (m - mean) / (n - 1);
+
+            return variance;
+        }
+
+        private static double GetQuartile(List<double> measurements, int count)
+        {
+            if (count % 2 == 0)
+                return (measurements[count / 2 - 1] + measurements[count / 2]) / 2;
+
+            return measurements[count / 2];
+        }
+
+        private static bool IsOutlier(OutlierMode outlierMode, double value, double lowerFence, double upperFence)
+        {
+            switch (outlierMode)
+            {
+                case OutlierMode.DontRemove:
+                    return false;
+                case OutlierMode.RemoveUpper:
+                    return value > upperFence;
+                case OutlierMode.RemoveLower:
+                    return value < lowerFence;
+                case OutlierMode.RemoveAll:
+                    return value < lowerFence || value > upperFence;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(outlierMode), outlierMode, null);
+            }
+        }
+    }
+}

--- a/BitFaster.Caching.ThroughputAnalysis/MeasurementsStatistics.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/MeasurementsStatistics.cs
@@ -9,17 +9,17 @@ namespace BitFaster.Caching.ThroughputAnalysis
     internal readonly ref struct MeasurementsStatistics
     {
         /// <summary>
-        /// Standard error in nanoseconds.
+        /// Standard error.
         /// </summary>
         public double StandardError { get; }
 
         /// <summary>
-        /// Mean in nanoseconds.
+        /// Mean.
         /// </summary>
         public double Mean { get; }
 
         /// <summary>
-        /// 99.9% confidence interval in nanoseconds.
+        /// 99.9% confidence interval.
         /// </summary>
         public ConfidenceInterval ConfidenceInterval { get; }
 

--- a/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
@@ -21,6 +21,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             {
                 int index = i;
                 threads[i] = new Thread(() => action(index));
+                //threads[i].Priority = ThreadPriority.BelowNormal;
                 threads[i].Start();
             }
 

--- a/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
@@ -21,7 +21,6 @@ namespace BitFaster.Caching.ThroughputAnalysis
             {
                 int index = i;
                 threads[i] = new Thread(() => action(index));
-                //threads[i].Priority = ThreadPriority.BelowNormal;
                 threads[i].Start();
             }
 

--- a/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
@@ -7,21 +7,21 @@ namespace BitFaster.Caching.ThroughputAnalysis
 {
     public class ParallelBenchmark
     {
-        public static TimeSpan Run(Action<int, IThroughputBenchConfig, ICache<long, int>> action, int threads, IThroughputBenchConfig config, ICache<long, int> cache)
+        public static TimeSpan Run(Action<int, IThroughputBenchConfig, ICache<long, int>> action, int threads)
         {
             Task[] tasks = new Task[threads];
             ManualResetEventSlim mre = new ManualResetEventSlim();
 
-            Action<int, IThroughputBenchConfig, ICache<long, int>> syncStart = (taskId, config, cache) =>
+            Action<int> syncStart = (taskId, config, cache) =>
             {
                 mre.Wait();
-                action(taskId, config, cache);
+                action(taskId);
             };
 
             for (int i = 0; i < tasks.Length; i++)
             {
                 int index = i;
-                tasks[i] = Task.Factory.StartNew(() => syncStart(index, config, cache), TaskCreationOptions.LongRunning);
+                tasks[i] = Task.Factory.StartNew(() => syncStart(index), TaskCreationOptions.LongRunning);
             }
 
             // try to mitigate spam from MemoryCache

--- a/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
@@ -12,7 +12,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             Task[] tasks = new Task[threads];
             ManualResetEventSlim mre = new ManualResetEventSlim();
 
-            Action<int> syncStart = (taskId) =>
+            Action<int> syncStart = taskId =>
             {
                 mre.Wait();
                 action(taskId);

--- a/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,21 +7,21 @@ namespace BitFaster.Caching.ThroughputAnalysis
 {
     public class ParallelBenchmark
     {
-        public static TimeSpan Run(Action<int> action, int threads)
+        public static TimeSpan Run(Action<int, IThroughputBenchConfig, ICache<long, int>> action, int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
             Task[] tasks = new Task[threads];
             ManualResetEventSlim mre = new ManualResetEventSlim();
 
-            Action<int> syncStart = taskId =>
+            Action<int, IThroughputBenchConfig, ICache<long, int>> syncStart = (taskId, config, cache) =>
             {
                 mre.Wait();
-                action(taskId);
+                action(taskId, config, cache);
             };
 
             for (int i = 0; i < tasks.Length; i++)
             {
                 int index = i;
-                tasks[i] = Task.Factory.StartNew(() => syncStart(index), TaskCreationOptions.LongRunning);
+                tasks[i] = Task.Factory.StartNew(() => syncStart(index, config, cache), TaskCreationOptions.LongRunning);
             }
 
             // try to mitigate spam from MemoryCache

--- a/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ParallelBenchmark.cs
@@ -7,12 +7,12 @@ namespace BitFaster.Caching.ThroughputAnalysis
 {
     public class ParallelBenchmark
     {
-        public static TimeSpan Run(Action<int, IThroughputBenchConfig, ICache<long, int>> action, int threads)
+        public static TimeSpan Run(Action<int> action, int threads)
         {
             Task[] tasks = new Task[threads];
             ManualResetEventSlim mre = new ManualResetEventSlim();
 
-            Action<int> syncStart = (taskId, config, cache) =>
+            Action<int> syncStart = (taskId) =>
             {
                 mre.Wait();
                 action(taskId);

--- a/BitFaster.Caching.ThroughputAnalysis/PowerPlan.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/PowerPlan.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace BitFaster.Caching.ThroughputAnalysis
+{
+    // Taken from BenchmarkDotNet here:
+    // https://github.com/dotnet/BenchmarkDotNet/blob/5557aee0638bda38001bd6c2000164d9b96d315a/src/BenchmarkDotNet/Running/PowerManagementApplier.cs#L45
+    // https://github.com/dotnet/BenchmarkDotNet/blob/5557aee0638bda38001bd6c2000164d9b96d315a/src/BenchmarkDotNet/Helpers/PowerManagementHelper.cs#L9
+    internal class PowerPlan
+    {
+        public static void EnableHighPerformance()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return;
+            }
+
+            var highPerformancePlanId = new Guid("8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c");
+
+            if (CurrentPlan != highPerformancePlanId)
+            {
+                Console.WriteLine($"Current power plan is {CurrentPlanFriendlyName}");
+
+                if (PowerSetActiveScheme(IntPtr.Zero, ref highPerformancePlanId) == 0)
+                {
+                    Console.WriteLine($"Switched to High Performance power plan.");
+                }
+            }
+            else
+            {
+                Console.WriteLine($"Current Windows power plan = {CurrentPlanFriendlyName}");
+            }
+        }
+
+        internal static Guid? CurrentPlan
+        {
+            get
+            {
+                IntPtr activeGuidPtr = IntPtr.Zero;
+                uint res = PowerGetActiveScheme(IntPtr.Zero, ref activeGuidPtr);
+                if (res != SuccessCode)
+                    return null;
+
+                return (Guid)Marshal.PtrToStructure(activeGuidPtr, typeof(Guid));
+            }
+        }
+
+        internal static string CurrentPlanFriendlyName
+        {
+            get
+            {
+                uint buffSize = 0;
+                StringBuilder buffer = new StringBuilder();
+                IntPtr activeGuidPtr = IntPtr.Zero;
+                uint res = PowerGetActiveScheme(IntPtr.Zero, ref activeGuidPtr);
+                if (res != SuccessCode)
+                    return null;
+                res = PowerReadFriendlyName(IntPtr.Zero, activeGuidPtr, IntPtr.Zero, IntPtr.Zero, buffer, ref buffSize);
+                if (res == ErrorMoreData)
+                {
+                    buffer.Capacity = (int)buffSize;
+                    res = PowerReadFriendlyName(IntPtr.Zero, activeGuidPtr,
+                        IntPtr.Zero, IntPtr.Zero, buffer, ref buffSize);
+                }
+                if (res != SuccessCode)
+                    return null;
+
+                return buffer.ToString();
+            }
+        }
+
+        private const uint ErrorMoreData = 234;
+        private const uint SuccessCode = 0;
+
+        [DllImport("powrprof.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+        private static extern uint PowerReadFriendlyName(IntPtr RootPowerKey, IntPtr SchemeGuid, IntPtr SubGroupOfPowerSettingGuid, IntPtr PowerSettingGuid, StringBuilder Buffer, ref uint BufferSize);
+
+        [DllImport("powrprof.dll", ExactSpelling = true)]
+        private static extern int PowerSetActiveScheme(IntPtr ReservedZero, ref Guid policyGuid);
+
+        [DllImport("powrprof.dll", ExactSpelling = true)]
+        private static extern uint PowerGetActiveScheme(IntPtr UserRootPowerKey, ref IntPtr ActivePolicyGuid);
+    }
+}

--- a/BitFaster.Caching.ThroughputAnalysis/Program.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Program.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Threading;
 using BitFaster.Caching.ThroughputAnalysis;
 
 Host.PrintInfo();
-
-int minWorker, minIOC;
-ThreadPool.GetMinThreads(out minWorker, out minIOC);
-ThreadPool.SetMinThreads(Environment.ProcessorCount*2, minIOC);
 
 var (mode, size) = CommandParser.Parse(args);
 

--- a/BitFaster.Caching.ThroughputAnalysis/Program.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Program.cs
@@ -2,6 +2,8 @@
 using BitFaster.Caching.ThroughputAnalysis;
 
 Host.PrintInfo();
+PowerPlan.EnableHighPerformance();
+Console.WriteLine();
 
 var (mode, size) = CommandParser.Parse(args);
 

--- a/BitFaster.Caching.ThroughputAnalysis/Program.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Program.cs
@@ -1,7 +1,12 @@
 ﻿using System;
+using System.Threading;
 using BitFaster.Caching.ThroughputAnalysis;
 
 Host.PrintInfo();
+
+int minWorker, minIOC;
+ThreadPool.GetMinThreads(out minWorker, out minIOC);
+ThreadPool.SetMinThreads(Environment.ProcessorCount*2, minIOC);
 
 var (mode, size) = CommandParser.Parse(args);
 

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -51,7 +51,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             foreach (int tc in Enumerable.Range(minThreads, maxThreads - (minThreads -1)).ToArray())
             {
                 const int warmup = 3;
-                const int runs = 15;
+                const int runs = 11;
 
                 UpdateTitle(mode, tc, minThreads, maxThreads);
 

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -48,18 +48,18 @@ namespace BitFaster.Caching.ThroughputAnalysis
             foreach (int tc in Enumerable.Range(1, maxThreads).ToArray())
             {
                 const int warmup = 3;
-                const int runs = 6;
+                const int runs = 15;
 
                 UpdateTitle(mode, tc, maxThreads);
 
                 foreach (var cacheConfig in cachesToTest)
                 {
                     var (sched, cache) = cacheConfig.Create(tc);
-                    double thru = bench.Run(warmup, runs, tc, dataConfig, cache);
+                    (int samples, double thru) = bench.Run(warmup, runs, tc, dataConfig, cache);
                     (sched as IDisposable)?.Dispose();
 
                     cacheConfig.DataRow[tc.ToString()] = thru.ToString();
-                    Console.WriteLine($"{cacheConfig.Name.PadRight(18)} ({tc:00}) {Format.Throughput(thru)} million ops/sec");
+                    Console.WriteLine($"{cacheConfig.Name.PadRight(18)} ({tc:00}) {Format.Throughput(thru)} million ops/sec, {samples:00} samples");
                 }
             }
 

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -46,7 +46,9 @@ namespace BitFaster.Caching.ThroughputAnalysis
             Console.WriteLine($"Running {mode} with size {capacity} over {maxThreads} threads...");
             Console.WriteLine();
 
-            foreach (int tc in Enumerable.Range(1, maxThreads).ToArray())
+            int minThreads = 5;
+
+            foreach (int tc in Enumerable.Range(5, maxThreads - minThreads).ToArray())
             {
                 const int warmup = 3;
                 const int runs = 15;

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -48,7 +48,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             Console.WriteLine($"Running {mode} with size {capacity} over {maxThreads} threads...");
             Console.WriteLine();
 
-            foreach (int tc in Enumerable.Range(minThreads, maxThreads - minThreads).ToArray())
+            foreach (int tc in Enumerable.Range(minThreads, maxThreads - (minThreads -1)).ToArray())
             {
                 const int warmup = 3;
                 const int runs = 15;

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Microsoft.FSharp.Core.CompilerServices;
 
 namespace BitFaster.Caching.ThroughputAnalysis
 {
@@ -39,21 +40,20 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 new ConcurrentLfuFactory(capacity)
             };
 
-            var exporter = new Exporter(maxThreads);
+            int minThreads = 1;
+            var exporter = new Exporter(minThreads, maxThreads);
             exporter.Initialize(cachesToTest);
 
             Console.WriteLine();
             Console.WriteLine($"Running {mode} with size {capacity} over {maxThreads} threads...");
             Console.WriteLine();
 
-            int minThreads = 5;
-
-            foreach (int tc in Enumerable.Range(5, maxThreads - minThreads).ToArray())
+            foreach (int tc in Enumerable.Range(minThreads, maxThreads - minThreads).ToArray())
             {
                 const int warmup = 3;
                 const int runs = 15;
 
-                UpdateTitle(mode, tc, maxThreads);
+                UpdateTitle(mode, tc, minThreads, maxThreads);
 
                 foreach (var cacheConfig in cachesToTest)
                 {
@@ -80,7 +80,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             //    .Write(Format.MarkDown);
         }
 
-        private static void UpdateTitle(Mode mode, int tc, int maxTc)
+        private static void UpdateTitle(Mode mode, int tc, int minTc, int maxTc)
         {
             Console.Title = $"{mode} {tc}/{maxTc}";
         }

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 
@@ -55,11 +56,14 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 foreach (var cacheConfig in cachesToTest)
                 {
                     var (sched, cache) = cacheConfig.Create(tc);
+
+                    var sw = Stopwatch.StartNew();
                     (int samples, double thru) = bench.Run(warmup, runs, tc, dataConfig, cache);
+                    var e = sw.Elapsed;
                     (sched as IDisposable)?.Dispose();
 
                     cacheConfig.DataRow[tc.ToString()] = thru.ToString();
-                    Console.WriteLine($"{cacheConfig.Name.PadRight(18)} ({tc:00}) {Format.Throughput(thru)} million ops/sec, {samples:00} samples");
+                    Console.WriteLine($"{cacheConfig.Name.PadRight(18)} ({tc:00}) {Format.Throughput(thru)} million ops/sec, {samples:00} samples in {e.TotalSeconds:0.0}secs");
                 }
             }
 

--- a/BitFaster.Caching.ThroughputAnalysis/Runner.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Runner.cs
@@ -59,7 +59,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     (sched as IDisposable)?.Dispose();
 
                     cacheConfig.DataRow[tc.ToString()] = thru.ToString();
-                    Console.WriteLine($"{cacheConfig.Name.PadRight(18)} ({tc:00}) {FormatThroughput(thru)} million ops/sec");
+                    Console.WriteLine($"{cacheConfig.Name.PadRight(18)} ({tc:00}) {Format.Throughput(thru)} million ops/sec");
                 }
             }
 
@@ -72,13 +72,6 @@ namespace BitFaster.Caching.ThroughputAnalysis
             //    .From(resultTable)
             //    .Configure(o => o.NumberAlignment = Alignment.Right)
             //    .Write(Format.MarkDown);
-        }
-
-        private static string FormatThroughput(double thru)
-        {
-            string dformat = "0.00;-0.00";
-            string raw = thru.ToString(dformat);
-            return raw.PadLeft(7, ' ');
         }
 
         private static void UpdateTitle(Mode mode, int tc, int maxTc)

--- a/BitFaster.Caching.ThroughputAnalysis/Stage.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/Stage.cs
@@ -1,0 +1,9 @@
+﻿namespace BitFaster.Caching.ThroughputAnalysis
+{
+    public enum Stage
+    {
+        Warmup,
+        Pilot,
+        Workload,
+    }
+}

--- a/BitFaster.Caching.ThroughputAnalysis/ThreadPoolInspector.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThreadPoolInspector.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+
+namespace BitFaster.Caching.ThroughputAnalysis
+{
+    internal class ThreadPoolInspector
+    {
+        public static void WaitForEmpty()
+        {
+            int count = 0;
+            while (ThreadPool.PendingWorkItemCount > 0) 
+            {
+                Thread.Yield();
+                Thread.Sleep(1);
+
+                if (count++ > 10)
+                {
+                    Console.WriteLine("Waiting for thread pool to flush...");
+                }
+            }
+        }
+    }
+}

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchConfig.cs
@@ -6,7 +6,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 {
     public interface IThroughputBenchConfig
     {
-        int Iterations { get; }
+        int Iterations { get; set; }
 
         int Samples { get; }
 
@@ -15,17 +15,15 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class ZipfConfig : IThroughputBenchConfig
     {
-        private readonly int iterations;
+        private int iterations;
         private readonly long[] samples;
 
-        public ZipfConfig(int iterations, int sampleCount, double s, int n)
+        public ZipfConfig(int sampleCount, double s, int n)
         {
-            this.iterations = iterations;
-
             samples = FastZipf.Generate(sampleCount, s, n);
         }
 
-        public int Iterations => iterations;
+        public int Iterations { get => iterations; set => iterations = value; }
 
         public int Samples => samples.Length;
 
@@ -37,20 +35,19 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class EvictionConfig : IThroughputBenchConfig
     {
-        private readonly int iterations;
+        private int iterations;
 
         private readonly long[][] samples;
 
         const int maxSamples = 10_000_000;
 
-        public EvictionConfig(int iterations, int sampleCount, int threadCount)
+        public EvictionConfig(int sampleCount, int threadCount)
         {
             if (sampleCount > maxSamples)
             {
                 throw new ArgumentOutOfRangeException(nameof(sampleCount), "Sample count too large, will result in overlap");
             }
 
-            this.iterations = iterations;
             samples = new long[threadCount][];
 
             Parallel.ForEach(Enumerable.Range(0, threadCount), i =>
@@ -59,7 +56,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             });
         }
 
-        public int Iterations => iterations;
+        public int Iterations { get => iterations; set => iterations = value; }
 
         public int Samples => samples[0].Length;
 

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -96,8 +96,6 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 long[] samples = config.GetTestData(index);
                 int func(long x) => (int)x;
 
-                bool yield = index % Environment.ProcessorCount == 0 && threads > 1;
-
                 for (int i = 0; i < config.Iterations; i++)
                 {
                     for (int s = 0; s < samples.Length; s++)

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Perfolizer.Mathematics.OutlierDetection;
 
 namespace BitFaster.Caching.ThroughputAnalysis
 {
@@ -20,23 +22,50 @@ namespace BitFaster.Caching.ThroughputAnalysis
     {
         public Action<ICache<long, int>> Initialize { get; set; }
 
+        // https://github.com/dotnet/BenchmarkDotNet/blob/b4ac9df9f7890ca9669e2b9c8835af35c072a453/src/BenchmarkDotNet/Engines/EngineGeneralStage.cs#L18
         public double Run(int warmup, int runs, int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
-            double[] results = new double[warmup + runs];
+            var results = new List<double>();
 
             Initialize?.Invoke(cache);
 
-            for (int i = 0; i < warmup + runs; i++)
+            for (int i = 0; i < warmup; i++)
             {
-                results[i] = Run(threads, config, cache);
+                Run(i, threads, config, cache);
             }
+
+            int iterationCounter = 0;
+            double effectiveMaxRelativeError = 0.04; // https://github.com/dotnet/BenchmarkDotNet/blob/b4ac9df9f7890ca9669e2b9c8835af35c072a453/src/BenchmarkDotNet/Jobs/AccuracyMode.cs#L11
+
+            OutlierMode outlierMode = OutlierMode.RemoveUpper;
+            int maxIters = 25;
+
+            while (true)
+            {
+                iterationCounter++;
+                results.Add(Run(iterationCounter, threads, config, cache));
+                var statistics = MeasurementsStatistics.Calculate(results, outlierMode);
+                double actualError = statistics.ConfidenceInterval.Margin;
+
+                double maxError1 = effectiveMaxRelativeError * statistics.Mean;
+                double maxError2 = double.MaxValue;
+                double maxError = Math.Min(maxError1, maxError2);
+
+                if (iterationCounter >= runs && actualError < maxError)
+                    break;
+
+                if (iterationCounter >= maxIters)
+                    break;
+            }
+
+            var finalStats = MeasurementsStatistics.Calculate(results, outlierMode);
 
             // return million ops/sec
             const int oneMillion = 1_000_000;
-            return AverageLast(results, runs) / oneMillion;
+            return finalStats.Mean / oneMillion;
         }
 
-        protected abstract double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache);
+        protected abstract double Run(int iter, int threads, IThroughputBenchConfig config, ICache<long, int> cache);
 
         private static double AverageLast(double[] results, int count)
         {
@@ -52,7 +81,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
 
     public class ReadThroughputBenchmark : ThroughputBenchmarkBase
     {
-        protected override double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache)
+        protected override double Run(int iter,int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
             [MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
             void action(int index)
@@ -72,13 +101,29 @@ namespace BitFaster.Caching.ThroughputAnalysis
             var time = ParallelBenchmark.Run(action, threads);
 
             // throughput = ops/sec
-            return (threads * config.Samples * config.Iterations) / time.TotalSeconds;
+            var throughput = (threads * config.Samples * config.Iterations) / time.TotalSeconds;
+
+       //     if (throughput / 1_000_000 > 500)
+            {
+             //   Console.WriteLine($"{iter} {FormatThroughput(throughput / 1_000_000.0)} ops/sec");
+
+            }
+
+            return throughput;
+        }
+
+        private static string FormatThroughput(double thru)
+        {
+            string dformat = "0.00;-0.00";
+            string raw = thru.ToString(dformat);
+            return raw.PadLeft(7, ' ');
         }
     }
 
+
     public class UpdateThroughputBenchmark : ThroughputBenchmarkBase
     {
-        protected override double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache)
+        protected override double Run(int iter,int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
             [MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
             void action(int index)

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using Perfolizer.Mathematics.OutlierDetection;
 
 namespace BitFaster.Caching.ThroughputAnalysis
@@ -105,12 +104,6 @@ namespace BitFaster.Caching.ThroughputAnalysis
                     {
                         DeadCodeEliminationHelper.KeepAliveWithoutBoxing(cache.GetOrAdd(samples[s], func));
                     }
-
-                    // try to allow memory cache eviction thread to run
-                    //if (yield)
-                    //{
-                    //    Thread.Yield();
-                    //}
                 }
             }
 

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -66,17 +66,6 @@ namespace BitFaster.Caching.ThroughputAnalysis
         }
 
         protected abstract double Run(int iter, int threads, IThroughputBenchConfig config, ICache<long, int> cache);
-
-        private static double AverageLast(double[] results, int count)
-        {
-            double result = 0;
-            for (int i = results.Length - count; i < results.Length; i++)
-            {
-                result += results[i];
-            }
-
-            return result / count;
-        }
     }
 
     public class ReadThroughputBenchmark : ThroughputBenchmarkBase
@@ -99,27 +88,17 @@ namespace BitFaster.Caching.ThroughputAnalysis
             }
 
             var time = ParallelBenchmark.Run(action, threads);
-
-            // throughput = ops/sec
             var throughput = (threads * config.Samples * config.Iterations) / time.TotalSeconds;
-
-       //     if (throughput / 1_000_000 > 500)
+            if (false)
             {
-             //   Console.WriteLine($"{iter} {FormatThroughput(throughput / 1_000_000.0)} ops/sec");
-
+#pragma warning disable CS0162 // Unreachable code detected
+                Console.WriteLine($"{iter} {Format.Throughput(throughput / 1_000_000.0)} ops/sec");
+#pragma warning restore CS0162 // Unreachable code detected
             }
 
             return throughput;
         }
-
-        private static string FormatThroughput(double thru)
-        {
-            string dformat = "0.00;-0.00";
-            string raw = thru.ToString(dformat);
-            return raw.PadLeft(7, ' ');
-        }
     }
-
 
     public class UpdateThroughputBenchmark : ThroughputBenchmarkBase
     {

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -55,7 +55,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
         protected override double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
             [MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
-            static void action(int index, IThroughputBenchConfig config, ICache<long, int> cache)
+            void action(int index)
             {
                 long[] samples = config.GetTestData(index);
                 int func(long x) => (int)x;
@@ -69,7 +69,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 }
             }
 
-            var time = ParallelBenchmark.Run(action, threads, config, cache);
+            var time = ParallelBenchmark.Run(action, threads);
 
             // throughput = ops/sec
             return (threads * config.Samples * config.Iterations) / time.TotalSeconds;
@@ -81,7 +81,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
         protected override double Run(int threads, IThroughputBenchConfig config, ICache<long, int> cache)
         {
             [MethodImpl(BenchmarkDotNet.Portability.CodeGenHelper.AggressiveOptimizationOption)]
-            static void action(int index, IThroughputBenchConfig config, ICache<long, int> cache)
+            void action(int index)
             {
                 long[] samples = config.GetTestData(index);
 
@@ -94,7 +94,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 }
             }
 
-            var time = ParallelBenchmark.Run(action, threads, config, cache);
+            var time = ParallelBenchmark.Run(action, threads);
 
             // throughput = ops/sec
             return (threads * config.Samples * config.Iterations) / time.TotalSeconds;

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -46,7 +46,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 var sw = Stopwatch.StartNew();
                 Run(Stage.Pilot, 0, threads, config, cache);
 
-                valid = sw.Elapsed > TimeSpan.FromMilliseconds(200) ? valid + 1 : 0;    
+                valid = sw.Elapsed > TimeSpan.FromMilliseconds(400) ? valid + 1 : 0;    
 
                 if (valid > 3)
                 {
@@ -59,7 +59,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             int runCounter = 0;
             double effectiveMaxRelativeError = 0.02; // https://github.com/dotnet/BenchmarkDotNet/blob/b4ac9df9f7890ca9669e2b9c8835af35c072a453/src/BenchmarkDotNet/Jobs/AccuracyMode.cs#L11
 
-            OutlierMode outlierMode = OutlierMode.RemoveUpper;
+            OutlierMode outlierMode = OutlierMode.RemoveLower;
             int maxRuns = 80;
 
             while (true)

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -318,6 +318,7 @@ namespace BitFaster.Caching.Lru
         {
             if (this.dictionary.TryGetValue(key, out var node))
             {
+                LockAndMoveToEnd(node);
                 node.Value.Value = value;
                 Interlocked.Increment(ref this.metrics.updatedCount);
                 return true;
@@ -333,6 +334,7 @@ namespace BitFaster.Caching.Lru
             // first, try to update
             if (this.dictionary.TryGetValue(key, out var existingNode))
             {
+                LockAndMoveToEnd(existingNode);
                 existingNode.Value.Value = value;
                 Interlocked.Increment(ref this.metrics.updatedCount);
                 return;


### PR DESCRIPTION
- Use BenchmarkDotNet's method to keep return values alive, mitigating dead code elimination for the return value from cache GetOrAdd. This reduces peak throughput by about 10%, likely due to the extra non-inlined method.
- Apply optimization option to test execution method.
- Use Threads instead of Tasks. This is more stable, but MemoryCache results now have more extreme outliers due to unpredictable nature of background thread eviction.
- Replicate the BenchmarkDotNet main loop to determine when the result is stable, based on computing statistics from the results so far.
- Use Perfolizer to eliminate outliers from the result calculation - this eliminates some of the outliers from MemoryCache when the eviction thread is not scheduled. The update and evict scenarios provoke unbounded growth/failure to evict for MemoryCache due to threadpool backlog.
- Adapt the number of iterations in each run so that a run is approximately 200ms. This gives a worst-case scenario time of about 35 secs, so an entire test run can complete on a 96 core machine in less than 1 day.
- Wait for the thread pool to empty before each run. This flushes out any backlog that MemoryCache has built up, making results more consistent.


---

Results for adaptive mode:

| Min iters | Max iters | Max Relative Error | Target Iteration time |
|-----------|-----------|----------------------|-----------------------|
| 15   | 80  | 0.02 | 200ms |

![Results_Read_500](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/4f946120-e1b7-4e1f-b70a-bc63e5536961)

![Results_ReadWrite_500](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/8cc4717a-a03d-4772-868e-3bd1ba8b1d2b)

![Results_Update_500](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/d49ea16d-491e-40c3-bf4d-6fb9693c3d86)

![Results_Evict_500](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/6dc76492-6f3e-4316-88b2-73991b92ca6d)
