### PR TITLE
Update target frameworks

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!-- https://stackoverflow.com/a/59916801/131345 -->
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 

--- a/BitFaster.Caching.Benchmarks/DataStructureBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DataStructureBenchmarks.cs
@@ -10,7 +10,7 @@ namespace BitFaster.Caching.Benchmarks
 #if Windows
     [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
+    [SimpleJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser(displayGenColumns: false)]
     public class DataStructureBenchmarks
     {

--- a/BitFaster.Caching.Benchmarks/DisposerBench.cs
+++ b/BitFaster.Caching.Benchmarks/DisposerBench.cs
@@ -11,7 +11,7 @@ namespace BitFaster.Caching.Benchmarks
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
     [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
+    [SimpleJob(RuntimeMoniker.Net90)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DisposerBench

--- a/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
@@ -10,7 +10,7 @@ namespace BitFaster.Caching.Benchmarks
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
     [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
+    [SimpleJob(RuntimeMoniker.Net90)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DrainBenchmarks
     {
@@ -187,7 +187,7 @@ namespace BitFaster.Caching.Benchmarks
         public void DrainArray()
         {
             Add();
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
             buffer.DrainTo(output.AsSpan());
 #else
             buffer.DrainTo(new ArraySegment<string>(output));

--- a/BitFaster.Caching.Benchmarks/Lfu/CmSketchFlat.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/CmSketchFlat.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
 #endif
@@ -53,7 +53,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
         /// <returns>The estimated frequency of the value.</returns>
         public int EstimateFrequency(T value)
         {
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET
             return EstimateFrequencyStd(value);
 #else
 
@@ -76,7 +76,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
         /// <param name="value">The value.</param>
         public void Increment(T value)
         {
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET
             IncrementStd(value);
 #else
 
@@ -207,7 +207,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
             return (int)((y >> 16) ^ y);
         }
 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
         private unsafe int EstimateFrequencyAvx(T value)
         {
             int hash = Spread(comparer.GetHashCode(value));

--- a/BitFaster.Caching.Benchmarks/Lfu/CmSketchNoPin.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/CmSketchNoPin.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 
-#if NET6_0_OR_GREATER
+#if NET
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
 using System.Runtime.Intrinsics.X86;
@@ -57,7 +56,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
         /// <returns>The estimated frequency of the value.</returns>
         public int EstimateFrequency(T value)
         {
-#if NET48
+#if NETSTANDARD
             return EstimateFrequencyStd(value);
 #else
 
@@ -67,7 +66,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
             {
                 return EstimateFrequencyAvx(value);
             }
-#if NET6_0_OR_GREATER
+#if NET
             else if (isa.IsArm64Supported)
             {
                 return EstimateFrequencyArm(value);
@@ -86,7 +85,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
         /// <param name="value">The value.</param>
         public void Increment(T value)
         {
-#if NET48
+#if NETSTANDARD
             IncrementStd(value);
 #else
 
@@ -96,7 +95,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
             {
                 IncrementAvx(value);
             }
-#if NET6_0_OR_GREATER
+#if NET
             else if (isa.IsArm64Supported)
             {
                 IncrementArm(value);
@@ -233,7 +232,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
             size = (size - (count0 >> 2)) >> 1;
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         private unsafe int EstimateFrequencyAvx(T value)
         {
             int blockHash = Spread(comparer.GetHashCode(value));
@@ -267,7 +266,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
                     .AsUInt16();
 
                 // set the zeroed high parts of the long value to ushort.Max
-#if NET6_0
+#if NET
                 count = Avx2.Blend(count, Vector128<ushort>.AllBitsSet, 0b10101010);
 #else
                 count = Avx2.Blend(count, Vector128.Create(ushort.MaxValue), 0b10101010);
@@ -333,7 +332,7 @@ namespace BitFaster.Caching.Benchmarks.Lfu
         }
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe void IncrementArm(T value)
         {

--- a/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
@@ -41,7 +41,7 @@ namespace BitFaster.Caching.Benchmarks
         [Benchmark()]
         public long EnvironmentTickCount64()
         {
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             return Environment.TickCount64;
 #else
             return 0;

--- a/BitFaster.Caching.HitRateAnalysis/BitFaster.Caching.HitRateAnalysis.csproj
+++ b/BitFaster.Caching.HitRateAnalysis/BitFaster.Caching.HitRateAnalysis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <RetainVMGarbageCollection>true</RetainVMGarbageCollection>

--- a/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
+++ b/BitFaster.Caching.ThroughputAnalysis/BitFaster.Caching.ThroughputAnalysis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <SignAssembly>False</SignAssembly>
     <Version>2.0.0</Version>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/BitFaster.Caching.UnitTests.Std/BitFaster.Caching.UnitTests.Std.csproj
+++ b/BitFaster.Caching.UnitTests.Std/BitFaster.Caching.UnitTests.Std.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BitFaster.Caching.UnitTests.Std/DurationTests.cs
+++ b/BitFaster.Caching.UnitTests.Std/DurationTests.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.UnitTests.Std
             // On .NET Standard, only windows uses TickCount64
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Duration.SinceEpoch().raw.Should().BeCloseTo(Duration.GetTickCount64(), 15);
+                Duration.SinceEpoch().raw.Should().BeCloseTo(Environment.TickCount64, 15);
             }
             else
             {

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryAsyncCacheTests.cs
@@ -91,8 +91,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.removedItems.First().Key.Should().Be(1);
         }
 
-        // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+// backcompat: remove conditional compile
+#if NET
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -258,8 +258,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             cache.Keys.Count().Should().Be(0);
         }
 
-       // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+// backcompat: remove conditional compile
+#if NET
         [Fact]
         public void WhenRemovedValueIsReturned()
         {

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
@@ -79,8 +79,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.removedItems.First().Key.Should().Be(1);
         }
 
-        // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+// backcompat: remove conditional compile
+#if NET
         [Fact]
         public void WhenRemovedValueIsReturned()
         {

--- a/BitFaster.Caching.UnitTests/BitFaster.Caching.UnitTests.csproj
+++ b/BitFaster.Caching.UnitTests/BitFaster.Caching.UnitTests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>  
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>  
   </PropertyGroup>
 
   <ItemGroup>

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -100,7 +100,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             buffer.DrainTo(output).Should().Be(0);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenBufferContainsItemsDrainArrayTakesItems()
         {

--- a/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
@@ -55,7 +55,7 @@ namespace BitFaster.Caching.UnitTests
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WheUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -155,7 +155,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.testCacheEvents.FireUpdated(1, new AtomicFactory<int, int>(2), new AtomicFactory<int, int>(3));
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             this.updatedItems.First().Key.Should().Be(1);
 #else
             this.updatedItems.Should().BeEmpty();

--- a/BitFaster.Caching.UnitTests/CacheEventsTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheEventsTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 namespace BitFaster.Caching.UnitTests
 {
 // backcompat: remove 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
     public class CacheEventsTests
     {
         [Fact]

--- a/BitFaster.Caching.UnitTests/CacheMetricsTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheMetricsTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace BitFaster.Caching.UnitTests
 {
 // backcompat: remove 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
     public class CacheMetricsTests
     {
         [Fact]

--- a/BitFaster.Caching.UnitTests/CacheTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheTests.cs
@@ -12,7 +12,7 @@ namespace BitFaster.Caching.UnitTests
     public class CacheTests
     {
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenCacheInterfaceDefaultGetOrAddFallback()
         {

--- a/BitFaster.Caching.UnitTests/DurationTests.cs
+++ b/BitFaster.Caching.UnitTests/DurationTests.cs
@@ -22,7 +22,7 @@ namespace BitFaster.Caching.UnitTests
         [Fact]
         public void SinceEpoch()
         {
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 // eps is 1/200 of a second
@@ -36,7 +36,7 @@ namespace BitFaster.Caching.UnitTests
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Duration.SinceEpoch().raw.Should().BeCloseTo(Duration.GetTickCount64(), 15);
+                Duration.SinceEpoch().raw.Should().BeCloseTo(Environment.TickCount, 15);
             }
             else
             {
@@ -50,7 +50,7 @@ namespace BitFaster.Caching.UnitTests
         [Fact]
         public void ToTimeSpan()
         {
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 new Duration(100).ToTimeSpan().Should().BeCloseTo(new TimeSpan(100), TimeSpan.FromMilliseconds(50));
@@ -75,7 +75,7 @@ namespace BitFaster.Caching.UnitTests
         [Fact]
         public void FromTimeSpan()
         {
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw

--- a/BitFaster.Caching.UnitTests/Intrinsics.cs
+++ b/BitFaster.Caching.UnitTests/Intrinsics.cs
@@ -1,7 +1,5 @@
-﻿#if NETCOREAPP3_1_OR_GREATER
+﻿#if NET
 using System.Runtime.Intrinsics.X86;
-#endif
-#if NET6_0_OR_GREATER
 using System.Runtime.Intrinsics.Arm;
 #endif
 
@@ -13,15 +11,9 @@ namespace BitFaster.Caching.UnitTests
     {
         public static void SkipAvxIfNotSupported<I>()
         {
-#if NETCOREAPP3_1_OR_GREATER
-    #if NET6_0_OR_GREATER
+#if NET
             // when we are trying to test Avx2/Arm64, skip the test if it's not supported
             Skip.If(typeof(I) == typeof(DetectIsa) && !(Avx2.IsSupported || AdvSimd.Arm64.IsSupported));
-    #else
-            // when we are trying to test Avx2, skip the test if it's not supported
-            Skip.If(typeof(I) == typeof(DetectIsa) && !Avx2.IsSupported);
-    #endif
-
 #else
             Skip.If(true);
 #endif

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuCoreTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuCoreTests.cs
@@ -41,7 +41,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             valueFactory.timesCalled.Should().Be(1);
             result1.Should().Be(result2);
         }
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenKeyIsRequestedWithArgItIsCreatedAndCached()
         {
@@ -63,7 +63,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             result1.Should().Be(result2);
         }
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public async Task WhenKeyIsRequestedWithArgItIsCreatedAndCachedAsync()
         {
@@ -105,7 +105,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             lfu.TryGet(1, out _).Should().BeFalse();
         }
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenKeyExistsTryRemoveReturnsValue()
         {

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -477,7 +477,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenWriteBufferIsFullUpdatesAreDropped()
         {

--- a/BitFaster.Caching.UnitTests/Lfu/TimerWheelTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/TimerWheelTests.cs
@@ -122,7 +122,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             this.lfuNodeList.Count.Should().Be(0);
         }
 
-#if NET6_0_OR_GREATER
+#if NET
         [Theory]
         [MemberData(nameof(ClockData))]
         public void WhenAdvanceBackwardsNothingIsEvicted(long clock)

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -429,7 +429,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenKeyExistsTryUpdateIncrementsUpdateCount()
         {

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -733,7 +733,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenKeyExistsTryUpdateIncrementsUpdateCount()
         {
@@ -812,7 +812,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenItemExistsAddOrUpdateFiresUpdateEvent()
         {

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP3_1_OR_GREATER
+﻿#if NET
 
 using FluentAssertions;
 using BitFaster.Caching.Lru;

--- a/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
@@ -148,7 +148,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
 // backcompat: remove 
-#if NETCOREAPP3_1_OR_GREATER
+#if NET
         [Fact]
         public void WhenInterfaceDefaultItemUpdatedRegisteredNoOp()
         {

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -9,7 +9,7 @@ using BitFaster.Caching.UnitTests.Retry;
 namespace BitFaster.Caching.UnitTests.Lru
 {
 // backcompat: remove conditional compile
-#if !NETCOREAPP3_1_OR_GREATER
+#if !NET
     public class TlruStopwatchPolicyTests
     {
         private readonly TLruLongTicksPolicy<int, int> policy = new TLruLongTicksPolicy<int, int>(TimeSpan.FromSeconds(10));

--- a/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
@@ -59,7 +59,7 @@ namespace BitFaster.Caching.UnitTests
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -83,7 +83,7 @@ namespace BitFaster.Caching.UnitTests
         }
 
         // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public async Task WhenKeyDoesNotExistGetOrAddArgAddsValueWithArg()
         {

--- a/BitFaster.Caching.UnitTests/ScopedAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedAsyncCacheTests.cs
@@ -53,7 +53,7 @@ namespace BitFaster.Caching.UnitTests
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public async Task GetOrAddAsyncArgDisposedScopeThrows()
         {

--- a/BitFaster.Caching.UnitTests/ScopedCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTestBase.cs
@@ -58,7 +58,7 @@ namespace BitFaster.Caching.UnitTests
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -82,7 +82,7 @@ namespace BitFaster.Caching.UnitTests
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenKeyDoesNotExistGetOrAddArgAddsValueWithArg()
         {

--- a/BitFaster.Caching/AssemblyInfo.cs
+++ b/BitFaster.Caching/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 
-#if NET6_0_OR_GREATER
+#if NET
 [module: System.Runtime.CompilerServices.SkipLocalsInit]
 #endif
 

--- a/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryAsyncCache.cs
@@ -113,7 +113,7 @@ namespace BitFaster.Caching.Atomic
         }
 
         // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         ///<inheritdoc/>
         ///<remarks>
         ///If the value factory is still executing, returns false.

--- a/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
@@ -107,7 +107,7 @@ namespace BitFaster.Caching.Atomic
         }
 
         // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         ///<inheritdoc/>
         ///<remarks>
         ///If the value factory is still executing, returns false.

--- a/BitFaster.Caching/Atomic/ConcurrentDictionaryExtensions.cs
+++ b/BitFaster.Caching/Atomic/ConcurrentDictionaryExtensions.cs
@@ -124,7 +124,7 @@ namespace BitFaster.Caching.Atomic
              where K : notnull
         {
             var kvp = new KeyValuePair<K, AtomicFactory<K, V>>(item.Key, new AtomicFactory<K, V>(item.Value));
-#if NET6_0_OR_GREATER
+#if NET
             return dictionary.TryRemove(kvp);
 #else
             // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
@@ -142,7 +142,7 @@ namespace BitFaster.Caching.Atomic
              where K : notnull
         {
             var kvp = new KeyValuePair<K, AsyncAtomicFactory<K, V>>(item.Key, new AsyncAtomicFactory<K, V>(item.Value));
-#if NET6_0_OR_GREATER
+#if NET
             return dictionary.TryRemove(kvp);
 #else
             // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
-    <LangVersion>11.0</LangVersion>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <Authors>Alex Peck</Authors>
     <Company />
     <Product>BitFaster.Caching</Product>

--- a/BitFaster.Caching/BitOps.cs
+++ b/BitFaster.Caching/BitOps.cs
@@ -34,7 +34,7 @@ namespace BitFaster.Caching
         /// <returns>Smallest power of two greater than or equal to x.</returns>
         public static uint CeilingPowerOfTwo(uint x)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD
             // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
             --x;
             x |= x >> 1;
@@ -55,7 +55,7 @@ namespace BitFaster.Caching
         /// <returns>Smallest power of two greater than or equal to x.</returns>
         internal static ulong CeilingPowerOfTwo(ulong x)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD
             // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
             --x;
             x |= x >> 1;
@@ -87,7 +87,7 @@ namespace BitFaster.Caching
         /// <returns>The number of trailing zero bits.</returns>
         internal static int TrailingZeroCount(ulong x)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD
             // https://codereview.stackexchange.com/questions/288007/c-bit-utility-functions-popcount-trailing-zeros-count-reverse-all-bits
             return BitCount(~x & (x - 1));
 #else
@@ -112,7 +112,7 @@ namespace BitFaster.Caching
         /// <returns>The number of 1 bits.</returns>
         public static int BitCount(uint x)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD
             var count = 0;
             while (x != 0)
             {
@@ -143,7 +143,7 @@ namespace BitFaster.Caching
         /// <returns>The number of 1 bits.</returns>
         public static int BitCount(ulong x)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD
             var count = 0;
             while (x != 0)
             {

--- a/BitFaster.Caching/Buffers/ArrayExtensions.cs
+++ b/BitFaster.Caching/Buffers/ArrayExtensions.cs
@@ -6,7 +6,7 @@ namespace BitFaster.Caching.Buffers
     // Used to avoid conditional compilation to work with Span<T> and ArraySegment<T>.
     internal static class ArrayExtensions
     {
-#if NETSTANDARD2_0
+#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T[] AsSpanOrArray<T>(this T[] array)
         { 

--- a/BitFaster.Caching/CacheEventProxyBase.cs
+++ b/BitFaster.Caching/CacheEventProxyBase.cs
@@ -62,7 +62,7 @@ namespace BitFaster.Caching
             itemUpdatedProxy += value;
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             events.ItemUpdated += OnItemUpdated;
 #endif
         }
@@ -72,7 +72,7 @@ namespace BitFaster.Caching
             this.itemUpdatedProxy -= value;
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             if (this.itemUpdatedProxy == null)
             {
                 this.events.ItemUpdated -= OnItemUpdated;

--- a/BitFaster.Caching/Duration.cs
+++ b/BitFaster.Caching/Duration.cs
@@ -26,15 +26,6 @@ namespace BitFaster.Caching
 
         internal static readonly Duration Zero = new Duration(0);
 
-#if NETCOREAPP3_0_OR_GREATER
-        private static readonly bool IsMacOS = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-#else
-        private static readonly bool IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-
-        [DllImport("kernel32")]
-        internal static extern long GetTickCount64();
-#endif
-
         internal Duration(long raw)
         { 
             this.raw = raw; 
@@ -47,25 +38,7 @@ namespace BitFaster.Caching
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Duration SinceEpoch()
         {
-#if NETCOREAPP3_0_OR_GREATER
-            if (IsMacOS)
-            {
-                return new Duration(Stopwatch.GetTimestamp());
-            }
-            else
-            {
-                return new Duration(Environment.TickCount64);
-            }
-#else
-            if (IsWindows)
-            {
-                return new Duration(GetTickCount64());
-            }
-            else
-            {
-                return new Duration(Stopwatch.GetTimestamp());
-            }
-#endif
+            return new Duration(Stopwatch.GetTimestamp());
         }
 
         /// <summary>
@@ -75,25 +48,7 @@ namespace BitFaster.Caching
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public TimeSpan ToTimeSpan()
         {
-#if NETCOREAPP3_0_OR_GREATER
-            if (IsMacOS)
-            {
-                return StopwatchTickConverter.FromTicks(raw);
-            }
-            else
-            {
-                return TimeSpan.FromMilliseconds(raw);
-            }
-#else
-            if (IsWindows)
-            {
-                return TimeSpan.FromMilliseconds(raw);
-            }
-            else
-            {
-                return StopwatchTickConverter.FromTicks(raw);
-            }
-#endif
+            return StopwatchTickConverter.FromTicks(raw);
         }
 
         /// <summary>
@@ -104,25 +59,7 @@ namespace BitFaster.Caching
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Duration FromTimeSpan(TimeSpan timeSpan)
         {
-#if NETCOREAPP3_0_OR_GREATER
-            if (IsMacOS)
-            {
-                return new Duration(StopwatchTickConverter.ToTicks(timeSpan));
-            }
-            else
-            {
-                return new Duration((long)timeSpan.TotalMilliseconds);
-            }
-#else
-            if (IsWindows)
-            {
-                return new Duration((long)timeSpan.TotalMilliseconds);
-            }
-            else
-            {
-                return new Duration(StopwatchTickConverter.ToTicks(timeSpan));
-            }
-#endif
+            return new Duration(StopwatchTickConverter.ToTicks(timeSpan));
         }
 
         /// <summary>

--- a/BitFaster.Caching/IAsyncCache.cs
+++ b/BitFaster.Caching/IAsyncCache.cs
@@ -54,8 +54,8 @@ namespace BitFaster.Caching
         /// <returns>A task that represents the asynchronous GetOrAdd operation.</returns>
         ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory);
 
-        // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+// backcompat: remove conditional compile
+#if !NETSTANDARD
         /// <summary>
         /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
         /// existing value if the key already exists.

--- a/BitFaster.Caching/IAsyncCacheExt.cs
+++ b/BitFaster.Caching/IAsyncCacheExt.cs
@@ -17,7 +17,7 @@ namespace BitFaster.Caching
         // certain build targets, for other build targets we will define them within this new interface to avoid breaking
         // existing clients.
 // backcompat: remove conditional compile
-#if !NETCOREAPP3_0_OR_GREATER
+#if NETSTANDARD
         /// <summary>
         /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
         /// existing value if the key already exists.

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -54,8 +54,8 @@ namespace BitFaster.Caching
         /// in the cache, or the new value if the key was not in the cache.</returns>
         V GetOrAdd(K key, Func<K, V> valueFactory);
 
-        // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+// backcompat: remove conditional compile
+#if NET
         /// <summary>
         /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
         /// existing value if the key already exists.

--- a/BitFaster.Caching/ICacheEvents.cs
+++ b/BitFaster.Caching/ICacheEvents.cs
@@ -13,7 +13,7 @@ namespace BitFaster.Caching
         event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         /// <summary>
         /// Occurs when an item is updated.
         /// </summary>

--- a/BitFaster.Caching/ICacheExt.cs
+++ b/BitFaster.Caching/ICacheExt.cs
@@ -16,7 +16,7 @@ namespace BitFaster.Caching
         // certain build targets, for other build targets we will define them within this new interface to avoid breaking
         // existing clients.
 // backcompat: remove conditional compile
-#if !NETCOREAPP3_0_OR_GREATER
+#if !NET
         /// <summary>
         /// Adds a key/value pair to the cache if the key does not already exist. Returns the new value, or the 
         /// existing value if the key already exists.

--- a/BitFaster.Caching/ICacheMetrics.cs
+++ b/BitFaster.Caching/ICacheMetrics.cs
@@ -33,7 +33,7 @@ namespace BitFaster.Caching
         long Evicted { get; }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         /// <summary>
         /// Gets the total number of updated items.
         /// </summary>

--- a/BitFaster.Caching/IScoped.cs
+++ b/BitFaster.Caching/IScoped.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BitFaster.Caching
 {

--- a/BitFaster.Caching/IScopedAsyncCache.cs
+++ b/BitFaster.Caching/IScopedAsyncCache.cs
@@ -59,8 +59,8 @@ namespace BitFaster.Caching
         /// <returns>A task that represents the asynchronous ScopedGetOrAdd operation.</returns>
         ValueTask<Lifetime<V>> ScopedGetOrAddAsync(K key, Func<K, Task<Scoped<V>>> valueFactory);
 
-        // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+// backcompat: remove conditional compile
+#if !NETSTANDARD
         /// <summary>
         /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
         /// the new value, or the existing value if the key already exists.

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -60,8 +60,8 @@ namespace BitFaster.Caching
         /// the cache.</returns>
         Lifetime<V> ScopedGetOrAdd(K key, Func<K, Scoped<V>> valueFactory);
 
-        // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+// backcompat: remove conditional compile
+#if !NETSTANDARD
         /// <summary>
         /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
         /// the new value, or the existing value if the key already exists.

--- a/BitFaster.Caching/Intrinsics.cs
+++ b/BitFaster.Caching/Intrinsics.cs
@@ -1,8 +1,5 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NET
 using System.Runtime.Intrinsics.X86;
-#endif
-
-#if NET6_0
 using System.Runtime.Intrinsics.Arm;
 #endif
 
@@ -18,7 +15,7 @@ namespace BitFaster.Caching
         /// </summary>
         bool IsAvx2Supported { get; }
 
-#if NET6_0_OR_GREATER
+#if NET
         /// <summary>
         /// Gets a value indicating whether Arm64 is supported.
         /// </summary>
@@ -31,15 +28,15 @@ namespace BitFaster.Caching
     /// </summary>
     public readonly struct DetectIsa : IsaProbe
     {
-#if NETSTANDARD2_0
-        /// <inheritdoc/>
-        public bool IsAvx2Supported => false;
-#else
+#if NET
         /// <inheritdoc/>
         public bool IsAvx2Supported => Avx2.IsSupported;
+#else
+        /// <inheritdoc/>
+        public bool IsAvx2Supported => false;
 #endif
 
-#if NET6_0_OR_GREATER
+#if NET
         /// <inheritdoc/>
         public bool IsArm64Supported => AdvSimd.Arm64.IsSupported;
 #else

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -166,7 +166,7 @@ namespace BitFaster.Caching.Lfu
                 TakeCandidatesInLruOrder(this.windowLru, candidates, itemCount);
             }
 
-#if NET6_0_OR_GREATER
+#if NET
             foreach (var candidate in CollectionsMarshal.AsSpan(candidates))
 #else
             foreach (var candidate in candidates)
@@ -301,7 +301,7 @@ namespace BitFaster.Caching.Lfu
         [MethodImpl(MethodImplOptions.NoInlining)]
         void TryRemove(N node)
         {
-#if NET6_0_OR_GREATER
+#if NET
                 if (this.dictionary.TryRemove(new KeyValuePair<K, N>(node.Key, node)))
 #else
                 // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
@@ -323,7 +323,7 @@ namespace BitFaster.Caching.Lfu
                     {
                         var kvp = new KeyValuePair<K, N>(item.Key, node);
 
-#if NET6_0_OR_GREATER
+#if NET
                         if (this.dictionary.TryRemove(kvp))
 #else
                         // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
@@ -821,7 +821,7 @@ namespace BitFaster.Caching.Lfu
             // This handles the case where the same key exists in the write buffer both
             // as added and removed. Remove via KVP ensures we don't remove added nodes.
             var kvp = new KeyValuePair<K, N>(evictee.Key, (N)evictee);
-#if NET6_0_OR_GREATER
+#if NET
             this.dictionary.TryRemove(kvp);
 #else
             ((ICollection<KeyValuePair<K, N>>)this.dictionary).Remove(kvp);

--- a/BitFaster.Caching/Lru/ClassicLru.cs
+++ b/BitFaster.Caching/Lru/ClassicLru.cs
@@ -254,7 +254,7 @@ namespace BitFaster.Caching.Lru
                 {
                     var kvp = new KeyValuePair<K, LinkedListNode<LruItem>>(item.Key, node);
 
-#if NET6_0_OR_GREATER
+#if NET
                     if (this.dictionary.TryRemove(kvp))
 #else
                     // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -313,8 +313,8 @@ namespace BitFaster.Caching.Lru
                     if (EqualityComparer<V>.Default.Equals(existing.Value, item.Value))
                     {
                         var kvp = new KeyValuePair<K, I>(item.Key, existing);
-#if NET6_0_OR_GREATER
-                    if (this.dictionary.TryRemove(kvp))
+#if NET
+                        if (this.dictionary.TryRemove(kvp))
 #else
                         // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
                         if (((ICollection<KeyValuePair<K, I>>)this.dictionary).Remove(kvp))
@@ -391,7 +391,7 @@ namespace BitFaster.Caching.Lru
 
                         this.itemPolicy.Update(existing);
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
                         this.telemetryPolicy.OnItemUpdated(existing.Key, oldValue, existing.Value);
 #endif
                         Disposer<V>.Dispose(oldValue);
@@ -784,7 +784,7 @@ namespace BitFaster.Caching.Lru
 
                     var kvp = new KeyValuePair<K, I>(item.Key, item);
 
-#if NET6_0_OR_GREATER
+#if NET
                     if (this.dictionary.TryRemove(kvp))
 #else
                     // https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
@@ -858,7 +858,7 @@ namespace BitFaster.Caching.Lru
         // heap, which slows down the policies with hit counter logic in benchmarks. Likely
         // this approach keeps the structs data members in the same CPU cache line as the LRU.
         // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [DebuggerDisplay("Hit = {Hits}, Miss = {Misses}, Upd = {Updated}, Evict = {Evicted}")]
 #else
         [DebuggerDisplay("Hit = {Hits}, Miss = {Misses}, Evict = {Evicted}")]
@@ -883,7 +883,7 @@ namespace BitFaster.Caching.Lru
             public long Evicted => lru.telemetryPolicy.Evicted;
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             public long Updated => lru.telemetryPolicy.Updated;
 #endif
             public int Capacity => lru.Capacity;
@@ -897,7 +897,7 @@ namespace BitFaster.Caching.Lru
             }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
             public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
             {
                 add { this.lru.telemetryPolicy.ItemUpdated += value; }

--- a/BitFaster.Caching/Lru/ITelemetryPolicy.cs
+++ b/BitFaster.Caching/Lru/ITelemetryPolicy.cs
@@ -28,7 +28,7 @@ namespace BitFaster.Caching.Lru
         void OnItemRemoved(K key, V value, ItemRemovedReason reason);
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         /// <summary>
         /// Register the update of an item.
         /// </summary>

--- a/BitFaster.Caching/NullableAttributes.cs
+++ b/BitFaster.Caching/NullableAttributes.cs
@@ -8,7 +8,7 @@
 
 namespace System.Diagnostics.CodeAnalysis
 {
-#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+#if NETSTANDARD2_0
     /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
     [ExcludeFromCodeCoverage]
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
@@ -144,9 +144,7 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>Gets the condition parameter value.</summary>
         public bool ParameterValue { get; }
     }
-#endif
 
-#if NETSTANDARD2_0 ||  NETCOREAPP2_0 ||  NETCOREAPP2_1 ||  NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET45 || NET451 || NET452 || NET46 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
     /// <summary>Specifies that the method or property will ensure that the listed field and property members have not-null values.</summary>
     [ExcludeFromCodeCoverage]
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]

--- a/BitFaster.Caching/Padding.cs
+++ b/BitFaster.Caching/Padding.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BitFaster.Caching
+﻿namespace BitFaster.Caching
 {
     internal class Padding
     {

--- a/BitFaster.Caching/ScopedAsyncCache.cs
+++ b/BitFaster.Caching/ScopedAsyncCache.cs
@@ -87,7 +87,7 @@ namespace BitFaster.Caching
         }
 
 // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         /// <summary>
         /// Adds a key/scoped value pair to the cache if the key does not already exist. Returns a lifetime for either 
         /// the new value, or the existing value if the key already exists.


### PR DESCRIPTION
This pull request removes unsupported target frameworks (.NET Core, .NET 6.0) and simplifies conditional compilation so it supports `NETSTANDARD` (.NET Standard 2.0) and `NET` (.NET 8.0 and .NET 9.0).