### PR TITLE
Clear buffers under lock

### DIFF
--- a/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
+++ b/BitFaster.Caching/Buffers/MpscBoundedBuffer.cs
@@ -254,6 +254,9 @@ namespace BitFaster.Caching.Buffers
         /// <summary>
         /// Removes all values from the buffer.
         /// </summary>
+        /// <remarks>
+        /// Clear must be called from the single consumer thread.
+        /// </remarks>
         public void Clear()
         {
             while (TryTake(out _) != BufferStatus.Empty)

--- a/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
+++ b/BitFaster.Caching/Buffers/StripedMpscBuffer.cs
@@ -123,7 +123,7 @@ namespace BitFaster.Caching.Buffers
         /// Removes all values from the buffer.
         /// </summary>
         /// <remarks>
-        /// Not thread safe.
+        /// Clear must be called from the single consumer thread.
         /// </remarks>
         public void Clear()
         {

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -137,11 +137,10 @@ namespace BitFaster.Caching.Lfu
         {
             this.Trim(this.Count);
 
-            this.readBuffer.Clear();
-            this.writeBuffer.Clear();
-
             lock (maintenanceLock)
             {
+                this.readBuffer.Clear();
+                this.writeBuffer.Clear();
                 this.cmSketch.Clear();
             }
         }


### PR DESCRIPTION
The read and write buffer are both mp-sc (single consumer) - it is only valid for 1 thread to deque. Prior change switched from `Clear` allocating a new buffer to `TryTake` until empty. 

Clearing the buffers must be protected by the maintenance lock, otherwise two threads can effectively dequeue - this situation is provoked by a test causing the build to hang intermittently.