### PR TITLE
Extract ConcurrentLfuCore with generic node and policy

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -310,7 +310,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
         private static void RunIntegrityCheck<K,V>(ConcurrentLfu<K,V> cache, ITestOutputHelper output)
         {
-            new ConcurrentLfuIntegrityChecker<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>>(cache).Validate(output);
+            new ConcurrentLfuIntegrityChecker<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>>(cache.Core).Validate(output);
         }
     }
 
@@ -318,7 +318,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         where N : LfuNode<K, V>
         where P : struct, INodePolicy<K, V, N>
     {
-        private readonly ConcurrentLfu<K, V> cache;
+        private readonly ConcurrentLfuCore<K, V, N, P> cache;
 
         private readonly LfuNodeList<K, V> windowLru;
         private readonly LfuNodeList<K, V> probationLru;
@@ -334,7 +334,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private static FieldInfo readBufferField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("readBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
         private static FieldInfo writeBufferField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("writeBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        public ConcurrentLfuIntegrityChecker(ConcurrentLfu<K, V> cache)
+        public ConcurrentLfuIntegrityChecker(ConcurrentLfuCore<K, V, N, P> cache)
         {
             this.cache = cache;
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -307,7 +307,6 @@ namespace BitFaster.Caching.UnitTests.Lfu
             RunIntegrityCheck(lfu, this.output);
         }
 
-
         private static void RunIntegrityCheck<K,V>(ConcurrentLfu<K,V> cache, ITestOutputHelper output)
         {
             new ConcurrentLfuIntegrityChecker<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>>(cache.Core).Validate(output);

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -572,7 +572,11 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.GetOrAdd(1, k => k + 1);
             cache.GetOrAdd(2, k => k + 1);
 
-            cache.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 2), new KeyValuePair<int, int>(2, 3) });
+            var enumerator = cache.GetEnumerator();
+            enumerator.MoveNext().Should().BeTrue();
+            enumerator.Current.Should().Be(new KeyValuePair<int, int>(1, 2));
+            enumerator.MoveNext().Should().BeTrue();
+            enumerator.Current.Should().Be(new KeyValuePair<int, int>(2, 3));
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -27,6 +27,30 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
+        public void WhenCapacityIsLessThan3CtorThrows()
+        {
+            Action constructor = () => { var x = new ConcurrentLfu<int, string>(2); };
+
+            constructor.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
+        public void WhenCapacityIsValidCacheIsCreated()
+        {
+            var x = new ConcurrentLfu<int, string>(3);
+
+            x.Capacity.Should().Be(3);
+        }
+
+        [Fact]
+        public void WhenConcurrencyIsLessThan1CtorThrows()
+        {
+            Action constructor = () => { var x = new ConcurrentLfu<int, string>(0, 20, new ForegroundScheduler(), EqualityComparer<int>.Default); };
+
+            constructor.Should().Throw<ArgumentOutOfRangeException>();
+        }
+
+        [Fact]
         public void DefaultSchedulerIsThreadPool()
         {
             var cache = new ConcurrentLfu<int, int>(20);

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using BitFaster.Caching.UnitTests.Lru;
@@ -572,7 +570,11 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.GetOrAdd(1, k => k + 1);
             cache.GetOrAdd(2, k => k + 1);
 
-            cache.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 2), new KeyValuePair<int, int>(2, 3) });
+            var enumerator = cache.GetEnumerator();
+            enumerator.MoveNext().Should().BeTrue();
+            enumerator.Current.Should().Be(new KeyValuePair<int, int>(1, 2));
+            enumerator.MoveNext().Should().BeTrue();
+            enumerator.Current.Should().Be(new KeyValuePair<int, int>(2, 3));
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using BitFaster.Caching.UnitTests.Lru;
@@ -570,11 +572,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.GetOrAdd(1, k => k + 1);
             cache.GetOrAdd(2, k => k + 1);
 
-            var enumerator = cache.GetEnumerator();
-            enumerator.MoveNext().Should().BeTrue();
-            enumerator.Current.Should().Be(new KeyValuePair<int, int>(1, 2));
-            enumerator.MoveNext().Should().BeTrue();
-            enumerator.Current.Should().Be(new KeyValuePair<int, int>(2, 3));
+            cache.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 2), new KeyValuePair<int, int>(2, 3) });
         }
 
         [Fact]

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Authors>Alex Peck</Authors>
     <Company />
     <Product>BitFaster.Caching</Product>

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Authors>Alex Peck</Authors>
     <Company />
     <Product>BitFaster.Caching</Product>

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -128,12 +128,6 @@ namespace BitFaster.Caching.Lfu
         }
 
         ///<inheritdoc/>
-        public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
-        {
-            return core.GetEnumerator();
-        }
-
-        ///<inheritdoc/>
         public V GetOrAdd(K key, Func<K, V> valueFactory)
         {
             return core.GetOrAdd(key, valueFactory);
@@ -203,9 +197,15 @@ namespace BitFaster.Caching.Lfu
         }
 
         ///<inheritdoc/>
+        public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+        {
+            return core.GetEnumerator();
+        }
+
+        ///<inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>>)core).GetEnumerator();
+            return core.GetEnumerator();
         }
 
 #if DEBUG
@@ -276,7 +276,7 @@ namespace BitFaster.Caching.Lfu
     /// Based on the Caffeine library by ben.manes@gmail.com (Ben Manes).
     /// https://github.com/ben-manes/caffeine
     
-    internal struct ConcurrentLfuCore<K, V, N, P> : ICache<K, V>, IAsyncCache<K, V>, IBoundedPolicy
+    internal struct ConcurrentLfuCore<K, V, N, P> : IBoundedPolicy
         where N : LfuNode<K, V>
         where P : struct, INodePolicy<K, V, N>
     {
@@ -660,11 +660,6 @@ namespace BitFaster.Caching.Lfu
                 }
                 spinner.SpinOnce();
             }
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((ConcurrentLfuCore<K, V, N, P>)this).GetEnumerator();
         }
 
         private void TryScheduleDrain()

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -53,6 +53,8 @@ namespace BitFaster.Caching.Lfu
             this.core = new (concurrencyLevel, capacity, scheduler, comparer);
         }
 
+        internal ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>> Core => core;
+
         ///<inheritdoc/>
         public int Count => core.Count;
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -309,6 +309,9 @@ namespace BitFaster.Caching.Lfu
 
         public ConcurrentLfuCore(int concurrencyLevel, int capacity, IScheduler scheduler, IEqualityComparer<K> comparer, Action drainBuffers)
         {
+            if (capacity < 3)
+                Throw.ArgOutOfRange(nameof(capacity));
+
             int dictionaryCapacity = ConcurrentDictionarySize.Estimate(capacity);
             this.dictionary = new (concurrencyLevel, dictionaryCapacity, comparer);
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -1026,8 +1026,8 @@ namespace BitFaster.Caching.Lfu
                 {
                     Idle => !delayable,
                     Required => true,
-                    ProcessingToIdle or ProcessingToRequired => false,
-                    _ => false,// not reachable
+                    // ProcessingToIdle or ProcessingToRequired => false, undefined not reachable
+                    _ => false,
                 };
             }
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -205,7 +205,7 @@ namespace BitFaster.Caching.Lfu
         ///<inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return core.GetEnumerator();
+            return ((ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>>)core).GetEnumerator();
         }
 
 #if DEBUG

--- a/BitFaster.Caching/Lfu/LfuNode.cs
+++ b/BitFaster.Caching/Lfu/LfuNode.cs
@@ -1,6 +1,6 @@
 ﻿namespace BitFaster.Caching.Lfu
 {
-    internal sealed class LfuNode<K, V>
+    internal class LfuNode<K, V>
     {
         internal LfuNodeList<K, V> list;
         internal LfuNode<K, V> next;
@@ -56,5 +56,12 @@
         Window,
         Probation,
         Protected,
+    }
+
+    internal sealed class AccessOrderNode<K, V> : LfuNode<K, V>
+    {
+        public AccessOrderNode(K k, V v) : base(k, v)
+        {
+        }
     }
 }

--- a/BitFaster.Caching/Lfu/NodePolicy.cs
+++ b/BitFaster.Caching/Lfu/NodePolicy.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace BitFaster.Caching.Lfu
+{
+    internal interface INodePolicy<K, V, N>
+        where N : LfuNode<K, V>
+    {
+        N Create(K key, V value);
+    }
+
+    internal struct AccessOrderPolicy<K, V> : INodePolicy<K, V, AccessOrderNode<K, V>>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public AccessOrderNode<K, V> Create(K key, V value)
+        {
+            return new AccessOrderNode<K, V>(key, value);
+        }
+    }
+}


### PR DESCRIPTION
To prepare for time-based expiry in https://github.com/bitfaster/BitFaster.Caching/pull/516, add the extension points for different node type and policy.

Considerations:
- Keep implementation details internal, only expose ConcurrentLfu
- Since LfuNode is used extensively in arrays (buffers), ensure the array type is sealed to avoid array covariance check on write.
- Preserve existing perf without any regression. Options are:
   - Make ConcurrentLfuCore a base class similar to ConcurrentLruCore core. This means that all types involved in the inheritance chain must be public, and the consumer sees all the messy generics.
   - Make ConcurrentLfuCore a class as a data member of ConcurrentLfu. This introduces another method call that appears to incur overhead even when inlnied.
   - Make ConcurrentLfuCore a mutable struct as a data member of ConcurrentLfu, so it is effectively embedded inside ConcurrentLfu. This means more weird tricks, but keeps a clean API for the consumer with all details internal. Later it can be switched to a more conventional approach if needed. This way it is possible to preserve perf and hide details.

# Baseline

| Method                  | Runtime            | Mean      | Error     | Ratio |
|------------------------ |------------------- |----------:|----------:|------:|
| ConcurrentDictionary    | .NET 6.0           |  7.408 ns | 0.0840 ns |  1.00 |
| ConcurrentLfuBackground | .NET 6.0           | 25.191 ns | 0.4176 ns |  3.40 |
| ConcurrentLfuForeround  | .NET 6.0           | 54.582 ns | 0.1453 ns |  7.37 |
| ConcurrentLfuThreadPool | .NET 6.0           | 52.433 ns | 1.0606 ns |  7.08 |
| ConcurrentLfuNull       | .NET 6.0           | 22.916 ns | 0.0724 ns |  3.09 |
|                         |                    |           |           |       |
| ConcurrentDictionary    | .NET Framework 4.8 | 13.660 ns | 0.1253 ns |  1.00 |
| ConcurrentLfuBackground | .NET Framework 4.8 | 53.615 ns | 0.7679 ns |  3.92 |
| ConcurrentLfuForeround  | .NET Framework 4.8 | 85.688 ns | 0.4863 ns |  6.27 |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 53.179 ns | 0.6894 ns |  3.91 |
| ConcurrentLfuNull       | .NET Framework 4.8 | 34.872 ns | 0.0943 ns |  2.56 |


# Composition, class with inlined method:

| Method                  | Runtime            | Mean      | Error     | Ratio |
|------------------------ |------------------- |----------:|----------:|------:|
| ConcurrentDictionary    | .NET 6.0           |  7.674 ns | 0.1271 ns |  1.00 |
| ConcurrentLfuBackground | .NET 6.0           | 27.493 ns | 0.5544 ns |  3.56 |
| ConcurrentLfuForeround  | .NET 6.0           | 56.669 ns | 0.2408 ns |  7.38 |
| ConcurrentLfuThreadPool | .NET 6.0           | 56.861 ns | 1.0975 ns |  7.46 |
| ConcurrentLfuNull       | .NET 6.0           | 24.793 ns | 0.1747 ns |  3.23 |
|                         |                    |           |           |       |
| ConcurrentDictionary    | .NET Framework 4.8 | 14.160 ns | 0.0499 ns |  1.00 |
| ConcurrentLfuBackground | .NET Framework 4.8 | 57.114 ns | 0.5622 ns |  4.03 |
| ConcurrentLfuForeround  | .NET Framework 4.8 | 91.424 ns | 0.2424 ns |  6.46 |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 41.091 ns | 0.5140 ns |  2.90 |
| ConcurrentLfuNull       | .NET Framework 4.8 | 36.338 ns | 0.3480 ns |  2.57 |

# Composition, struct:

| Method                  | Runtime            | Mean      | Error     | Ratio |
|------------------------ |------------------- |----------:|----------:|------:|
| ConcurrentDictionary    | .NET 6.0           |  7.425 ns | 0.0346 ns |  1.00 |
| ConcurrentLfuBackground | .NET 6.0           | 25.875 ns | 0.5423 ns |  3.48 |
| ConcurrentLfuForeround  | .NET 6.0           | 55.217 ns | 0.1233 ns |  7.44 |
| ConcurrentLfuThreadPool | .NET 6.0           | 46.655 ns | 0.9456 ns |  6.23 |
| ConcurrentLfuNull       | .NET 6.0           | 24.009 ns | 0.1620 ns |  3.23 |
|                         |                    |           |           |       |
| ConcurrentDictionary    | .NET Framework 4.8 | 13.654 ns | 0.0517 ns |  1.00 |
| ConcurrentLfuBackground | .NET Framework 4.8 | 53.155 ns | 0.6734 ns |  3.89 |
| ConcurrentLfuForeround  | .NET Framework 4.8 | 91.844 ns | 0.8469 ns |  6.73 |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 55.283 ns | 1.1236 ns |  4.13 |
| ConcurrentLfuNull       | .NET Framework 4.8 | 36.005 ns | 0.4577 ns |  2.64 |


| Method                  | Runtime            | Mean      | Error     | StdDev    | Ratio | Allocated |
|------------------------ |------------------- |----------:|----------:|----------:|------:|----------:|
| ConcurrentDictionary    | .NET 6.0           |  7.946 ns | 0.0697 ns | 0.0652 ns |  1.00 |         - |
| ConcurrentLfuBackground | .NET 6.0           | 24.142 ns | 0.5005 ns | 0.4915 ns |  3.04 |         - |
| ConcurrentLfuForeround  | .NET 6.0           | 55.121 ns | 0.2244 ns | 0.1989 ns |  6.94 |         - |
| ConcurrentLfuThreadPool | .NET 6.0           | 47.264 ns | 0.3649 ns | 0.3413 ns |  5.95 |         - |
| ConcurrentLfuNull       | .NET 6.0           | 23.108 ns | 0.0716 ns | 0.0670 ns |  2.91 |         - |
|                         |                    |           |           |           |       |           |
| ConcurrentDictionary    | .NET Framework 4.8 | 13.624 ns | 0.1048 ns | 0.0929 ns |  1.00 |         - |
| ConcurrentLfuBackground | .NET Framework 4.8 | 53.769 ns | 0.9205 ns | 0.8610 ns |  3.95 |         - |
| ConcurrentLfuForeround  | .NET Framework 4.8 | 90.028 ns | 0.5291 ns | 0.4418 ns |  6.61 |         - |
| ConcurrentLfuThreadPool | .NET Framework 4.8 | 54.531 ns | 1.1134 ns | 2.0637 ns |  4.17 |         - |
| ConcurrentLfuNull       | .NET Framework 4.8 | 37.841 ns | 0.1223 ns | 0.1144 ns |  2.78 |         - |