### PR TITLE
Mitigate LFU struct tearing (new node)

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -371,7 +371,7 @@ namespace BitFaster.Caching.Lfu
                 }
                 else
                 { 
-                    var newNode = policy.Create(key, value);
+                    var newNode = policy.Clone(node, value);
                     if (this.dictionary.TryUpdate(key, newNode, node))
                     { 
                         // This can't be lossy, because we need to attach the new node.

--- a/BitFaster.Caching/Lfu/LfuNode.cs
+++ b/BitFaster.Caching/Lfu/LfuNode.cs
@@ -114,6 +114,9 @@ namespace BitFaster.Caching.Lfu
             this.prevTime = prev;
         }
 
+        // Note: there is a special case for non-atomic value types. When the node has been updated,
+        // GetNextInTimeOrder() will return this. In this situation, the node is not attached to the
+        // timer wheel.
         public TimeOrderNode<K, V> GetNextInTimeOrder()
         {
             return nextTime;


### PR DESCRIPTION
When updating a large struct, instead of updating in place, we can instead create a new node. Since nodes are not updated, no tearing can occur.

Time based expiry is a special case that is handled as follows:

- The new `INodePolicy.Clone` method creates the replacement node to insert into the dictionary. For `ExpireAfterPolicy` this avoids calling expiry calculator on create, and we set current expiry to match old node. We also set GetNextInTimeOrder == self, this is a hack so that `ExpireAfterPolicy.OnWrite` knows the node was not created and is currently detached from the `TimerWheel`.
- In `ExpireAfterPolicy.OnWrite`, check if next == self to schedule/reschedule. Schedule will just overwrite next to a valid node.
- Add note to GetNextInTimeOrder to explain

TODO:
- Unit test
- Soak test
- Verify TLFU logic