### PR TITLE
Fix race in LFU maintenance for add-remove-add of the same key

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
     [Collection("Soak")]
     public class ConcurrentLfuSoakTests
     {
-        private const int soakIterations = 100;
+        private const int soakIterations = 10;
         private const int threads = 4;
         private const int loopIterations = 100_000;
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
     [Collection("Soak")]
     public class ConcurrentLfuSoakTests
     {
-        private const int soakIterations = 10;
+        private const int soakIterations = 100;
         private const int threads = 4;
         private const int loopIterations = 100_000;
 
@@ -376,14 +376,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 node.WasRemoved.Should().BeFalse();
                 node.WasDeleted.Should().BeFalse();
 
-                // This can occur if there is a race between:
-                // Thread 1: TryRemove, delete node from dictionary, set WasRemoved flag
-                // Thread 2: Check WasRemoved flag, if not add to lru
-                // It's not clear how WasRemoved can be false in this situation.
-                if (!cache.TryGet(node.Key, out _))
-                {
-                    output.WriteLine($"Orphaned node with key {node.Key} detected.");
-                }
+                cache.TryGet(node.Key, out _).Should().BeTrue($"Orphaned node with key {node.Key} detected.");
 
                 node = node.Next;
             }

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -701,13 +701,17 @@ namespace BitFaster.Caching.Lfu
 
                 if (candidate.node.WasRemoved)
                 {
-                    Evict(candidate.node);
+                    var evictee = candidate.node;
+                    candidate.Next();
+                    Evict(evictee);
                     continue;
                 }
 
                 if (victim.node.WasRemoved)
                 {
-                    Evict(victim.node);
+                    var evictee = victim.node;
+                    victim.Next();
+                    Evict(evictee);
                     continue;
                 }
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -602,11 +602,11 @@ namespace BitFaster.Caching.Lfu
 
         private void PromoteProbation(LfuNode<K, V> node)
         {
-            if (node.list == null)
-            {
-                // Ignore stale accesses for an entry that is no longer present
-                return;
-            }
+            //if (node.list == null)
+            //{
+            //    // Ignore stale accesses for an entry that is no longer present
+            //    return;
+            //}
 
             this.probationLru.Remove(node);
             this.protectedLru.AddLast(node);

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -131,7 +131,7 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
-        public void Clear()
+        public void Clear2()
         {
             int lruCount = 0;
             lock (maintenanceLock)
@@ -149,23 +149,24 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        public void Clear()
+        {
+            Trim(int.MaxValue);
+        }
+
         public void Trim(int itemCount)
         {
-            int lruCount = 0;
+            List<LfuNode<K, V>> candidates;
             lock (maintenanceLock)
             {
-                lruCount = this.windowLru.Count + this.probationLru.Count + this.protectedLru.Count;
-            }
-
-            itemCount = Math.Min(itemCount, lruCount);
-            var candidates = new List<LfuNode<K, V>>(itemCount);
-
-            // TODO: this is LRU order eviction, Caffeine is based on frequency
-            lock (maintenanceLock)
-            {
-                // flush all buffers
                 Maintenance();
 
+                int lruCount = this.windowLru.Count + this.probationLru.Count + this.protectedLru.Count;
+
+                itemCount = Math.Min(itemCount, lruCount);
+                candidates = new (itemCount);
+
+                // Note: this is LRU order eviction, Caffeine is based on frequency
                 // walk in lru order, get itemCount keys to evict
                 TakeCandidatesInLruOrder(this.probationLru, candidates, itemCount);
                 TakeCandidatesInLruOrder(this.protectedLru, candidates, itemCount);

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -765,7 +765,7 @@ namespace BitFaster.Caching.Lfu
             evictee.WasDeleted = true;
 
             this.dictionary.TryRemove(evictee.Key, out var _);
-            evictee.list.Remove(evictee);
+            evictee.list?.Remove(evictee);
             Disposer<V>.Dispose(evictee.Value);
             this.metrics.evictedCount++;
         }

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -144,7 +144,6 @@ namespace BitFaster.Caching.Lfu
                 Maintenance();
 
                 int lruCount = this.windowLru.Count + this.probationLru.Count + this.protectedLru.Count;
-
                 itemCount = Math.Min(itemCount, lruCount);
                 candidates = new (itemCount);
 
@@ -763,7 +762,12 @@ namespace BitFaster.Caching.Lfu
             evictee.WasRemoved = true;
             evictee.WasDeleted = true;
 
-            this.dictionary.TryRemove(evictee.Key, out var _);
+            var kvp = new KeyValuePair<K, N>(evictee.Key, (N)evictee);
+#if NET6_0_OR_GREATER
+            this.dictionary.TryRemove(kvp);
+#else
+            ((ICollection<KeyValuePair<K, N>>)this.dictionary).Remove(kvp);
+#endif
             evictee.list.Remove(evictee);
             Disposer<V>.Dispose(evictee.Value);
             this.metrics.evictedCount++;

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -609,12 +609,6 @@ namespace BitFaster.Caching.Lfu
 
         private void PromoteProbation(LfuNode<K, V> node)
         {
-            //if (node.list == null)
-            //{
-            //    // Ignore stale accesses for an entry that is no longer present
-            //    return;
-            //}
-
             this.probationLru.Remove(node);
             this.protectedLru.AddLast(node);
             node.Position = Position.Protected;

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -699,6 +699,18 @@ namespace BitFaster.Caching.Lfu
                     break;
                 }
 
+                if (candidate.node.WasRemoved)
+                {
+                    Evict(candidate.node);
+                    continue;
+                }
+
+                if (victim.node.WasRemoved)
+                {
+                    Evict(victim.node);
+                    continue;
+                }
+
                 // Evict the entry with the lowest frequency
                 if (candidate.freq > victim.freq)
                 {
@@ -749,6 +761,9 @@ namespace BitFaster.Caching.Lfu
 
         private void Evict(LfuNode<K, V> evictee)
         {
+            evictee.WasRemoved = true;
+            evictee.WasDeleted = true;
+
             this.dictionary.TryRemove(evictee.Key, out var _);
             evictee.list.Remove(evictee);
             Disposer<V>.Dispose(evictee.Value);

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -131,24 +131,6 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
-        public void Clear2()
-        {
-            int lruCount = 0;
-            lock (maintenanceLock)
-            {
-                lruCount = this.windowLru.Count + this.probationLru.Count + this.protectedLru.Count;
-            }
-
-            this.Trim(lruCount);
-
-            lock (maintenanceLock)
-            {
-                this.readBuffer.Clear();
-                this.writeBuffer.Clear();
-                this.cmSketch.Clear();
-            }
-        }
-
         public void Clear()
         {
             Trim(int.MaxValue);

--- a/BitFaster.Caching/Lfu/LfuNode.cs
+++ b/BitFaster.Caching/Lfu/LfuNode.cs
@@ -21,12 +21,18 @@
 
         public Position Position { get; set; }
 
+        /// <summary>
+        /// Node was removed from the dictionary, but is still present in the LRU lists.
+        /// </summary>
         public bool WasRemoved
         {
             get => this.wasRemoved;
             set => this.wasRemoved = value;
         }
 
+        /// <summary>
+        /// Node has been removed both from the dictionary and the LRU lists.
+        /// </summary>
         public bool WasDeleted
         {
             get => this.wasDeleted;


### PR DESCRIPTION
- Evict removes via KVP, instead of just key. This prevents incorrect removal of nodes added to the dictionary when there are two nodes in the write buffer/LRUs with the same key. For example:
   - Node 1 is added with key x
   - Node 1 is removed, now exists only in write buffer + LRU list
   - Node 2 is added with key x, and is also in the write buffer + LRU list
   - Maintenance previously found node 1, and deleted key x from the dictionary detaching node 2. Delete is now via KVP, so node 2 will not be deleted in this situation.
- Check for removed nodes during `EvictFromMain()`
- `Evict()` marks items as removed/deleted
- Revise Trim logic to use LRU count instead of the dictionary. If TryRemove has been called, the dictionary can contain fewer items than the LRU lists. First call `Maintenance()` to flush buffers and mitigate this.
- Enable node detachment integrity check as part of soak tests