### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/benchpr.yml
+++ b/.github/workflows/benchpr.yml
@@ -18,9 +18,9 @@ jobs:
     - name: Disable Windows Defender
       run: Set-MpPreference -DisableRealtimeMonitoring $true
       shell: powershell
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.0.x
@@ -30,7 +30,7 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Clone splitasm repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: bitfaster/splitasm
         path: splitasm
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.0.x
@@ -81,9 +81,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.0.x

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -16,9 +16,9 @@ jobs:
       checks: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           3.1.x
@@ -93,9 +93,9 @@ jobs:
       checks: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.0.x
@@ -131,9 +131,9 @@ jobs:
       checks: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
           6.0.x


### PR DESCRIPTION
Update actions to avoid dependency on deprecated node version:

![image](https://github.com/bitfaster/BitFaster.Caching/assets/12851828/8ad932ba-0b12-4638-b088-3071bf1e2f67)
