### PR TITLE
Static OS check to select clock

### DIFF
--- a/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
@@ -7,6 +7,7 @@ using BenchmarkDotNet.Jobs;
 namespace BitFaster.Caching.Benchmarks
 {
 #if Windows
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
     [SimpleJob(RuntimeMoniker.Net48)]
 #endif
     [SimpleJob(RuntimeMoniker.Net60)]

--- a/BitFaster.Caching.UnitTests/DurationTests.cs
+++ b/BitFaster.Caching.UnitTests/DurationTests.cs
@@ -10,6 +10,8 @@ namespace BitFaster.Caching.UnitTests
 {
     public class DurationTests
     {
+        public static readonly ulong epsilon = (ulong)Duration.FromMilliseconds(20).raw;
+
         private readonly ITestOutputHelper testOutputHelper;
 
         public DurationTests(ITestOutputHelper testOutputHelper)

--- a/BitFaster.Caching.UnitTests/Lru/AfterAccessPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/AfterAccessPolicyTests.cs
@@ -53,7 +53,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.TickCount.Should().BeCloseTo(Duration.SinceEpoch().raw, Duration.epsilon);
+            item.TickCount.Should().BeCloseTo(Duration.SinceEpoch().raw, DurationTests.epsilon);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/DiscretePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/DiscretePolicyTests.cs
@@ -48,7 +48,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             item.Key.Should().Be(1);
             item.Value.Should().Be(2);
 
-            item.TickCount.Should().BeCloseTo(timeToExpire.raw + Duration.SinceEpoch().raw, Duration.epsilon);
+            item.TickCount.Should().BeCloseTo(timeToExpire.raw + Duration.SinceEpoch().raw, DurationTests.epsilon);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -56,7 +56,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.TickCount.Should().BeCloseTo(Duration.SinceEpoch().raw, Duration.epsilon);
+            item.TickCount.Should().BeCloseTo(Duration.SinceEpoch().raw, DurationTests.epsilon);
         }
 
         [Fact]

--- a/BitFaster.Caching/Duration.cs
+++ b/BitFaster.Caching/Duration.cs
@@ -26,8 +26,6 @@ namespace BitFaster.Caching
 
         internal static readonly Duration Zero = new Duration(0);
 
-        internal static readonly ulong epsilon = (ulong)Duration.FromMilliseconds(20).raw;
-
 #if NETCOREAPP3_0_OR_GREATER
         private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 #endif

--- a/BitFaster.Caching/Duration.cs
+++ b/BitFaster.Caching/Duration.cs
@@ -28,6 +28,10 @@ namespace BitFaster.Caching
 
         internal static readonly ulong epsilon = (ulong)Duration.FromMilliseconds(20).raw;
 
+#if NETCOREAPP3_0_OR_GREATER
+        private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+#endif
+
         internal Duration(long raw)
         { 
             this.raw = raw; 
@@ -41,7 +45,7 @@ namespace BitFaster.Caching
         public static Duration SinceEpoch()
         {
 #if NETCOREAPP3_0_OR_GREATER
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (IsMacOS)
             {
                 return new Duration(Stopwatch.GetTimestamp());
             }
@@ -61,8 +65,8 @@ namespace BitFaster.Caching
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TimeSpan ToTimeSpan()
         {
-#if NETCOREAPP3_0_OR_GREATER    
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+#if NETCOREAPP3_0_OR_GREATER
+            if (IsMacOS)
             {
                 return StopwatchTickConverter.FromTicks(raw);
             }
@@ -72,7 +76,7 @@ namespace BitFaster.Caching
             }
 #else
             return StopwatchTickConverter.FromTicks(raw);
-#endif    
+#endif
         }
 
         /// <summary>
@@ -84,7 +88,7 @@ namespace BitFaster.Caching
         public static Duration FromTimeSpan(TimeSpan timeSpan)
         {
 #if NETCOREAPP3_0_OR_GREATER
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (IsMacOS)
             {
                 return new Duration(StopwatchTickConverter.ToTicks(timeSpan));
             }
@@ -94,7 +98,7 @@ namespace BitFaster.Caching
             }
 #else
             return new Duration(StopwatchTickConverter.ToTicks(timeSpan));
-#endif       
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
This brings a more noticeable gain, building on #540. The OS check is not a JIT intrinsic until .NET8, so repeated checks are a penalty. As a follow up, need to verify whether windows bench was regressed and whether the OS check is ultimately elided by the JIT.

With this fix (static readonly bool):

| Method                   | Mean      | Error     | StdDev    | Ratio | Allocated | 
|------------------------- |----------:|----------:|----------:|------:|----------:|
| ConcurrentDictionary     |  4.023 ns | 0.0114 ns | 0.0089 ns |  1.00 |         - | 
| FastConcurrentTLru       | 14.995 ns | 0.0046 ns | 0.0036 ns |  3.73 |         - | 
| FastConcLruAfterAccess   | 17.534 ns | 0.0465 ns | 0.0388 ns |  4.36 |         - | 
| FastConcLruAfter         | 20.035 ns | 0.0061 ns | 0.0051 ns |  4.98 |         - | 
| ConcurrentTLru           | 19.744 ns | 0.0047 ns | 0.0037 ns |  4.91 |         - | 


v2.5.0 baseline

| Method                   | Mean      | Error     | StdDev    | Ratio | Allocated | 
|------------------------- |----------:|----------:|----------:|------:|----------:|
| ConcurrentDictionary     |  3.935 ns | 0.0771 ns | 0.0721 ns |  1.00 |         - | 
| FastConcurrentTLru       | 16.610 ns | 0.0064 ns | 0.0054 ns |  4.22 |         - | 
| FastConcLruAfterAccess   | 18.822 ns | 0.0069 ns | 0.0058 ns |  4.79 |         - | 
| FastConcLruAfter         | 21.149 ns | 0.0166 ns | 0.0139 ns |  5.38 |         - | 
| ConcurrentTLru           | 21.449 ns | 0.0067 ns | 0.0052 ns |  5.46 |         - | 


```
BenchmarkDotNet v0.13.12, macOS Sonoma 14.1.1 (23B81) [Darwin 23.1.0]
Apple M2, 1 CPU, 8 logical and 8 physical cores
.NET SDK 8.0.100
  [Host]   : .NET 6.0.29 (6.0.2924.17105), Arm64 RyuJIT AdvSIMD
  .NET 6.0 : .NET 6.0.29 (6.0.2924.17105), Arm64 RyuJIT AdvSIMD
Job=.NET 6.0  Runtime=.NET 6.0  
```