### PR TITLE
Optimize ConcurrentLru read throughput

### DIFF
--- a/BitFaster.Caching/Lru/AfterAccessPolicy.cs
+++ b/BitFaster.Caching/Lru/AfterAccessPolicy.cs
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.Lru
         public void Touch(LongTickCountLruItem<K, V> item)
         {
             item.TickCount = this.time.Last;
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/DiscretePolicy.cs
+++ b/BitFaster.Caching/Lru/DiscretePolicy.cs
@@ -35,7 +35,7 @@ namespace BitFaster.Caching.Lru
             var currentExpiry = new Duration(item.TickCount - this.time.Last);
             var newExpiry = expiry.GetExpireAfterRead(item.Key, item.Value, currentExpiry);
             item.TickCount = this.time.Last + newExpiry.raw;
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/LruItem.cs
+++ b/BitFaster.Caching/Lru/LruItem.cs
@@ -85,6 +85,17 @@ namespace BitFaster.Caching.Lru
             set => this.wasRemoved = value;
         }
 
+        /// <summary>
+        /// Marks the item as accessed, if it was not already accessed.
+        /// </summary>
+        public void MarkAccessed()
+        { 
+            if (!this.wasAccessed)
+            { 
+                this.wasAccessed = true;    
+            }
+        }
+
         internal V SeqLockRead()
         { 
             var spin = new SpinWait();

--- a/BitFaster.Caching/Lru/LruItem.cs
+++ b/BitFaster.Caching/Lru/LruItem.cs
@@ -14,8 +14,8 @@ namespace BitFaster.Caching.Lru
     {
         private V data;
 
-        private volatile bool wasAccessed;
-        private volatile bool wasRemoved;
+        private bool wasAccessed;
+        private bool wasRemoved;
 
         // only used when V is a non-atomic value type to prevent torn reads
         private int sequence;

--- a/BitFaster.Caching/Lru/LruPolicy.cs
+++ b/BitFaster.Caching/Lru/LruPolicy.cs
@@ -23,7 +23,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Touch(LruItem<K, V> item)
         {
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
@@ -38,7 +38,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Touch(LongTickCountLruItem<K, V> item)
         {
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/TlruDateTimePolicy.cs
+++ b/BitFaster.Caching/Lru/TlruDateTimePolicy.cs
@@ -35,7 +35,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Touch(TimeStampedLruItem<K, V> item)
         {
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lru/TlruTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruTicksPolicy.cs
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Touch(TickCountLruItem<K, V> item)
         {
-            item.WasAccessed = true;
+            item.MarkAccessed();
         }
 
         ///<inheritdoc/>


### PR DESCRIPTION
`LruItem.WasAccessed` was previously `volatile` to ensure that thread A marking an item as accessed is visible to thread B that is cycling the cache. Under the covers, `volatile` equates to half fence for reads and writes.

From the [.NET memory model](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md):

- **Volatile reads** have "acquire semantics" - no read or write that is later in the program order may be speculatively executed ahead of a volatile read. 
- **Volatile writes** have "release semantics" - the effects of a volatile write will not be observable before effects of all previous, in program order, reads and writes become observable.
- **Full-fence** operations have "full-fence semantics" - effects of reads and writes must be observable no later or no earlier than a full-fence operation according to their relative program order.
 
Immediately before calling `ConcurrentLruCore.Cycle`, there is always an **interlocked** call. We can thus piggy-back on interlocked and avoid the half fences.

Without the check in `MarkAccessed`, this does not result in the same throughput boost as https://github.com/bitfaster/BitFaster.Caching/pull/643 because x64 has a [strong memory model](https://preshing.com/20120930/weak-vs-strong-memory-models/) (the write has release semantics and generates traffic to ensure CPU cache coherence).

# Before
![Results_Read_500_base](https://github.com/user-attachments/assets/ca1eb204-f103-4e6d-8b3a-a964540539fe)

# After
![Results_Read_500](https://github.com/user-attachments/assets/318cee8e-1db1-4a0e-8b1d-0bb4ab398621)
