### PR TITLE
Optimize ConcurrentLru read throughput (volatile)

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net48;net6.0;net8.0</TargetFrameworks>
+    <LangVersion>10.0</LangVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!-- https://stackoverflow.com/a/59916801/131345 -->
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -66,8 +66,8 @@ namespace BitFaster.Caching.Benchmarks
         [GlobalSetup]
         public void GlobalSetup()
         {
-            memoryCache.Set(key.ToString(), "1", new System.Runtime.Caching.CacheItemPolicy());
-            exMemoryCache.Set(key, "1");
+            memoryCache.Set(key.ToString(), 1, new System.Runtime.Caching.CacheItemPolicy());
+            exMemoryCache.Set(key, 1);
         }
 
         [GlobalCleanup]
@@ -147,15 +147,15 @@ namespace BitFaster.Caching.Benchmarks
         }
 
         [Benchmark()]
-        public object RuntimeMemoryCacheGet()
+        public int RuntimeMemoryCacheGet()
         {
-            return memoryCache.Get("1");
+            return (int)memoryCache.Get("1");
         }
 
         [Benchmark()]
-        public object ExtensionsMemoryCacheGet()
+        public int ExtensionsMemoryCacheGet()
         {
-            return exMemoryCache.Get(1);
+            return (int)exMemoryCache.Get(1);
         }
 
         public class MemoryCacheOptionsAccessor

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -66,8 +66,8 @@ namespace BitFaster.Caching.Benchmarks
         [GlobalSetup]
         public void GlobalSetup()
         {
-            memoryCache.Set(key.ToString(), "test", new System.Runtime.Caching.CacheItemPolicy());
-            exMemoryCache.Set(key, "test");
+            memoryCache.Set(key.ToString(), "1", new System.Runtime.Caching.CacheItemPolicy());
+            exMemoryCache.Set(key, "1");
         }
 
         [GlobalCleanup]
@@ -147,15 +147,15 @@ namespace BitFaster.Caching.Benchmarks
         }
 
         [Benchmark()]
-        public int RuntimeMemoryCacheGet()
+        public object RuntimeMemoryCacheGet()
         {
-            return (int)memoryCache.Get("1");
+            return memoryCache.Get("1");
         }
 
         [Benchmark()]
-        public int ExtensionsMemoryCacheGet()
+        public object ExtensionsMemoryCacheGet()
         {
-            return (int)exMemoryCache.Get(1);
+            return exMemoryCache.Get(1);
         }
 
         public class MemoryCacheOptionsAccessor

--- a/BitFaster.Caching/Lru/AfterAccessPolicy.cs
+++ b/BitFaster.Caching/Lru/AfterAccessPolicy.cs
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.Lru
         public void Touch(LongTickCountLruItem<K, V> item)
         {
             item.TickCount = this.time.Last;
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/DiscretePolicy.cs
+++ b/BitFaster.Caching/Lru/DiscretePolicy.cs
@@ -35,7 +35,7 @@ namespace BitFaster.Caching.Lru
             var currentExpiry = new Duration(item.TickCount - this.time.Last);
             var newExpiry = expiry.GetExpireAfterRead(item.Key, item.Value, currentExpiry);
             item.TickCount = this.time.Last + newExpiry.raw;
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/LruItem.cs
+++ b/BitFaster.Caching/Lru/LruItem.cs
@@ -14,8 +14,8 @@ namespace BitFaster.Caching.Lru
     {
         private V data;
 
-        private volatile bool wasAccessed;
-        private volatile bool wasRemoved;
+        private bool wasAccessed;
+        private bool wasRemoved;
 
         // only used when V is a non-atomic value type to prevent torn reads
         private int sequence;
@@ -72,8 +72,8 @@ namespace BitFaster.Caching.Lru
         /// </summary>
         public bool WasAccessed
         {
-            get => this.wasAccessed;
-            set => this.wasAccessed = value;
+            get => Volatile.Read(ref this.wasAccessed);
+            set => Volatile.Write(ref this.wasAccessed, value);
         }
 
         /// <summary>
@@ -81,8 +81,19 @@ namespace BitFaster.Caching.Lru
         /// </summary>
         public bool WasRemoved
         {
-            get => this.wasRemoved;
-            set => this.wasRemoved = value;
+            get => Volatile.Read(ref this.wasRemoved);
+            set => Volatile.Write(ref this.wasRemoved, value);
+        }
+
+        /// <summary>
+        /// Marks the item as accessed, if it was not already accessed.
+        /// </summary>
+        public void MarkAccessed()
+        { 
+            if (!Volatile.Read(ref this.wasAccessed))
+            { 
+                 Volatile.Write(ref this.wasAccessed, true);
+            }
         }
 
         internal V SeqLockRead()

--- a/BitFaster.Caching/Lru/LruPolicy.cs
+++ b/BitFaster.Caching/Lru/LruPolicy.cs
@@ -23,7 +23,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Touch(LruItem<K, V> item)
         {
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
@@ -38,7 +38,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Touch(LongTickCountLruItem<K, V> item)
         {
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/TlruDateTimePolicy.cs
+++ b/BitFaster.Caching/Lru/TlruDateTimePolicy.cs
@@ -35,7 +35,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Touch(TimeStampedLruItem<K, V> item)
         {
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/TlruTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruTicksPolicy.cs
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Touch(TickCountLruItem<K, V> item)
         {
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>


### PR DESCRIPTION
Improve read throughput by ~150% by avoiding volatile writes (store-load memory barrier).

# Before
![Results_Read_500_base](https://github.com/user-attachments/assets/ca1eb204-f103-4e6d-8b3a-a964540539fe)

# After
![Results_Read_500](https://github.com/user-attachments/assets/ae95c4e0-77b5-4a3b-9b0c-a0f4c69d5910)

TODO: investigate read latency/code size. I would assume impact is negligible and this is a good tradeoff.
