### PR TITLE
P/Invoke TickCount64 for .NET Standard on Windows

### DIFF
--- a/BitFaster.Caching.UnitTests/DurationTests.cs
+++ b/BitFaster.Caching.UnitTests/DurationTests.cs
@@ -34,9 +34,16 @@ namespace BitFaster.Caching.UnitTests
                 Duration.SinceEpoch().raw.Should().BeCloseTo(Environment.TickCount64, 15);
             }
 #else
-            // eps is 1/200 of a second
-            ulong eps = (ulong)(Stopwatch.Frequency / 200);
-            Duration.SinceEpoch().raw.Should().BeCloseTo(Stopwatch.GetTimestamp(), eps);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Duration.SinceEpoch().raw.Should().BeCloseTo(Duration.GetTickCount64(), 15);
+            }
+            else
+            {
+                // eps is 1/200 of a second
+                ulong eps = (ulong)(Stopwatch.Frequency / 200);
+                Duration.SinceEpoch().raw.Should().BeCloseTo(Stopwatch.GetTimestamp(), eps);
+            }
 #endif
         }
 
@@ -53,8 +60,15 @@ namespace BitFaster.Caching.UnitTests
                 new Duration(1000).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(10));
             }
 #else
-            // for Stopwatch.GetTimestamp() this is number of ticks
-            new Duration(1 * Stopwatch.Frequency).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                new Duration(1000).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(10));
+            }
+            else
+            {
+                // for Stopwatch.GetTimestamp() this is number of ticks
+                new Duration(1 * Stopwatch.Frequency).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10));
+            }
 #endif    
         }
 
@@ -73,8 +87,16 @@ namespace BitFaster.Caching.UnitTests
                     .Should().Be((long)TimeSpan.FromSeconds(1).TotalMilliseconds);
             }
 #else
-            Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
+                    .Should().Be((long)TimeSpan.FromSeconds(1).TotalMilliseconds);
+            }
+            else
+            {
+                Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
                 .Should().Be(Stopwatch.Frequency);
+            }
 #endif    
         }
 

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -32,10 +32,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenTtlIsCloseToMaxAllow()
         {
-            double maxTicks = long.MaxValue / 100.0d;
-            var ttl = TimeSpan.FromTicks((long)maxTicks) - TimeSpan.FromTicks(10);
+            var ttl = Duration.MaxRepresentable;
 
-            new TLruLongTicksPolicy<int, int>(ttl).TimeToLive.Should().BeCloseTo(ttl, TimeSpan.FromTicks(20));
+            new TLruLongTicksPolicy<int, int>(ttl).TimeToLive.Should().BeCloseTo(ttl, TimeSpan.FromSeconds(1));
         }
 
         [Fact]
@@ -58,9 +57,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            // seconds = ticks / Stopwatch.Frequency
-            ulong epsilon = (ulong)(TimeSpan.FromMilliseconds(20).TotalSeconds * Stopwatch.Frequency);
-            item.TickCount.Should().BeCloseTo(Stopwatch.GetTimestamp(), epsilon);
+            item.TickCount.Should().BeCloseTo(Duration.SinceEpoch().raw, DurationTests.epsilon);
         }
 
         [Fact]
@@ -91,7 +88,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsExpiredShouldDiscardIsTrue()
         {
             var item = this.policy.CreateItem(1, 2);
-            item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
+            item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(11).raw;
 
             this.policy.ShouldDiscard(item).Should().BeTrue();
         }
@@ -100,7 +97,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenItemIsNotExpiredShouldDiscardIsFalse()
         {
             var item = this.policy.CreateItem(1, 2);
-            item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(9));
+            item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(9).raw;
 
             this.policy.ShouldDiscard(item).Should().BeFalse();
         }
@@ -155,7 +152,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             if (isExpired)
             {
-                item.TickCount = Stopwatch.GetTimestamp() - TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.FromSeconds(11));
+                item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(11).raw;
             }
 
             return item;

--- a/BitFaster.Caching/Duration.cs
+++ b/BitFaster.Caching/Duration.cs
@@ -63,6 +63,7 @@ namespace BitFaster.Caching
             }
             else
             {
+                // Warning: not currently covered by unit tests
                 return new Duration(Stopwatch.GetTimestamp());
             }
 #endif
@@ -91,6 +92,7 @@ namespace BitFaster.Caching
             }
             else
             {
+                // Warning: not currently covered by unit tests
                 return StopwatchTickConverter.FromTicks(raw);
             }
 #endif
@@ -120,6 +122,7 @@ namespace BitFaster.Caching
             }
             else
             {
+                // Warning: not currently covered by unit tests
                 return new Duration(StopwatchTickConverter.ToTicks(timeSpan));
             }
 #endif

--- a/BitFaster.Caching/Duration.cs
+++ b/BitFaster.Caching/Duration.cs
@@ -28,6 +28,11 @@ namespace BitFaster.Caching
 
 #if NETCOREAPP3_0_OR_GREATER
         private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+#else
+        private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        [DllImport("kernel32")]
+        internal static extern long GetTickCount64();
 #endif
 
         internal Duration(long raw)
@@ -52,7 +57,14 @@ namespace BitFaster.Caching
                 return new Duration(Environment.TickCount64);
             }
 #else
-            return new Duration(Stopwatch.GetTimestamp());
+            if (IsWindows)
+            {
+                return new Duration(GetTickCount64());
+            }
+            else
+            {
+                return new Duration(Stopwatch.GetTimestamp());
+            }
 #endif
         }
 
@@ -73,7 +85,14 @@ namespace BitFaster.Caching
                 return TimeSpan.FromMilliseconds(raw);
             }
 #else
-            return StopwatchTickConverter.FromTicks(raw);
+            if (IsWindows)
+            {
+                return TimeSpan.FromMilliseconds(raw);
+            }
+            else
+            {
+                return StopwatchTickConverter.FromTicks(raw);
+            }
 #endif
         }
 
@@ -95,7 +114,14 @@ namespace BitFaster.Caching
                 return new Duration((long)timeSpan.TotalMilliseconds);
             }
 #else
-            return new Duration(StopwatchTickConverter.ToTicks(timeSpan));
+            if (IsWindows)
+            {
+                return new Duration((long)timeSpan.TotalMilliseconds);
+            }
+            else
+            {
+                return new Duration(StopwatchTickConverter.ToTicks(timeSpan));
+            }
 #endif
         }
 


### PR DESCRIPTION
Note; this introduces a test hole: there are currently no tests that verify .NET standard when it is not running on Windows (we only execute NET4.8 on Windows to test .NET Standard). Since code coverage analysis only runs for .NET Core build targets, this is not observable in the code coverage report.