### PR TITLE
Eagerly purge deleted items from internal LRU queues

### DIFF
--- a/BitFaster.Caching.UnitTests/Lru/DiscretePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/DiscretePolicyTests.cs
@@ -114,48 +114,60 @@ namespace BitFaster.Caching.UnitTests.Lru
             this.policy.CanDiscard().Should().BeTrue();
         }
 
-
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteHot(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteHot(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteHot(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteWarm(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteWarm(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteWarm(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Remove)]
-        public void RouteCold(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Remove)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteCold(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteCold(item).Should().Be(expectedDestination);
         }
 
-        private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)
+        private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool wasRemoved, bool isExpired)
         {
             var item = this.policy.CreateItem(1, 2);
 
             item.WasAccessed = wasAccessed;
+            item.WasRemoved = wasRemoved;
 
             if (isExpired)
             {

--- a/BitFaster.Caching.UnitTests/Lru/LruPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/LruPolicyTests.cs
@@ -69,40 +69,47 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Theory]
-        [InlineData(true, ItemDestination.Warm)]
-        [InlineData(false, ItemDestination.Cold)]
-        public void RouteHot(bool wasAccessed, ItemDestination expectedDestination)
+        [InlineData(true, false, ItemDestination.Warm)]
+        [InlineData(false, false, ItemDestination.Cold)]
+        [InlineData(false, true, ItemDestination.Remove)]
+        [InlineData(true, true, ItemDestination.Remove)]
+        public void RouteHot(bool wasAccessed, bool wasRemoved, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed);
+            var item = CreateItem(wasAccessed, wasRemoved);
 
             this.policy.RouteHot(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(true, ItemDestination.Warm)]
-        [InlineData(false, ItemDestination.Cold)]
-        public void RouteWarm(bool wasAccessed, ItemDestination expectedDestination)
+        [InlineData(true, false, ItemDestination.Warm)]
+        [InlineData(false, false, ItemDestination.Cold)]
+        [InlineData(true, true, ItemDestination.Remove)]
+        [InlineData(false, true, ItemDestination.Remove)]
+        public void RouteWarm(bool wasAccessed, bool wasRemoved, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed);
+            var item = CreateItem(wasAccessed, wasRemoved);
 
             this.policy.RouteWarm(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(true, ItemDestination.Warm)]
-        [InlineData(false, ItemDestination.Remove)]
-        public void RouteCold(bool wasAccessed, ItemDestination expectedDestination)
+        [InlineData(true, false, ItemDestination.Warm)]
+        [InlineData(false, false, ItemDestination.Remove)]
+        [InlineData(true, true, ItemDestination.Remove)]
+        [InlineData(false, true, ItemDestination.Remove)]
+        public void RouteCold(bool wasAccessed, bool wasRemoved, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed);
+            var item = CreateItem(wasAccessed, wasRemoved);
 
             this.policy.RouteCold(item).Should().Be(expectedDestination);
         }
 
-        private LruItem<int, int> CreateItem(bool wasAccessed)
+        private LruItem<int, int> CreateItem(bool wasAccessed, bool wasRemoved)
         {
             var item = this.policy.CreateItem(1, 2);
 
             item.WasAccessed = wasAccessed;
+            item.WasRemoved = wasRemoved;
 
             return item;
         }

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -108,46 +108,59 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteHot(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteHot(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteHot(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteWarm(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteWarm(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteWarm(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Remove)]
-        public void RouteCold(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Remove)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteCold(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteCold(item).Should().Be(expectedDestination);
         }
 
-        private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)
+        private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool wasRemoved, bool isExpired)
         {
             var item = this.policy.CreateItem(1, 2);
 
             item.WasAccessed = wasAccessed;
+            item.WasRemoved = wasRemoved;
 
             if (isExpired)
             {

--- a/BitFaster.Caching.UnitTests/Lru/TlruDateTimePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruDateTimePolicyTests.cs
@@ -86,46 +86,59 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteHot(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteHot(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteHot(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteWarm(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteWarm(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteWarm(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Remove)]
-        public void RouteCold(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Remove)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteCold(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteCold(item).Should().Be(expectedDestination);
         }
 
-        private TimeStampedLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)
+        private TimeStampedLruItem<int, int> CreateItem(bool wasAccessed, bool wasRemoved, bool isExpired)
         {
             var item = this.policy.CreateItem(1, 2);
 
             item.WasAccessed = wasAccessed;
+            item.WasRemoved = wasRemoved;
 
             if (isExpired)
             {

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -110,46 +110,59 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteHot(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteHot(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteHot(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteWarm(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteWarm(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteWarm(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Remove)]
-        public void RouteCold(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Remove)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteCold(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteCold(item).Should().Be(expectedDestination);
         }
 
-        private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)
+        private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool wasRemoved, bool isExpired)
         {
             var item = this.policy.CreateItem(1, 2);
 
             item.WasAccessed = wasAccessed;
+            item.WasRemoved = wasRemoved;
 
             if (isExpired)
             {

--- a/BitFaster.Caching.UnitTests/Lru/TlruTicksPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruTicksPolicyTests.cs
@@ -87,46 +87,59 @@ namespace BitFaster.Caching.UnitTests.Lru
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteHot(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteHot(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteHot(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Cold)]
-        public void RouteWarm(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Cold)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteWarm(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteWarm(item).Should().Be(expectedDestination);
         }
 
         [Theory]
-        [InlineData(false, true, ItemDestination.Remove)]
-        [InlineData(true, true, ItemDestination.Remove)]
-        [InlineData(true, false, ItemDestination.Warm)]
-        [InlineData(false, false, ItemDestination.Remove)]
-        public void RouteCold(bool wasAccessed, bool isExpired, ItemDestination expectedDestination)
+        [InlineData(false, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, true, ItemDestination.Remove)]
+        [InlineData(true, false, false, ItemDestination.Warm)]
+        [InlineData(false, false, false, ItemDestination.Remove)]
+        [InlineData(false, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, true, ItemDestination.Remove)]
+        [InlineData(true, true, false, ItemDestination.Remove)]
+        [InlineData(false, true, false, ItemDestination.Remove)]
+        public void RouteCold(bool wasAccessed, bool wasRemoved, bool isExpired, ItemDestination expectedDestination)
         {
-            var item = CreateItem(wasAccessed, isExpired);
+            var item = CreateItem(wasAccessed, wasRemoved, isExpired);
 
             this.policy.RouteCold(item).Should().Be(expectedDestination);
         }
 
-        private TickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)
+        private TickCountLruItem<int, int> CreateItem(bool wasAccessed, bool wasRemoved, bool isExpired)
         {
             var item = this.policy.CreateItem(1, 2);
 
             item.WasAccessed = wasAccessed;
+            item.WasRemoved = wasRemoved;
 
             if (isExpired)
             {

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -624,6 +624,12 @@ namespace BitFaster.Caching.Lru
 
                 if (this.hotQueue.TryDequeue(out var item))
                 {
+                    // special case: removed during warmup
+                    if (item.WasRemoved)
+                    {
+                        return;
+                    }
+
                     int count = this.Move(item, ItemDestination.Warm, ItemRemovedReason.Evicted);
 
                     // if warm is now full, overflow to cold and mark as warm

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -501,7 +501,7 @@ namespace BitFaster.Caching.Lru
                     {
                         if (q.TryDequeue(out var item))
                         {
-                            if (this.itemPolicy.ShouldDiscard(item))
+                            if (this.itemPolicy.ShouldDiscard(item) | item.WasRemoved)
                             {
                                 Interlocked.Decrement(ref queueCounter);
                                 this.Move(item, ItemDestination.Remove, ItemRemovedReason.Trimmed);

--- a/BitFaster.Caching/Lru/DiscretePolicy.cs
+++ b/BitFaster.Caching/Lru/DiscretePolicy.cs
@@ -72,7 +72,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteHot(LongTickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }
@@ -89,7 +89,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteWarm(LongTickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }
@@ -106,7 +106,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteCold(LongTickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }

--- a/BitFaster.Caching/Lru/LruPolicy.cs
+++ b/BitFaster.Caching/Lru/LruPolicy.cs
@@ -84,7 +84,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteCold(LruItem<K, V> item)
         {
-            if (item.WasAccessed)
+            if (item.WasAccessed & !item.WasRemoved)
             {
                 return ItemDestination.Warm;
             }

--- a/BitFaster.Caching/Lru/LruPolicy.cs
+++ b/BitFaster.Caching/Lru/LruPolicy.cs
@@ -50,6 +50,11 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteHot(LruItem<K, V> item)
         {
+            if (item.WasRemoved)
+            {
+                return ItemDestination.Remove;
+            }
+
             if (item.WasAccessed)
             {
                 return ItemDestination.Warm;
@@ -62,6 +67,11 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteWarm(LruItem<K, V> item)
         {
+            if (item.WasRemoved)
+            {
+                return ItemDestination.Remove;
+            }
+
             if (item.WasAccessed)
             {
                 return ItemDestination.Warm;

--- a/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TLruLongTicksPolicy.cs
@@ -71,7 +71,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteHot(LongTickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }
@@ -88,7 +88,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteWarm(LongTickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }
@@ -105,7 +105,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteCold(LongTickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }

--- a/BitFaster.Caching/Lru/TlruDateTimePolicy.cs
+++ b/BitFaster.Caching/Lru/TlruDateTimePolicy.cs
@@ -68,7 +68,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteHot(TimeStampedLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }
@@ -85,7 +85,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteWarm(TimeStampedLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }
@@ -102,7 +102,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteCold(TimeStampedLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }

--- a/BitFaster.Caching/Lru/TlruTicksPolicy.cs
+++ b/BitFaster.Caching/Lru/TlruTicksPolicy.cs
@@ -73,7 +73,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteHot(TickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }
@@ -90,7 +90,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteWarm(TickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }
@@ -107,7 +107,7 @@ namespace BitFaster.Caching.Lru
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ItemDestination RouteCold(TickCountLruItem<K, V> item)
         {
-            if (this.ShouldDiscard(item))
+            if (this.ShouldDiscard(item) | item.WasRemoved)
             {
                 return ItemDestination.Remove;
             }


### PR DESCRIPTION
When items are deleted, they remain in the internal queues until fully cycled out of cold. This is because the cycle/route methods do not inspect `WasDeleted`. Instead, purge them as items transition from queue to queue as part of cycle.

This change doesn't trigger double dispose/event due to the implementation of the `Move` method first attempting to remove the item from the dictionary:


```cs
        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        private int Move(I item, ItemDestination where, ItemRemovedReason removedReason)
        {
            item.WasAccessed = false;

            switch (where)
            {
                case ItemDestination.Warm:
                    this.warmQueue.Enqueue(item);
                    return Interlocked.Increment(ref this.counter.warm);
                case ItemDestination.Cold:
                    this.coldQueue.Enqueue(item);
                    return Interlocked.Increment(ref this.counter.cold);
                case ItemDestination.Remove:

                    var kvp = new KeyValuePair<K, I>(item.Key, item);

                    // when the item is already removed, skip event/metric counting
                    if (this.dictionary.TryRemove(kvp))
                    {
                        OnRemove(item.Key, item, removedReason);
                    }
                    break;
            }

            return 0;
        }
```

Scenarios covered:

- Item removed from hot during warmup
- Item removed from hot after warmup
- Item removed from warm during warmup
- Item removed from warm after warmp
- Item removed from cold after warmp
- Item removed then call TrimExpired
- Item removed then call Trim

Found two other bugs in Trim logic:
- TrimExpired missed the lock to make it thread-safe
- When trimmed item is in cold queue, we always trimmed an additional item from warm, which is incorrect.
