### PR TITLE
Add IAsyncCacheExt

### DIFF
--- a/BitFaster.Caching/IAsyncCacheExt.cs
+++ b/BitFaster.Caching/IAsyncCacheExt.cs
@@ -1,16 +1,17 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {
     /// <summary>
-    /// Represents a generic cache of key/value pairs. This is a new interface with new methods to avoid breaking backward compatibility.
+    /// Represents a generic cache of key/value pairs.
     /// </summary>
     /// <typeparam name="K">The type of keys in the cache.</typeparam>
     /// <typeparam name="V">The type of values in the cache.</typeparam>
-    /// <remarks>This interface enables .NET Standard to use cache methods added to ICache since v2.0. It will be removed in the next major version.</remarks>
-    public interface ICacheExt<K, V> : ICache<K, V>
+    /// <remarks>This interface enables .NET Standard to use cache methods added to IAsyncCache since v2.0. It will be removed in the next major version.</remarks>
+    public interface IAsyncCacheExt<K, V> : IAsyncCache<K, V>
     {
         // Following methods were also defined in ICache with default interface implementation which only works for
         // certain build targets, for other build targets we will define them within this new interface to avoid breaking
@@ -23,11 +24,11 @@ namespace BitFaster.Caching
         /// </summary>
         /// <typeparam name="TArg">The type of an argument to pass into valueFactory.</typeparam>
         /// <param name="key">The key of the element to add.</param>
-        /// <param name="valueFactory">The factory function used to generate a value for the key.</param>
+        /// <param name="valueFactory">The factory function used to asynchronously generate a value for the key.</param>
         /// <param name="factoryArgument">An argument value to pass into valueFactory.</param>
-        /// <returns>The value for the key. This will be either the existing value for the key if the key is already 
-        /// in the cache, or the new value if the key was not in the cache.</returns>
-        V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument);
+        /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
+        /// <remarks>The default implementation given here is the fallback that provides backwards compatibility for classes that implement ICache on prior versions</remarks>
+        ValueTask<V> GetOrAddAsync<TArg>(K key, Func<K, TArg, Task<V>> valueFactory, TArg factoryArgument);
 
         /// <summary>
         /// Attempts to remove and return the value that has the specified key.

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -32,7 +32,7 @@ namespace BitFaster.Caching.Lfu
     /// https://github.com/ben-manes/caffeine
     [DebuggerTypeProxy(typeof(ConcurrentLfu<,>.LfuDebugView<>))]
     [DebuggerDisplay("Count = {Count}/{Capacity}")]
-    public sealed class ConcurrentLfu<K, V> : ICacheExt<K, V>, IAsyncCache<K, V>, IBoundedPolicy
+    public sealed class ConcurrentLfu<K, V> : ICacheExt<K, V>, IAsyncCacheExt<K, V>, IBoundedPolicy
         where K : notnull
     {
         // Note: for performance reasons this is a mutable struct, it cannot be readonly.

--- a/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
@@ -9,7 +9,7 @@ using BitFaster.Caching.Scheduler;
 namespace BitFaster.Caching.Lfu
 {
     // LFU with time-based expiry policy. Provided as a wrapper around ConcurrentLfuCore to hide generic item and policy.
-    internal sealed class ConcurrentTLfu<K, V> : ICacheExt<K, V>, IAsyncCache<K, V>, IBoundedPolicy, ITimePolicy, IDiscreteTimePolicy
+    internal sealed class ConcurrentTLfu<K, V> : ICacheExt<K, V>, IAsyncCacheExt<K, V>, IBoundedPolicy, ITimePolicy, IDiscreteTimePolicy
         where K : notnull
     {
         // Note: for performance reasons this is a mutable struct, it cannot be readonly.

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -18,7 +18,7 @@ namespace BitFaster.Caching.Lru
     /// </remarks>
     /// <typeparam name="K">The type of the key</typeparam>
     /// <typeparam name="V">The type of the value</typeparam>
-    public sealed class ClassicLru<K, V> : ICacheExt<K, V>, IAsyncCache<K, V>, IBoundedPolicy, IEnumerable<KeyValuePair<K, V>>
+    public sealed class ClassicLru<K, V> : ICacheExt<K, V>, IAsyncCacheExt<K, V>, IBoundedPolicy, IEnumerable<KeyValuePair<K, V>>
         where K : notnull
     {
         private readonly int capacity;

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -32,7 +32,7 @@ namespace BitFaster.Caching.Lru
     ///   <item><description>When cold is full, cold tail is moved to warm head or removed from dictionary on depending on WasAccessed.</description></item>
     ///</list>
     /// </remarks>
-    public class ConcurrentLruCore<K, V, I, P, T> : ICacheExt<K, V>, IAsyncCache<K, V>, IEnumerable<KeyValuePair<K, V>>
+    public class ConcurrentLruCore<K, V, I, P, T> : ICacheExt<K, V>, IAsyncCacheExt<K, V>, IEnumerable<KeyValuePair<K, V>>
         where K : notnull
         where I : LruItem<K, V>
         where P : struct, IItemPolicy<K, V, I>


### PR DESCRIPTION
Similar to PR #566, enable users of .NET Standard to combine:

- `ConcurrentLruBuilder.WithExpireAfter()`
- New methods added to `ICacheAsync` since v2.0