### PR TITLE
Drain threads for memory cache hit rate analysis

### DIFF
--- a/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
+++ b/BitFaster.Caching.HitRateAnalysis/Arc/Runner.cs
@@ -31,7 +31,7 @@ namespace BitFaster.Caching.HitRateAnalysis.Arc
 
             this.config.Analysis.WriteToConsole();
             Analysis<long>.WriteToFile(this.config.Name, this.config.Analysis);
-            Analysis<long>.Plot(this.config.Title, this.config.Name, this.config.Analysis);
+            Analysis<long>.Plot(this.config.Name, this.config.Title, this.config.Analysis);
         }
 
         private int AnalyzeSmall()

--- a/BitFaster.Caching.HitRateAnalysis/MemoryCacheAdaptor.cs
+++ b/BitFaster.Caching.HitRateAnalysis/MemoryCacheAdaptor.cs
@@ -69,6 +69,8 @@ namespace BitFaster.Caching.HitRateAnalysis
                 this.metrics.requestHitCount++;
             }
 
+            ThreadPoolInspector.WaitForEmpty();
+
             return (V)result;
         }
 

--- a/BitFaster.Caching.HitRateAnalysis/MemoryCacheAdaptor.cs
+++ b/BitFaster.Caching.HitRateAnalysis/MemoryCacheAdaptor.cs
@@ -63,13 +63,12 @@ namespace BitFaster.Caching.HitRateAnalysis
                 entry.SetSize(1);
 
                 this.metrics.requestMissCount++;
+                ThreadPoolInspector.WaitForEmpty();
             }
             else
             {
                 this.metrics.requestHitCount++;
             }
-
-            ThreadPoolInspector.WaitForEmpty();
 
             return (V)result;
         }

--- a/BitFaster.Caching.HitRateAnalysis/ThreadPoolInspector.cs
+++ b/BitFaster.Caching.HitRateAnalysis/ThreadPoolInspector.cs
@@ -7,15 +7,19 @@ namespace BitFaster.Caching.HitRateAnalysis
     {
         public static void WaitForEmpty()
         {
-            int count = 0;
             while (ThreadPool.PendingWorkItemCount > 0)
             {
                 Thread.Yield();
-                Thread.Sleep(1);
 
-                if (count++ > 10)
+                // This is very hacky, but by experimentation 300 Sleep(0) consistently takes longer 
+                // than cache maintenance giving stable results with around 25% run time penalty.
+                // Sleep(1) makes the test take 50x longer.
+                if (ThreadPool.PendingWorkItemCount == 0)
                 {
-                    Console.WriteLine("Waiting for thread pool to flush...");
+                    for (int i = 0; i < 300; i++)
+                    {
+                        Thread.Sleep(0);
+                    }
                 }
             }
         }

--- a/BitFaster.Caching.HitRateAnalysis/ThreadPoolInspector.cs
+++ b/BitFaster.Caching.HitRateAnalysis/ThreadPoolInspector.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+
+namespace BitFaster.Caching.HitRateAnalysis
+{
+    internal class ThreadPoolInspector
+    {
+        public static void WaitForEmpty()
+        {
+            int count = 0;
+            while (ThreadPool.PendingWorkItemCount > 0)
+            {
+                Thread.Yield();
+                Thread.Sleep(1);
+
+                if (count++ > 10)
+                {
+                    Console.WriteLine("Waiting for thread pool to flush...");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
MemoryCache enqueues cache maintenance to the thread pool asynchronously. This leads to non-deterministic results in the hit rate tests, depending on whether cache maintenance has run.

ConcurrentLfu tests are run with a foreground scheduler (no background maintenance) to avoid this problem.

To make the tests fair, wait for all thread pool tasks to complete each time there is a MemoryCache read. This achieves stable results with a small penalty.

# Result with fix:
![results glimpse](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/88194c9e-1be8-4904-9551-490d0cf45b87)

# Result before fix:
![results glimpse](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/409722bd-2452-4a0f-8e92-ace46881f7c8)

Thread.Sleep(1) increases the test runtime for glimpse from 0.31 secs to about 15 secs - i.e. 4700% slower. Repeated Thread.Sleep(0) is only about 25% slower.


![results wiki](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/b22c185c-776b-4c49-b0e6-2211083c4090)

![results arc database](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/c03602f8-e368-49d8-b768-17c40e475993)

![results arc search](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/b18ab44b-e681-4717-947d-81e145b38cd6)
![results arc oltp](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/4c94a29f-1c8d-4a57-9ac8-7c7e0ca332f0)
