### PR TITLE
LFU after access fails to update expiry when read buffer is not full

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using BitFaster.Caching.UnitTests.Retry;
@@ -24,6 +25,27 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu = new ConcurrentTLfu<int, string>(capacity, new ExpireAfterWrite<int, string>(timeToLive));
         }
+
+        [Fact]
+        public void Repro()
+        { 
+            var cache = new ConcurrentLfuBuilder<int, int>()
+                .WithCapacity(10)
+                .WithExpireAfterAccess(TimeSpan.FromSeconds(5))
+                .Build();
+
+            cache.AddOrUpdate(1, 1);
+
+            Thread.Sleep(4000);
+
+            cache.TryGet(1, out var value).Should().BeTrue();
+
+            Thread.Sleep(2000);
+
+            cache.TryGet(1, out value).Should().BeTrue();
+            cache.TryGet(1, out value).Should().BeTrue();
+        }
+
 
         [Fact]
         public void ConstructAddAndRetrieveWithCustomComparerReturnsValue()

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
@@ -26,26 +26,35 @@ namespace BitFaster.Caching.UnitTests.Lfu
             lfu = new ConcurrentTLfu<int, string>(capacity, new ExpireAfterWrite<int, string>(timeToLive));
         }
 
-        [Fact]
-        public void Repro()
+        // This is a scenario test to verify maintenance is run promptly after read.
+        [RetryFact]
+        public void WhenItemIsAccessedTimeToExpireIsUpdated()
         { 
             var cache = new ConcurrentLfuBuilder<int, int>()
                 .WithCapacity(10)
                 .WithExpireAfterAccess(TimeSpan.FromSeconds(5))
                 .Build();
 
-            cache.AddOrUpdate(1, 1);
-
-            Thread.Sleep(4000);
-
-            cache.TryGet(1, out var value).Should().BeTrue();
-
-            Thread.Sleep(2000);
-
-            cache.TryGet(1, out value).Should().BeTrue();
-            cache.TryGet(1, out value).Should().BeTrue();
+            Timed.Execute(
+                cache,
+                cache =>
+                {
+                    cache.AddOrUpdate(1, 1);
+                    return cache;
+                },
+                TimeSpan.FromSeconds(4),
+                cache =>
+                {
+                    cache.TryGet(1, out var value);
+                },
+                TimeSpan.FromSeconds(2),
+                cache =>
+                { 
+                    cache.TryGet(1, out var value).Should().BeTrue();
+                    cache.TryGet(1, out value).Should().BeTrue();
+                }
+            );
         }
-
 
         [Fact]
         public void ConstructAddAndRetrieveWithCustomComparerReturnsValue()

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -272,7 +272,7 @@ namespace BitFaster.Caching.Lfu
                 {
                     bool delayable = this.readBuffer.TryAdd(node) != BufferStatus.Full;
 
-                    if (this.drainStatus.ShouldDrain(delayable))
+                    if (this.drainStatus.ShouldDrain(policy.IsReadDrainDelayable() && delayable))
                     {
                         TryScheduleDrain();
                     }

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -272,7 +272,7 @@ namespace BitFaster.Caching.Lfu
                 {
                     bool delayable = this.readBuffer.TryAdd(node) != BufferStatus.Full;
 
-                    if (this.drainStatus.ShouldDrain(policy.IsReadDrainDelayable() && delayable))
+                    if (this.drainStatus.ShouldDrain(delayable))
                     {
                         TryScheduleDrain();
                     }

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -276,6 +276,7 @@ namespace BitFaster.Caching.Lfu
                     {
                         TryScheduleDrain();
                     }
+                    this.policy.OnRead(node);
                     value = node.Value;
                     return true;
                 }
@@ -366,6 +367,7 @@ namespace BitFaster.Caching.Lfu
                 // and we will just lose ordering/hit count, but not orphan the node.
                 this.writeBuffer.TryAdd(node);
                 TryScheduleDrain();
+                this.policy.OnWrite(node);
                 return true;
             }
 
@@ -525,8 +527,6 @@ namespace BitFaster.Caching.Lfu
         {
             this.drainStatus.VolatileWrite(DrainStatus.ProcessingToIdle);
 
-            policy.AdvanceTime();
-
             // Note: this is only Span on .NET Core 3.1+, else this is no-op and it is still an array
             var buffer = this.drainBuffer.AsSpanOrArray();
 
@@ -601,7 +601,7 @@ namespace BitFaster.Caching.Lfu
                     break;
             }
 
-            policy.OnRead(node);
+            policy.AfterRead(node);
         }
 
         private void OnWrite(N node)
@@ -650,7 +650,7 @@ namespace BitFaster.Caching.Lfu
                     break;
             }
 
-            policy.OnWrite(node);
+            policy.AfterWrite(node);
         }
 
         private void PromoteProbation(LfuNode<K, V> node)

--- a/BitFaster.Caching/Lfu/NodePolicy.cs
+++ b/BitFaster.Caching/Lfu/NodePolicy.cs
@@ -10,9 +10,10 @@ namespace BitFaster.Caching.Lfu
     {
         N Create(K key, V value);
         bool IsExpired(N node);
-        void AdvanceTime();
         void OnRead(N node);
         void OnWrite(N node);
+        void AfterRead(N node);
+        void AfterWrite(N node);
         void OnEvict(N node);
         void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, N, P> cache) where P : struct, INodePolicy<K, V, N>;
         bool IsReadDrainDelayable();
@@ -34,17 +35,22 @@ namespace BitFaster.Caching.Lfu
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AdvanceTime()
-        {
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void OnRead(AccessOrderNode<K, V> node)
         {
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void OnWrite(AccessOrderNode<K, V> node)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AfterRead(AccessOrderNode<K, V> node)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AfterWrite(AccessOrderNode<K, V> node)
         {
         }
 
@@ -89,28 +95,32 @@ namespace BitFaster.Caching.Lfu
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsExpired(TimeOrderNode<K, V> node)
         {
-            return node.TimeToExpire < Duration.SinceEpoch();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AdvanceTime()
-        {
             current = Duration.SinceEpoch();
+            return node.TimeToExpire < current;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void OnRead(TimeOrderNode<K, V> node)
         {
-            var oldTte = node.TimeToExpire;
+            // we know IsExpired is always called immediate before OnRead, so piggyback on the current time
             node.TimeToExpire = current + expiryCalculator.GetExpireAfterRead(node.Key, node.Value, node.TimeToExpire - current);
-            if (oldTte.raw != node.TimeToExpire.raw)
-            {
-                wheel.Reschedule(node);
-            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void OnWrite(TimeOrderNode<K, V> node)
+        {
+            var current = Duration.SinceEpoch();
+            node.TimeToExpire = current + expiryCalculator.GetExpireAfterUpdate(node.Key, node.Value, node.TimeToExpire - current);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AfterRead(TimeOrderNode<K, V> node)
+        {
+            wheel.Reschedule(node);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AfterWrite(TimeOrderNode<K, V> node)
         {
             // if the node is not yet scheduled, it is being created
             // the time is set on create in case it is read before the buffer is processed
@@ -120,12 +130,7 @@ namespace BitFaster.Caching.Lfu
             }
             else
             {
-                var oldTte = node.TimeToExpire;
-                node.TimeToExpire = current + expiryCalculator.GetExpireAfterUpdate(node.Key, node.Value, node.TimeToExpire - current);
-                if (oldTte.raw != node.TimeToExpire.raw)
-                {
-                    wheel.Reschedule(node);
-                }
+                wheel.Reschedule(node);
             }
         }
 
@@ -138,7 +143,7 @@ namespace BitFaster.Caching.Lfu
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, TimeOrderNode<K, V>, P> cache) where P : struct, INodePolicy<K, V, TimeOrderNode<K, V>>
         {
-            wheel.Advance(ref cache, current);
+            wheel.Advance(ref cache, Duration.SinceEpoch());
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/BitFaster.Caching/Lfu/NodePolicy.cs
+++ b/BitFaster.Caching/Lfu/NodePolicy.cs
@@ -16,7 +16,6 @@ namespace BitFaster.Caching.Lfu
         void AfterWrite(N node);
         void OnEvict(N node);
         void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, N, P> cache) where P : struct, INodePolicy<K, V, N>;
-        bool IsReadDrainDelayable();
     }
 
     internal struct AccessOrderPolicy<K, V> : INodePolicy<K, V, AccessOrderNode<K, V>>
@@ -63,9 +62,6 @@ namespace BitFaster.Caching.Lfu
         public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, P> cache) where P : struct, INodePolicy<K, V, AccessOrderNode<K, V>>
         {
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsReadDrainDelayable() => true;
     }
 
     internal struct ExpireAfterPolicy<K, V> : INodePolicy<K, V, TimeOrderNode<K, V>>
@@ -145,8 +141,5 @@ namespace BitFaster.Caching.Lfu
         {
             wheel.Advance(ref cache, Duration.SinceEpoch());
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool IsReadDrainDelayable() => false;
     }
 }

--- a/BitFaster.Caching/Lfu/NodePolicy.cs
+++ b/BitFaster.Caching/Lfu/NodePolicy.cs
@@ -15,6 +15,7 @@ namespace BitFaster.Caching.Lfu
         void OnWrite(N node);
         void OnEvict(N node);
         void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, N, P> cache) where P : struct, INodePolicy<K, V, N>;
+        bool IsReadDrainDelayable();
     }
 
     internal struct AccessOrderPolicy<K, V> : INodePolicy<K, V, AccessOrderNode<K, V>>
@@ -56,6 +57,9 @@ namespace BitFaster.Caching.Lfu
         public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, P> cache) where P : struct, INodePolicy<K, V, AccessOrderNode<K, V>>
         {
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsReadDrainDelayable() => true;
     }
 
     internal struct ExpireAfterPolicy<K, V> : INodePolicy<K, V, TimeOrderNode<K, V>>
@@ -136,5 +140,8 @@ namespace BitFaster.Caching.Lfu
         {
             wheel.Advance(ref cache, current);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsReadDrainDelayable() => false;
     }
 }


### PR DESCRIPTION
From the discussion here https://github.com/bitfaster/BitFaster.Caching/pull/516, this is the repro:

```cs
[Fact]
public void Repro()
{ 
    var cache = new ConcurrentLfuBuilder<int, int>()
        .WithCapacity(10)
        .WithExpireAfterAccess(TimeSpan.FromSeconds(5))
        .Build();

    cache.AddOrUpdate(1, 1);

    Thread.Sleep(4000);

    cache.TryGet(1, out var value).Should().BeTrue(); // maintenance doesn't run here

    Thread.Sleep(2000);

    cache.TryGet(1, out value).Should().BeTrue();
    cache.TryGet(1, out value).Should().BeTrue();
}
```

Since maintenance only runs when the read buffer is full, expiry time is never updated.

Solution:

- Policy computes new expiry time at the call site (either on read or update), instead of during maintenance.
- For read, `IsExpired` has just been called, so we can piggyback on the current time to avoid two calls
- We can no longer avoid re-scheduling the same node as part of maintenance (previously we checked if expiry time had changed). Likely the removal of calling expiry calculator is equal cost.

There are a couple of further optimizations:
1. For expire after access, we could make a policy which has empty `OnRead` and `AfterRead` methods, enabling the JIT to elide the method calls to the policy and the expiry calculator, which are anyway a no-op.
2. During maintenance, it may be worth testing the node we are now scheduling against the last node we scheduled. For cases where the same node is read many times, this may avoid duplicate scheduling. Need to measure whether adding this is actually beneficial.