### PR TITLE
Enable build re-run

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -31,8 +31,6 @@ jobs:
 
     - name: Test (4.8)
       run: dotnet test --no-restore --verbosity normal -f net48 --logger "trx;LogFileName=results4.trx"
-    - name: Trap status
-
     - name: Upload test results (4.8)
       uses: actions/upload-artifact@v4  # upload test results
       if: success() || failure()        # run this step even if previous step failed

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -31,6 +31,8 @@ jobs:
 
     - name: Test (4.8)
       run: dotnet test --no-restore --verbosity normal -f net48 --logger "trx;LogFileName=results4.trx"
+    - name: Trap status
+
     - name: Upload test results (4.8)
       uses: actions/upload-artifact@v4  # upload test results
       if: success() || failure()        # run this step even if previous step failed
@@ -149,6 +151,10 @@ jobs:
   coverage:
 
     needs: [win, mac, linux]
+    if: |
+      needs.win.result == 'success' && 
+      needs.mac.result == 'success' && 
+      needs.linux.result == 'success'
     
     runs-on: ubuntu-latest
     

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -732,6 +732,10 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.TryUpdate(2, "3").Should().BeFalse();
         }
 
+        [Fact]
+        public void Fail()
+        { throw new Exception(); }
+
 // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -732,6 +732,12 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.TryUpdate(2, "3").Should().BeFalse();
         }
 
+        [Fact]
+        public void TestFail()
+        { 
+            throw new NotImplementedException();
+        }
+
 // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -732,12 +732,6 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.TryUpdate(2, "3").Should().BeFalse();
         }
 
-        [Fact]
-        public void TestFail()
-        { 
-            throw new NotImplementedException();
-        }
-
 // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
         [Fact]


### PR DESCRIPTION
Experiment with re-running.

What is happening:
1. Build runs, tests fail. Test results uploaded. Build action is marked failed.
2. Test report runs, detects failing test. Adds a failure annotation for potentially a different workflow.
3. Re-running Build does not delete the failure annotation - commit is permanently marked as a failure.

What should happen:
- Log should always be attached to build? Or build can be re-run.

For now, best approach seems to be disabling the test report. 