### PR TITLE
Update test action in gate.yml

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: windows-latest
 
     permissions:
+      contents: read
+      actions: read
       checks: write
 
     steps:

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -31,7 +31,8 @@ jobs:
 
     - name: Test (4.8)
       run: dotnet test --no-restore --verbosity normal -f net48 --logger "trx;LogFileName=results4.trx"
-    - uses: actions/upload-artifact@v4  # upload test results
+    - name: Upload test results (4.8)
+      uses: actions/upload-artifact@v4  # upload test results
       if: success() || failure()        # run this step even if previous step failed
       with:
           name: test-results-win48

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -13,8 +13,6 @@ jobs:
     runs-on: windows-latest
 
     permissions:
-      contents: read
-      actions: read
       checks: write
 
     steps:
@@ -92,8 +90,6 @@ jobs:
     runs-on: macos-latest
 
     permissions:
-      contents: read
-      actions: read
       checks: write
 
     steps:
@@ -132,8 +128,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
-      actions: read
       checks: write
 
     steps:

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/upload-artifact@v4  # upload test results
       if: success() || failure()        # run this step even if previous step failed
       with:
-          name: test-results4
+          name: test-results-win48
           path: BitFaster.Caching.UnitTests/TestResults/results4.trx
 #    - name: Generate unit test report (4.8)
 #      uses: phoenix-actions/test-reporting@v15

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Test (4.8)
       run: dotnet test --no-restore --verbosity normal -f net48 --logger "trx;LogFileName=results4.trx"
     - name: Generate unit test report (4.8)
-      uses: phoenix-actions/test-reporting@v12
+      uses: phoenix-actions/test-reporting@v15
       id: unit-test-report-win48
       if: success() || failure() 
       with:
@@ -46,7 +46,7 @@ jobs:
     - name: Test (3.1)
       run: dotnet test --no-restore --verbosity normal -f netcoreapp3.1 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results3.trx"
     - name: Generate unit test report (3.1)
-      uses: phoenix-actions/test-reporting@v12
+      uses: phoenix-actions/test-reporting@v15
       id: unit-test-report-win3
       if: success() || failure() 
       with:
@@ -65,7 +65,7 @@ jobs:
     - name: Test (6.0)
       run: dotnet test --no-restore --verbosity normal -f net6.0 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results6.trx"
     - name: Generate unit test report (6.0)
-      uses: phoenix-actions/test-reporting@v12
+      uses: phoenix-actions/test-reporting@v15
       id: unit-test-report-win6
       if: success() || failure() 
       with:
@@ -92,6 +92,8 @@ jobs:
     runs-on: macos-latest
 
     permissions:
+      contents: read
+      actions: read
       checks: write
 
     steps:
@@ -116,7 +118,7 @@ jobs:
         flag-name: mac
         parallel: true
     - name: Generate unit test report
-      uses: phoenix-actions/test-reporting@v12
+      uses: phoenix-actions/test-reporting@v15
       id: unit-test-report-mac
       if: success() || failure() 
       with:
@@ -130,6 +132,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      contents: read
+      actions: read
       checks: write
 
     steps:
@@ -154,7 +158,7 @@ jobs:
         flag-name: linux
         parallel: true
     - name: Generate unit test report
-      uses: phoenix-actions/test-reporting@v12
+      uses: phoenix-actions/test-reporting@v15
       id: unit-test-report-linux
       if: success() || failure() 
       with:

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -31,15 +31,20 @@ jobs:
 
     - name: Test (4.8)
       run: dotnet test --no-restore --verbosity normal -f net48 --logger "trx;LogFileName=results4.trx"
-    - name: Generate unit test report (4.8)
-      uses: phoenix-actions/test-reporting@v15
-      id: unit-test-report-win48
-      if: success() || failure() 
+    - uses: actions/upload-artifact@v4  # upload test results
+      if: success() || failure()        # run this step even if previous step failed
       with:
-        name: test results (win net4.8)
-        path: BitFaster.Caching.UnitTests/TestResults/results4.trx
-        reporter: dotnet-trx 
-        only-summary: 'true'
+          name: test-results4
+          path: BitFaster.Caching.UnitTests/TestResults/results4.trx
+#    - name: Generate unit test report (4.8)
+#      uses: phoenix-actions/test-reporting@v15
+#      id: unit-test-report-win48
+#      if: success() || failure() 
+#      with:
+#        name: test results (win net4.8)
+#        path: BitFaster.Caching.UnitTests/TestResults/results4.trx
+#        reporter: dotnet-trx 
+#        only-summary: 'true'
     
     - name: Test (3.1)
       run: dotnet test --no-restore --verbosity normal -f netcoreapp3.1 /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov --logger "trx;LogFileName=results3.trx"

--- a/.github/workflows/testreport.yml
+++ b/.github/workflows/testreport.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: phoenix-actions/test-reporting@v15
       id: unit-test-report-win48          # Set ID reference for step
       with:
-        artifact: test-results4           # artifact name
-        name: Tests (4.8)                 # Name of the check run which will be created
+        artifact: test-results-win48      # artifact name
+        name: Test results (win net4.8)   # Name of the check run which will be created
         path: '*.trx'                     # Path to test results (inside artifact .zip)
         reporter: dotnet-trx              # Format of test results

--- a/.github/workflows/testreport.yml
+++ b/.github/workflows/testreport.yml
@@ -15,3 +15,4 @@ jobs:
         name: Test results (win net4.8)   # Name of the check run which will be created
         path: '*.trx'                     # Path to test results (inside artifact .zip)
         reporter: dotnet-trx              # Format of test results
+        only-summary: 'true'

--- a/.github/workflows/testreport.yml
+++ b/.github/workflows/testreport.yml
@@ -1,0 +1,17 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['Build']                     # runs after Build workflow
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: phoenix-actions/test-reporting@v15
+      id: unit-test-report-win48          # Set ID reference for step
+      with:
+        artifact: test-results4           # artifact name
+        name: Tests (4.8)                 # Name of the check run which will be created
+        path: '*.trx'                     # Path to test results (inside artifact .zip)
+        reporter: dotnet-trx              # Format of test results


### PR DESCRIPTION
- Extract test report workflow as documented [here](https://github.com/phoenix-actions/test-reporting?tab=readme-ov-file#recommended-setup-for-public-repositories) for 'Recommended setup for public repositories'.
- Updated to v15

For now, only move the .NET 4.8 tests as a first step.
