### PR TITLE
LRU enumeration should not return expired/removed items

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -27,9 +27,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
         public ConcurrentTLru<K, V> CreateTLru<K, V>(ICapacityPartition capacity, TimeSpan timeToLive)
         {
-            // backcompat: use TLruTickCount64Policy
             return new ConcurrentTLru<K, V>(1, capacity, EqualityComparer<K>.Default, timeToLive);
-
         }
 
         public ConcurrentTLruTests()

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -101,7 +101,7 @@ namespace BitFaster.Caching.Lfu
         }
 
         // No lock count: https://arbel.net/2013/02/03/best-practices-for-using-concurrentdictionary/
-        public int Count => this.dictionary.Skip(0).Count();
+        public int Count => this.dictionary.Where(n => !n.Value.WasRemoved).Count();
 
         public int Capacity => this.capacity.Capacity;
 
@@ -342,7 +342,10 @@ namespace BitFaster.Caching.Lfu
         {
             foreach (var kvp in this.dictionary)
             {
-                yield return new KeyValuePair<K, V>(kvp.Key, kvp.Value.Value);
+                if (!kvp.Value.WasRemoved)
+                { 
+                    yield return new KeyValuePair<K, V>(kvp.Key, kvp.Value.Value); 
+                }
             }
         }
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -342,7 +342,7 @@ namespace BitFaster.Caching.Lfu
         {
             foreach (var kvp in this.dictionary)
             {
-                yield return new KeyValuePair<K, V>(kvp.Key, kvp.Value.Value); 
+                yield return new KeyValuePair<K, V>(kvp.Key, kvp.Value.Value);
             }
         }
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -101,7 +101,7 @@ namespace BitFaster.Caching.Lfu
         }
 
         // No lock count: https://arbel.net/2013/02/03/best-practices-for-using-concurrentdictionary/
-        public int Count => this.dictionary.Where(n => !n.Value.WasRemoved).Count();
+        public int Count => this.dictionary.Skip(0).Count();
 
         public int Capacity => this.capacity.Capacity;
 
@@ -342,10 +342,7 @@ namespace BitFaster.Caching.Lfu
         {
             foreach (var kvp in this.dictionary)
             {
-                if (!kvp.Value.WasRemoved)
-                { 
-                    yield return new KeyValuePair<K, V>(kvp.Key, kvp.Value.Value); 
-                }
+                yield return new KeyValuePair<K, V>(kvp.Key, kvp.Value.Value); 
             }
         }
 

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -98,7 +98,7 @@ namespace BitFaster.Caching.Lru
 
         // No lock count: https://arbel.net/2013/02/03/best-practices-for-using-concurrentdictionary/
         ///<inheritdoc/>
-        public int Count => this.dictionary.Skip(0).Count();
+        public int Count => this.dictionary.Where(i => !itemPolicy.ShouldDiscard(i.Value)).Count();
 
         ///<inheritdoc/>
         public int Capacity => this.capacity.Hot + this.capacity.Warm + this.capacity.Cold;
@@ -144,7 +144,10 @@ namespace BitFaster.Caching.Lru
         {
             foreach (var kvp in this.dictionary)
             {
-                yield return new KeyValuePair<K, V>(kvp.Key, kvp.Value.Value);
+                if (!itemPolicy.ShouldDiscard(kvp.Value))
+                { 
+                    yield return new KeyValuePair<K, V>(kvp.Key, kvp.Value.Value); 
+                }
             }
         }
 


### PR DESCRIPTION
This fixes a small gap, and introduces an observability difference because TLRU tests previously used to the count to observe eviction. To fix this:

- Remove the abstract base class used for TLRU tests - this is no longer needed since introducing `Duration` and having a single implementation of `TLruLongTicksPolicy`.
- Change the tests to use `ConcurrentTLru`, and verify expiry via the internal queue counters which are part of the public API.