### PR TITLE
Fix race in LRU concurrent update and TryRemove(kvp)

### DIFF
--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -308,18 +308,21 @@ namespace BitFaster.Caching.Lru
         {
             if (this.dictionary.TryGetValue(item.Key, out var existing))
             {
-                if (EqualityComparer<V>.Default.Equals(existing.Value, item.Value))
+                lock (existing)
                 {
-                    var kvp = new KeyValuePair<K, I>(item.Key, existing);
+                    if (EqualityComparer<V>.Default.Equals(existing.Value, item.Value))
+                    {
+                        var kvp = new KeyValuePair<K, I>(item.Key, existing);
 #if NET6_0_OR_GREATER
                     if (this.dictionary.TryRemove(kvp))
 #else
-                    // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
-                    if (((ICollection<KeyValuePair<K, I>>)this.dictionary).Remove(kvp))
+                        // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
+                        if (((ICollection<KeyValuePair<K, I>>)this.dictionary).Remove(kvp))
 #endif
-                    {
-                        OnRemove(item.Key, kvp.Value, ItemRemovedReason.Removed);
-                        return true;
+                        {
+                            OnRemove(item.Key, kvp.Value, ItemRemovedReason.Removed);
+                            return true;
+                        }
                     }
                 }
 


### PR DESCRIPTION
There is a lock in `TryUpdate` to prevent concurrent updates, but no item lock on `TryRemove(kvp)`. No lock is needed for `TryRemove(key)` because updates to the value do not affect the outcome - key should always be removed. The value is important in the kvp variant however, where the equivalent lock was missed leading to a race when the value changes between finding the existing LruItem and removing it.