### PR TITLE
Tune throughput test parameters

### DIFF
--- a/BitFaster.Caching.ThroughputAnalysis/SizeExec.sh
+++ b/BitFaster.Caching.ThroughputAnalysis/SizeExec.sh
@@ -1,0 +1,21 @@
+cls
+
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 1 100
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 1 10000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 1 1000000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 1 10000000
+
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 2 1000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 2 100000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 2 10000000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 2 100000000
+
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 3 100
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 3 10000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 3 1000000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 3 10000000
+
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 4 100
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 4 10000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 4 1000000
+dotnet BitFaster.Caching.ThroughputAnalysis.dll 4 10000000

--- a/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
+++ b/BitFaster.Caching.ThroughputAnalysis/ThroughputBenchmark.cs
@@ -31,7 +31,7 @@ namespace BitFaster.Caching.ThroughputAnalysis
             Initialize?.Invoke(cache);
 
             // Warmup a few times before estimating run time
-            config.Iterations = 10;
+            config.Iterations = 1;
 
             for (int i = 0; i < warmup; i++)
             {
@@ -46,14 +46,17 @@ namespace BitFaster.Caching.ThroughputAnalysis
                 var sw = Stopwatch.StartNew();
                 Run(Stage.Pilot, 0, threads, config, cache);
 
-                valid = sw.Elapsed > TimeSpan.FromMilliseconds(400) ? valid + 1 : 0;    
+                valid = sw.Elapsed > TimeSpan.FromMilliseconds(800) ? valid + 1 : 0;    
 
                 if (valid > 3)
                 {
                     break;
                 }
 
-                config.Iterations = (int)(1.2 * config.Iterations);
+                if (valid == 0)
+                { 
+                    config.Iterations = config.Iterations < 5 ? config.Iterations + 1 : (int)(1.2 * config.Iterations); 
+                }
             }
 
             int runCounter = 0;


### PR DESCRIPTION
Enable running faster with larger cache sizes. Read test with 10000000 elements is often taking several hours for each test pass, this drops max runtime to more like 15 minutes.