### PR TITLE
Migrate from FluentAssertions to Shouldly

### DIFF
--- a/BitFaster.Caching.UnitTests.Std/BitFaster.Caching.UnitTests.Std.csproj
+++ b/BitFaster.Caching.UnitTests.Std/BitFaster.Caching.UnitTests.Std.csproj
@@ -10,16 +10,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="ObjectLayoutInspector" Version="0.1.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BitFaster.Caching.UnitTests.Std/DurationTests.cs
+++ b/BitFaster.Caching.UnitTests.Std/DurationTests.cs
@@ -2,9 +2,9 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using Shouldly;
 
 namespace BitFaster.Caching.UnitTests.Std
 {
@@ -25,13 +25,11 @@ namespace BitFaster.Caching.UnitTests.Std
             // On .NET Standard, only windows uses TickCount64
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Duration.SinceEpoch().raw.Should().BeCloseTo(Duration.GetTickCount64(), 15);
+                Duration.SinceEpoch().raw.ShouldBe(Duration.GetTickCount64());
             }
             else
             {
-                // eps is 1/200 of a second
-                ulong eps = (ulong)(Stopwatch.Frequency / 200);
-                Duration.SinceEpoch().raw.Should().BeCloseTo(Stopwatch.GetTimestamp(), eps);
+                Duration.SinceEpoch().raw.ShouldBe(Stopwatch.GetTimestamp());
             }
         }
 
@@ -41,12 +39,12 @@ namespace BitFaster.Caching.UnitTests.Std
             // On .NET Standard, only windows uses TickCount64
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                new Duration(1000).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(10));
+                new Duration(1000).ToTimeSpan().ShouldBe(TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(10));
             }
             else
             {
                 // for Stopwatch.GetTimestamp() this is number of ticks
-                new Duration(1 * Stopwatch.Frequency).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10));
+                new Duration(1 * Stopwatch.Frequency).ToTimeSpan().ShouldBe(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10));
             }  
         }
 
@@ -57,12 +55,12 @@ namespace BitFaster.Caching.UnitTests.Std
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
-                    .Should().Be((long)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                    .ShouldBe((long)TimeSpan.FromSeconds(1).TotalMilliseconds);
             }
             else
             {
                 Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
-                .Should().Be(Stopwatch.Frequency);
+                .ShouldBe(Stopwatch.Frequency);
             } 
         }
 

--- a/BitFaster.Caching.UnitTests/Atomic/AsyncAtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AsyncAtomicFactoryTests.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Atomic
@@ -14,8 +14,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var a = new AsyncAtomicFactory<int, int>();
 
-            a.IsValueCreated.Should().BeFalse();
-            a.ValueIfCreated.Should().Be(0);
+            a.IsValueCreated.ShouldBeFalse();
+            a.ValueIfCreated.ShouldBe(0);
         }
 
         [Fact]
@@ -23,28 +23,28 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var a = new AsyncAtomicFactory<int, int>(1);
 
-            a.ValueIfCreated.Should().Be(1);
-            a.IsValueCreated.Should().BeTrue();
+            a.ValueIfCreated.ShouldBe(1);
+            a.IsValueCreated.ShouldBeTrue();
         }
 
         [Fact]
         public async Task WhenValueCreatedValueReturned()
         {
             var a = new AsyncAtomicFactory<int, int>();
-            (await a.GetValueAsync(1, k => Task.FromResult(2))).Should().Be(2);
+            (await a.GetValueAsync(1, k => Task.FromResult(2))).ShouldBe(2);
 
-            a.ValueIfCreated.Should().Be(2);
-            a.IsValueCreated.Should().BeTrue();
+            a.ValueIfCreated.ShouldBe(2);
+            a.IsValueCreated.ShouldBeTrue();
         }
 
         [Fact]
         public async Task WhenValueCreatedWithArgValueReturned()
         {
             var a = new AsyncAtomicFactory<int, int>();
-            (await a.GetValueAsync(1, (k, a) => Task.FromResult(k + a), 7)).Should().Be(8);
+            (await a.GetValueAsync(1, (k, a) => Task.FromResult(k + a), 7)).ShouldBe(8);
 
-            a.ValueIfCreated.Should().Be(8);
-            a.IsValueCreated.Should().BeTrue();
+            a.ValueIfCreated.ShouldBe(8);
+            a.IsValueCreated.ShouldBeTrue();
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var a = new AsyncAtomicFactory<int, int>();
             await a.GetValueAsync(1, k => Task.FromResult(2));
-            (await a.GetValueAsync(1, k => Task.FromResult(3))).Should().Be(2);
+            (await a.GetValueAsync(1, k => Task.FromResult(3))).ShouldBe(2);
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var a = new AsyncAtomicFactory<int, int>();
             await a.GetValueAsync(1, (k, a) => Task.FromResult(k + a), 7);
-            (await a.GetValueAsync(1, (k, a) => Task.FromResult(k + a), 9)).Should().Be(8);
+            (await a.GetValueAsync(1, (k, a) => Task.FromResult(k + a), 9)).ShouldBe(8);
         }
 
         [Fact]
@@ -70,9 +70,9 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             Func<Task> getOrAdd = async () => { await a.GetValueAsync(1, k => throw new ArithmeticException()); };
 
-            await getOrAdd.Should().ThrowAsync<ArithmeticException>();
+            var ex = await getOrAdd.ShouldThrowAsync<ArithmeticException>();;
 
-            (await a.GetValueAsync(1, k => Task.FromResult(3))).Should().Be(3);
+            (await a.GetValueAsync(1, k => Task.FromResult(3))).ShouldBe(3);
         }
 
         [Fact]
@@ -108,10 +108,10 @@ namespace BitFaster.Caching.UnitTests.Atomic
             await enter.Task;
             resume.SetResult(true);
 
-            (await first).Should().Be(result);
-            (await second).Should().Be(result);
+            (await first).ShouldBe(result);
+            (await second).ShouldBe(result);
 
-            winnerCount.Should().Be(1);
+            winnerCount.ShouldBe(1);
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             new AsyncAtomicFactory<int, int>()
                 .GetHashCode()
-                .Should().Be(0);
+                .ShouldBe(0);
         }
 
         [Fact]
@@ -127,7 +127,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             new AsyncAtomicFactory<int, int>(1)
                 .GetHashCode()
-                .Should().Be(1);
+                .ShouldBe(1);
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var a = new AsyncAtomicFactory<int, int>();
             var b = new AsyncAtomicFactory<int, int>();
 
-            a.Equals(b).Should().BeFalse();
+            a.Equals(b).ShouldBeFalse();
         }
 
         [Fact]
@@ -145,7 +145,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var a = new AsyncAtomicFactory<int, int>(1);
             var b = new AsyncAtomicFactory<int, int>();
 
-            a.Equals(b).Should().BeFalse();
+            a.Equals(b).ShouldBeFalse();
         }
 
         [Fact]
@@ -153,7 +153,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             new AsyncAtomicFactory<int, int>(1)
                 .Equals(null)
-                .Should().BeFalse();
+                .ShouldBeFalse();
         }
 
         [Fact]
@@ -163,7 +163,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             new AsyncAtomicFactory<int, int>(1)
                 .Equals(other)
-                .Should().BeTrue();
+                .ShouldBeTrue();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryAsyncCacheTests.cs
@@ -2,11 +2,10 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Moq;
 
@@ -31,23 +30,23 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             Action constructor = () => { var x = new AtomicFactoryAsyncCache<int, int>(null); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
         public void WhenCreatedCapacityPropertyWrapsInnerCache()
         {
-            this.cache.Policy.Eviction.Value.Capacity.Should().Be(capacity);
+            this.cache.Policy.Eviction.Value.Capacity.ShouldBe(capacity);
         }
 
         [Fact]
         public void WhenItemIsAddedCountIsCorrect()
         {
-            this.cache.Count.Should().Be(0);
+            this.cache.Count.ShouldBe(0);
 
             this.cache.AddOrUpdate(2, 2);
 
-            this.cache.Count.Should().Be(1);
+            this.cache.Count.ShouldBe(1);
         }
 
         [Fact]
@@ -56,8 +55,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             await this.cache.GetOrAddAsync(1, k => Task.FromResult(k));
 
-            this.cache.Metrics.Value.Misses.Should().Be(0);
-            this.cache.Metrics.Value.Hits.Should().Be(1);
+            this.cache.Metrics.Value.Misses.ShouldBe(0);
+            this.cache.Metrics.Value.Hits.ShouldBe(1);
         }
 
         [Fact]
@@ -65,8 +64,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             await this.cache.GetOrAddAsync(1, (k, a) => Task.FromResult(k + a), 2);
 
-            this.cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(3);
+            this.cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(3);
         }
 
         [Fact]
@@ -77,7 +76,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             var cache = new AtomicFactoryAsyncCache<int, int>(inner.Object);
 
-            cache.Events.HasValue.Should().BeFalse();
+            cache.Events.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -88,7 +87,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.TryRemove(1);
 
-            this.removedItems.First().Key.Should().Be(1);
+            this.removedItems.First().Key.ShouldBe(1);
         }
 
         // backcompat: remove conditional compile
@@ -101,9 +100,9 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 2);
             this.cache.AddOrUpdate(1, 3);
 
-            this.updatedItems.First().Key.Should().Be(1);
-            this.updatedItems.First().OldValue.Should().Be(2);
-            this.updatedItems.First().NewValue.Should().Be(3);
+            this.updatedItems.First().Key.ShouldBe(1);
+            this.updatedItems.First().OldValue.ShouldBe(2);
+            this.updatedItems.First().NewValue.ShouldBe(3);
         }
 #endif
 
@@ -112,8 +111,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             this.cache.AddOrUpdate(1, 1);
 
-            this.cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(1);
+            this.cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -122,8 +121,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.AddOrUpdate(1, 2);
 
-            this.cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(2);
+            this.cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(2);
         }
 
         [Fact]
@@ -133,13 +132,13 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             this.cache.Clear();
 
-            this.cache.Count.Should().Be(0);
+            this.cache.Count.ShouldBe(0);
         }
 
         [Fact]
         public void WhenItemDoesNotExistTryGetReturnsFalse()
         {
-            this.cache.TryGet(1, out var value).Should().BeFalse();
+            this.cache.TryGet(1, out var value).ShouldBeFalse();
         }
 
         [Fact]
@@ -147,8 +146,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             await this.cache.GetOrAddAsync(1, k => Task.FromResult(k));
 
-            this.cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(1);
+            this.cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -160,26 +159,26 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             this.cache.Policy.Eviction.Value.Trim(1);
 
-            this.cache.TryGet(0, out var value).Should().BeFalse();
+            this.cache.TryGet(0, out var value).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryRemoveReturnsFalse()
         {
-            this.cache.TryRemove(1).Should().BeFalse();
+            this.cache.TryRemove(1).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyExistsTryRemoveReturnsTrue()
         {
             this.cache.AddOrUpdate(1, 1);
-            this.cache.TryRemove(1).Should().BeTrue();
+            this.cache.TryRemove(1).ShouldBeTrue();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
         {
-            this.cache.TryUpdate(1, 1).Should().BeFalse();
+            this.cache.TryUpdate(1, 1).ShouldBeFalse();
         }
 
         [Fact]
@@ -187,38 +186,38 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             this.cache.AddOrUpdate(1, 1);
 
-            this.cache.TryUpdate(1, 2).Should().BeTrue();
+            this.cache.TryUpdate(1, 2).ShouldBeTrue();
             this.cache.TryGet(1, out var value);
-            value.Should().Be(2);
+            value.ShouldBe(2);
         }
 
         [Fact]
         public void WhenItemsAddedKeysContainsTheKeys()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, 1);
             cache.AddOrUpdate(2, 2);
-            cache.Keys.Should().BeEquivalentTo(new[] { 1, 2 });
+            cache.Keys.ShouldBe(new[] { 1, 2 });
         }
 
         [Fact]
         public void WhenItemsAddedGenericEnumerateContainsKvps()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, 1);
             cache.AddOrUpdate(2, 2);
-            cache.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
+            cache.ShouldBe(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
         }
 
         [Fact]
         public void WhenItemsAddedEnumerateContainsKvps()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, 1);
             cache.AddOrUpdate(2, 2);
 
             var enumerable = (IEnumerable)cache;
-            enumerable.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
+            enumerable.ShouldBe(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
         }
 
         [Fact]
@@ -230,7 +229,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             }
             catch { }
 
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -243,7 +242,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             catch { }
 
             // IEnumerable.Count() instead of Count property
-            cache.Count().Should().Be(0);
+            cache.Count().ShouldBe(0);
         }
 
         [Fact]
@@ -255,7 +254,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             }
             catch { }
 
-            cache.Keys.Count().Should().Be(0);
+            cache.Keys.Count().ShouldBe(0);
         }
 
        // backcompat: remove conditional compile
@@ -266,7 +265,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.TryRemove(1, out var value);
 
-            value.Should().Be(1);
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -275,21 +274,21 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.TryRemove(2, out var value);
 
-            value.Should().Be(0);
+            value.ShouldBe(0);
         }
 
         [Fact]
         public void WhenRemoveKeyValueAndValueDoesntMatchDontRemove()
         {
             this.cache.AddOrUpdate(1, 1);
-            this.cache.TryRemove(new KeyValuePair<int, int>(1, 2)).Should().BeFalse();
+            this.cache.TryRemove(new KeyValuePair<int, int>(1, 2)).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenRemoveKeyValueAndValueDoesMatchThenRemove()
         {
             this.cache.AddOrUpdate(1, 1);
-            this.cache.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
+            this.cache.TryRemove(new KeyValuePair<int, int>(1, 1)).ShouldBeTrue();
         }
 
         [Fact]
@@ -299,7 +298,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.innerCache.AddOrUpdate(1, new AsyncAtomicFactory<int, int>());
 
             // try to remove with the default value (0)
-            this.cache.TryRemove(new KeyValuePair<int, int>(1, 0)).Should().BeFalse();
+            this.cache.TryRemove(new KeyValuePair<int, int>(1, 0)).ShouldBeFalse();
         }
 #endif
 

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Moq;
 
@@ -30,23 +30,23 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             Action constructor = () => { var x = new AtomicFactoryCache<int, int>(null); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
         public void WhenCreatedCapacityPropertyWrapsInnerCache()
         {
-            this.cache.Policy.Eviction.Value.Capacity.Should().Be(capacity);
+            this.cache.Policy.Eviction.Value.Capacity.ShouldBe(capacity);
         }
 
         [Fact]
         public void WhenItemIsAddedCountIsCorrect()
         {
-            this.cache.Count.Should().Be(0);
+            this.cache.Count.ShouldBe(0);
 
             this.cache.AddOrUpdate(2, 2);
 
-            this.cache.Count.Should().Be(1);
+            this.cache.Count.ShouldBe(1);
         }
 
         [Fact]
@@ -55,8 +55,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.GetOrAdd(1, k => k);
 
-            this.cache.Metrics.Value.Misses.Should().Be(0);
-            this.cache.Metrics.Value.Hits.Should().Be(1);
+            this.cache.Metrics.Value.Misses.ShouldBe(0);
+            this.cache.Metrics.Value.Hits.ShouldBe(1);
         }
 
         [Fact]
@@ -64,8 +64,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             this.cache.GetOrAdd(1, (k, a) => k + a, 2);
 
-            this.cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(3);
+            this.cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(3);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.TryRemove(1);
 
-            this.removedItems.First().Key.Should().Be(1);
+            this.removedItems.First().Key.ShouldBe(1);
         }
 
         // backcompat: remove conditional compile
@@ -87,7 +87,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.TryRemove(1, out var value);
 
-            value.Should().Be(1);
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -96,21 +96,21 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.TryRemove(2, out var value);
 
-            value.Should().Be(0);
+            value.ShouldBe(0);
         }
 
         [Fact]
         public void WhenRemoveKeyValueAndValueDoesntMatchDontRemove()
         {
             this.cache.AddOrUpdate(1, 1);
-            this.cache.TryRemove(new KeyValuePair<int, int>(1, 2)).Should().BeFalse();
+            this.cache.TryRemove(new KeyValuePair<int, int>(1, 2)).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenRemoveKeyValueAndValueDoesMatchThenRemove()
         {
             this.cache.AddOrUpdate(1, 1);
-            this.cache.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
+            this.cache.TryRemove(new KeyValuePair<int, int>(1, 1)).ShouldBeTrue();
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.innerCache.AddOrUpdate(1, new AtomicFactory<int, int>());
 
             // try to remove with the default value (0)
-            this.cache.TryRemove(new KeyValuePair<int, int>(1, 0)).Should().BeFalse();
+            this.cache.TryRemove(new KeyValuePair<int, int>(1, 0)).ShouldBeFalse();
         }
 
         [Fact]
@@ -131,9 +131,9 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 2);
             this.cache.AddOrUpdate(1, 3);
 
-            this.updatedItems.First().Key.Should().Be(1);
-            this.updatedItems.First().OldValue.Should().Be(2);
-            this.updatedItems.First().NewValue.Should().Be(3);
+            this.updatedItems.First().Key.ShouldBe(1);
+            this.updatedItems.First().OldValue.ShouldBe(2);
+            this.updatedItems.First().NewValue.ShouldBe(3);
         }
 #endif
         [Fact]
@@ -144,7 +144,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             var cache = new AtomicFactoryCache<int, int>(inner.Object);
 
-            cache.Events.HasValue.Should().BeFalse();
+            cache.Events.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -152,8 +152,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             this.cache.AddOrUpdate(1, 1);
 
-            this.cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(1);
+            this.cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -162,8 +162,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             this.cache.AddOrUpdate(1, 1);
             this.cache.AddOrUpdate(1, 2);
 
-            this.cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(2);
+            this.cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(2);
         }
 
         [Fact]
@@ -173,13 +173,13 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             this.cache.Clear();
 
-            this.cache.Count.Should().Be(0);
+            this.cache.Count.ShouldBe(0);
         }
 
         [Fact]
         public void WhenItemDoesNotExistTryGetReturnsFalse()
         {
-            this.cache.TryGet(1, out var value).Should().BeFalse();
+            this.cache.TryGet(1, out var value).ShouldBeFalse();
         }
 
         [Fact]
@@ -187,8 +187,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             this.cache.GetOrAdd(1, k => k);
 
-            this.cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(1);
+            this.cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -200,26 +200,26 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             this.cache.Policy.Eviction.Value.Trim(1);
 
-            this.cache.TryGet(0, out var value).Should().BeFalse();
+            this.cache.TryGet(0, out var value).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryRemoveReturnsFalse()
         {
-            this.cache.TryRemove(1).Should().BeFalse();
+            this.cache.TryRemove(1).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyExistsTryRemoveReturnsTrue()
         {
             this.cache.AddOrUpdate(1, 1);
-            this.cache.TryRemove(1).Should().BeTrue();
+            this.cache.TryRemove(1).ShouldBeTrue();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
         {
-            this.cache.TryUpdate(1, 1).Should().BeFalse();
+            this.cache.TryUpdate(1, 1).ShouldBeFalse();
         }
 
         [Fact]
@@ -227,38 +227,38 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             this.cache.AddOrUpdate(1, 1);
 
-            this.cache.TryUpdate(1, 2).Should().BeTrue();
+            this.cache.TryUpdate(1, 2).ShouldBeTrue();
             this.cache.TryGet(1, out var value);
-            value.Should().Be(2);
+            value.ShouldBe(2);
         }
 
         [Fact]
         public void WhenItemsAddedKeysContainsTheKeys()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, 1);
             cache.AddOrUpdate(2, 2);
-            cache.Keys.Should().BeEquivalentTo(new[] { 1, 2 });
+            cache.Keys.ShouldBe(new[] { 1, 2 });
         }
 
         [Fact]
         public void WhenItemsAddedGenericEnumerateContainsKvps()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, 1);
             cache.AddOrUpdate(2, 2);
-            cache.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
+            cache.ShouldBe(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
         }
 
         [Fact]
         public void WhenItemsAddedEnumerateContainsKvps()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, 1);
             cache.AddOrUpdate(2, 2);
 
             var enumerable = (IEnumerable)cache;
-            enumerable.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
+            enumerable.ShouldBe(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
         }
 
         [Fact]
@@ -270,7 +270,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             }
             catch { }
 
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -283,7 +283,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             catch { }
 
             // IEnumerable.Count() instead of Count property
-            cache.Count().Should().Be(0);
+            cache.Count().ShouldBe(0);
         }
 
         [Fact]
@@ -295,7 +295,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             }
             catch { }
 
-            cache.Keys.Count().Should().Be(0);
+            cache.Keys.Count().ShouldBe(0);
         }
 
         private void OnItemRemoved(object sender, ItemRemovedEventArgs<int, int> e)

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedAsyncCacheTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Moq;
 
@@ -23,7 +20,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             Action constructor = () => { var x = new AtomicFactoryScopedAsyncCache<int, Disposable>(null); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -35,7 +32,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             scope.Dispose();
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeFalse();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
@@ -43,7 +40,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             await this.cache.ScopedGetOrAddAsync(1, k => Task.FromResult(new Scoped<Disposable>(new Disposable())));
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
         }
 
         [Fact]
@@ -54,7 +51,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             Func<Task> getOrAdd = async () => { await this.cache.ScopedGetOrAddAsync(1, k => Task.FromResult(scope)); };
 
-            await getOrAdd.Should().ThrowAsync<InvalidOperationException>();
+            var ex = await getOrAdd.ShouldThrowAsync<InvalidOperationException>();;
         }
 
         [Fact]
@@ -65,7 +62,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             var cache = new AtomicFactoryScopedAsyncCache<int, Disposable>(inner.Object);
 
-            cache.Events.HasValue.Should().BeFalse();
+            cache.Events.HasValue.ShouldBeFalse();
         }
 
         // Infer identified AddOrUpdate and TryUpdate as resource leaks. This test verifies correct disposal.
@@ -77,11 +74,11 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             this.cache.AddOrUpdate(1, disposable1);
 
-            this.cache.TryUpdate(1, disposable2).Should().BeTrue();
-            disposable1.IsDisposed.Should().BeTrue();
+            this.cache.TryUpdate(1, disposable2).ShouldBeTrue();
+            disposable1.IsDisposed.ShouldBeTrue();
 
-            this.cache.TryUpdate(1, new Disposable()).Should().BeTrue();
-            disposable2.IsDisposed.Should().BeTrue();
+            this.cache.TryUpdate(1, new Disposable()).ShouldBeTrue();
+            disposable2.IsDisposed.ShouldBeTrue();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedCacheTests.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Moq;
 
@@ -23,7 +20,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             Action constructor = () => { var x = new AtomicFactoryScopedCache<int, Disposable>(null); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -35,7 +32,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             scope.Dispose();
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeFalse();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
@@ -43,7 +40,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             this.cache.ScopedGetOrAdd(1, k => new Scoped<Disposable>(new Disposable()));
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
         }
 
         [Fact]
@@ -54,7 +51,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             Action getOrAdd = () => { this.cache.ScopedGetOrAdd(1, k => scope); };
 
-            getOrAdd.Should().Throw<InvalidOperationException>();
+            getOrAdd.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -65,7 +62,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             var cache = new AtomicFactoryScopedCache<int, Disposable>(inner.Object);
 
-            cache.Events.HasValue.Should().BeFalse();
+            cache.Events.HasValue.ShouldBeFalse();
         }
 
         // Infer identified AddOrUpdate and TryUpdate as resource leaks. This test verifies correct disposal.
@@ -77,11 +74,11 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             this.cache.AddOrUpdate(1, disposable1);
 
-            this.cache.TryUpdate(1, disposable2).Should().BeTrue();
-            disposable1.IsDisposed.Should().BeTrue();
+            this.cache.TryUpdate(1, disposable2).ShouldBeTrue();
+            disposable1.IsDisposed.ShouldBeTrue();
 
-            this.cache.TryUpdate(1, new Disposable()).Should().BeTrue();
-            disposable2.IsDisposed.Should().BeTrue();
+            this.cache.TryUpdate(1, new Disposable()).ShouldBeTrue();
+            disposable2.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -93,7 +90,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             }
             catch { }
 
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -106,7 +103,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             catch { }
 
             // IEnumerable.Count() instead of Count property
-            cache.Count().Should().Be(0);
+            cache.Count().ShouldBe(0);
         }
 
         [Fact]
@@ -118,7 +115,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             }
             catch { }
 
-            cache.Keys.Count().Should().Be(0);
+            cache.Keys.Count().ShouldBe(0);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactorySoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactorySoakTests.cs
@@ -2,8 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using BitFaster.Caching.Atomic;
-using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Atomic
@@ -27,7 +26,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 }
             });
 
-            counters.Sum(x => x).Should().Be(items);
+            counters.Sum(x => x).ShouldBe(items);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryTests.cs
@@ -1,9 +1,8 @@
-﻿
-using System;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Atomic
@@ -15,8 +14,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var a = new AtomicFactory<int, int>();
 
-            a.IsValueCreated.Should().BeFalse();
-            a.ValueIfCreated.Should().Be(0);
+            a.IsValueCreated.ShouldBeFalse();
+            a.ValueIfCreated.ShouldBe(0);
         }
 
         [Fact]
@@ -24,28 +23,28 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var a = new AtomicFactory<int, int>(1);
 
-            a.ValueIfCreated.Should().Be(1);
-            a.IsValueCreated.Should().BeTrue();
+            a.ValueIfCreated.ShouldBe(1);
+            a.IsValueCreated.ShouldBeTrue();
         }
 
         [Fact]
         public void WhenValueCreatedValueReturned()
         {
             var a = new AtomicFactory<int, int>();
-            a.GetValue(1, k => 2).Should().Be(2);
+            a.GetValue(1, k => 2).ShouldBe(2);
 
-            a.ValueIfCreated.Should().Be(2);
-            a.IsValueCreated.Should().BeTrue();
+            a.ValueIfCreated.ShouldBe(2);
+            a.IsValueCreated.ShouldBeTrue();
         }
 
         [Fact]
         public void WhenValueCreatedWithArgValueReturned()
         {
             var a = new AtomicFactory<int, int>();
-            a.GetValue(1, (k, a) => k + a, 7).Should().Be(8);
+            a.GetValue(1, (k, a) => k + a, 7).ShouldBe(8);
 
-            a.ValueIfCreated.Should().Be(8);
-            a.IsValueCreated.Should().BeTrue();
+            a.ValueIfCreated.ShouldBe(8);
+            a.IsValueCreated.ShouldBeTrue();
         }
 
         [Fact]
@@ -53,7 +52,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var a = new AtomicFactory<int, int>();
             a.GetValue(1, k => 2);
-            a.GetValue(1, k => 3).Should().Be(2);
+            a.GetValue(1, k => 3).ShouldBe(2);
         }
 
         [Fact]
@@ -61,7 +60,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var a = new AtomicFactory<int, int>();
             a.GetValue(1, (k, a) => k + a, 7);
-            a.GetValue(1, (k, a) => k + a, 9).Should().Be(8);
+            a.GetValue(1, (k, a) => k + a, 9).ShouldBe(8);
         }
 
         [Fact]
@@ -69,7 +68,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             new AtomicFactory<int, int>()
                 .GetHashCode()
-                .Should().Be(0);
+                .ShouldBe(0);
         }
 
         [Fact]
@@ -77,7 +76,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             new AtomicFactory<int, int>(1)
                 .GetHashCode()
-                .Should().Be(1);
+                .ShouldBe(1);
         }
 
         [Fact]
@@ -86,7 +85,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var a = new AtomicFactory<int, int>();
             var b = new AtomicFactory<int, int>();
 
-            a.Equals(b).Should().BeFalse();
+            a.Equals(b).ShouldBeFalse();
         }
 
         [Fact]
@@ -95,7 +94,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var a = new AtomicFactory<int, int>(1);
             var b = new AtomicFactory<int, int>();
 
-            a.Equals(b).Should().BeFalse();
+            a.Equals(b).ShouldBeFalse();
         }
 
         [Fact]
@@ -103,7 +102,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             new AtomicFactory<int, int>(1)
                 .Equals(null)
-                .Should().BeFalse();
+                .ShouldBeFalse();
         }
 
         [Fact]
@@ -113,7 +112,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             new AtomicFactory<int, int>(1)
                 .Equals(other)
-                .Should().BeTrue();
+                .ShouldBeTrue();
         }
 
         [Fact]
@@ -161,10 +160,10 @@ namespace BitFaster.Caching.UnitTests.Atomic
             factory.WaitOne();
             resume.Set();
 
-            (await first).Should().Be(result);
-            (await second).Should().Be(result);
+            (await first).ShouldBe(result);
+            (await second).ShouldBe(result);
 
-            winnerCount.Should().Be(1);
+            winnerCount.ShouldBe(1);
         }
 
         [Fact]
@@ -219,8 +218,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 Func<Task> act1 = () => first;
                 Func<Task> act2 = () => second;
 
-                await act1.Should().ThrowAsync<Exception>();
-                await act2.Should().ThrowAsync<Exception>();
+                await act1.ShouldThrowAsync<Exception>();;
+                await act2.ShouldThrowAsync<Exception>();;
 
                 if (throwCount == 1)
                 {
@@ -228,7 +227,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 }
             }
 
-            timesContended.Should().BeGreaterThan(0);
+            timesContended.ShouldBeGreaterThan(0);
         }
 
         [Fact]
@@ -271,11 +270,11 @@ namespace BitFaster.Caching.UnitTests.Atomic
             Func<Task> act1 = () => first;
             Func<Task> act2 = () => second;
 
-            await act1.Should().ThrowAsync<Exception>();
-            await act2.Should().ThrowAsync<Exception>();
+            await act1.ShouldThrowAsync<Exception>();;
+            await act2.ShouldThrowAsync<Exception>();;
 
             // verify exception is no longer cached
-            atomicFactory.GetValue(1, k => k).Should().Be(1);
+            atomicFactory.GetValue(1, k => k).ShouldBe(1);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Atomic/ConcurrentDictionaryExtensionTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/ConcurrentDictionaryExtensionTests.cs
@@ -1,9 +1,8 @@
-﻿
+﻿using System.Collections.Generic;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Atomic
@@ -18,8 +17,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             dictionary.GetOrAdd(1, k => k);
 
-            dictionary.TryGetValue(1, out int value).Should().BeTrue();
-            value.Should().Be(1);
+            dictionary.TryGetValue(1, out int value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -27,8 +26,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             await dictionaryAsync.GetOrAddAsync(1, k => Task.FromResult(k));
 
-            dictionaryAsync.TryGetValue(1, out int value).Should().BeTrue();
-            value.Should().Be(1);
+            dictionaryAsync.TryGetValue(1, out int value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -36,8 +35,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             dictionary.GetOrAdd(1, (k,a) => k + a, 2);
 
-            dictionary.TryGetValue(1, out int value).Should().BeTrue();
-            value.Should().Be(3);
+            dictionary.TryGetValue(1, out int value).ShouldBeTrue();
+            value.ShouldBe(3);
         }
 
         [Fact]
@@ -45,20 +44,20 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             await dictionaryAsync.GetOrAddAsync(1, (k, a) => Task.FromResult(k + a), 2);
 
-            dictionaryAsync.TryGetValue(1, out int value).Should().BeTrue();
-            value.Should().Be(3);
+            dictionaryAsync.TryGetValue(1, out int value).ShouldBeTrue();
+            value.ShouldBe(3);
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryGetReturnsFalse()
         {
-            dictionary.TryGetValue(1, out int _).Should().BeFalse();
+            dictionary.TryGetValue(1, out int _).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistAsyncTryGetReturnsFalse()
         {
-            dictionaryAsync.TryGetValue(1, out int _).Should().BeFalse();
+            dictionaryAsync.TryGetValue(1, out int _).ShouldBeFalse();
         }
 
         [Fact]
@@ -66,8 +65,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             dictionary.GetOrAdd(1, k => k);
 
-            dictionary.TryRemove(1, out int value).Should().BeTrue();
-            value.Should().Be(1);
+            dictionary.TryRemove(1, out int value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -75,8 +74,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             await dictionaryAsync.GetOrAddAsync(1, k => Task.FromResult(k));
 
-            dictionaryAsync.TryRemove(1, out int value).Should().BeTrue();
-            value.Should().Be(1);
+            dictionaryAsync.TryRemove(1, out int value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -84,8 +83,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             dictionary.GetOrAdd(1, k => k);
 
-            dictionary.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
-            dictionary.TryGetValue(1, out _).Should().BeFalse();
+            dictionary.TryRemove(new KeyValuePair<int, int>(1, 1)).ShouldBeTrue();
+            dictionary.TryGetValue(1, out _).ShouldBeFalse();
         }
 
         [Fact]
@@ -93,20 +92,20 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             await dictionaryAsync.GetOrAddAsync(1, k => Task.FromResult(k));
 
-            dictionaryAsync.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
-            dictionaryAsync.TryGetValue(1, out _).Should().BeFalse();
+            dictionaryAsync.TryRemove(new KeyValuePair<int, int>(1, 1)).ShouldBeTrue();
+            dictionaryAsync.TryGetValue(1, out _).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryRemoveReturnsFalse()
         {
-            dictionary.TryRemove(1, out int _).Should().BeFalse();
+            dictionary.TryRemove(1, out int _).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistAsyncTryRemoveReturnsFalse()
         {
-            dictionaryAsync.TryRemove(1, out int _).Should().BeFalse();
+            dictionaryAsync.TryRemove(1, out int _).ShouldBeFalse();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Atomic/ScopedAsyncAtomicFactorySoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/ScopedAsyncAtomicFactorySoakTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Atomic
@@ -32,7 +32,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                         {
                             using (lifetime)
                             {
-                                lifetime.Value.IsDisposed.Should().BeFalse();
+                                lifetime.Value.IsDisposed.ShouldBeFalse();
                             }
 
                             break;
@@ -41,7 +41,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 }
             });
 
-            counters.Sum(x => x).Should().Be(items);
+            counters.Sum(x => x).ShouldBe(items);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                         {
                             using (lifetime)
                             {
-                                lifetime.Value.IsDisposed.Should().BeFalse();
+                                lifetime.Value.IsDisposed.ShouldBeFalse();
                             }
 
                             break;

--- a/BitFaster.Caching.UnitTests/Atomic/ScopedAsyncAtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/ScopedAsyncAtomicFactoryTests.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Atomic
@@ -14,7 +14,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var atomicFactory = new ScopedAsyncAtomicFactory<int, Disposable>();
 
-            atomicFactory.ScopeIfCreated.Should().BeNull();
+            atomicFactory.ScopeIfCreated.ShouldBeNull();
         }
 
         [Fact]
@@ -23,16 +23,16 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var expectedDisposable = new Disposable();
             var atomicFactory = new ScopedAsyncAtomicFactory<int, Disposable>(expectedDisposable);
 
-            atomicFactory.ScopeIfCreated.Should().NotBeNull();
-            atomicFactory.ScopeIfCreated.TryCreateLifetime(out var lifetime).Should().BeTrue();
-            lifetime.Value.Should().Be(expectedDisposable);
+            atomicFactory.ScopeIfCreated.ShouldNotBeNull();
+            atomicFactory.ScopeIfCreated.TryCreateLifetime(out var lifetime).ShouldBeTrue();
+            lifetime.Value.ShouldBe(expectedDisposable);
         }
 
         [Fact]
         public void WhenNotInitTryCreateReturnsFalse()
         {
             var sa = new ScopedAsyncAtomicFactory<int, Disposable>();
-            sa.TryCreateLifetime(out var l).Should().BeFalse();
+            sa.TryCreateLifetime(out var l).ShouldBeFalse();
         }
 
         [Fact]
@@ -41,8 +41,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var expectedDisposable = new Disposable();
             var sa = new ScopedAsyncAtomicFactory<int, Disposable>(expectedDisposable);
 
-            sa.TryCreateLifetime(out var lifetime).Should().BeTrue();
-            lifetime.Value.Should().Be(expectedDisposable);
+            sa.TryCreateLifetime(out var lifetime).ShouldBeTrue();
+            lifetime.Value.ShouldBe(expectedDisposable);
         }
 
         [Fact]
@@ -55,8 +55,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 return Task.FromResult(new Scoped<IntHolder>(new IntHolder() { actualNumber = 2 }));
             });
 
-            result.r.Should().BeTrue();
-            result.l.Value.actualNumber.Should().Be(1);
+            result.r.ShouldBeTrue();
+            result.l.Value.actualNumber.ShouldBe(1);
         }
 
         [Fact]
@@ -69,8 +69,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 return Task.FromResult(new Scoped<IntHolder>(new IntHolder() { actualNumber = 2 }));
             });
 
-            result.r.Should().BeTrue();
-            result.l.Value.actualNumber.Should().Be(2);
+            result.r.ShouldBeTrue();
+            result.l.Value.actualNumber.ShouldBe(2);
         }
 
         [Fact]
@@ -81,8 +81,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             (bool r, Lifetime<IntHolder> l) result = await atomicFactory.TryCreateLifetimeAsync(1, factory);
 
-            result.r.Should().BeTrue();
-            result.l.Value.actualNumber.Should().Be(8);
+            result.r.ShouldBeTrue();
+            result.l.Value.actualNumber.ShouldBe(8);
         }
 
         [Fact]
@@ -96,8 +96,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 return Task.FromResult(new Scoped<IntHolder>(new IntHolder() { actualNumber = 2 }));
             });
 
-            result.r.Should().BeFalse();
-            result.l.Should().BeNull();
+            result.r.ShouldBeFalse();
+            result.l.ShouldBeNull();
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             
             atomicFactory.Dispose();
 
-            holder.disposed.Should().BeTrue();
+            holder.disposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -147,13 +147,13 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var result1 = await first;
             var result2 = await second;
 
-            result1.r.Should().BeTrue();
-            result2.r.Should().BeTrue();
+            result1.r.ShouldBeTrue();
+            result2.r.ShouldBeTrue();
 
-            result1.l.Value.actualNumber.Should().Be(winningNumber);
-            result2.l.Value.actualNumber.Should().Be(winningNumber);
+            result1.l.Value.actualNumber.ShouldBe(winningNumber);
+            result2.l.Value.actualNumber.ShouldBe(winningNumber);
                 
-            winnerCount.Should().Be(1);
+            winnerCount.ShouldBe(1);
         }
 
         [Fact]
@@ -179,10 +179,10 @@ namespace BitFaster.Caching.UnitTests.Atomic
 
             var result = await first;
 
-            result.r.Should().BeFalse();
-            result.l.Should().BeNull();
+            result.r.ShouldBeFalse();
+            result.l.ShouldBeNull();
 
-            holder.disposed.Should().BeTrue();
+            holder.disposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -211,17 +211,17 @@ namespace BitFaster.Caching.UnitTests.Atomic
             // If we create an item, to be in a consistent state we should dispose it.
 
             Func<Task> tryCreateAsync = async () => { await first; };
-            await tryCreateAsync.Should().ThrowAsync<InvalidOperationException>();
+            var ex = await tryCreateAsync.ShouldThrowAsync<InvalidOperationException>();;
 
             (bool r, Lifetime<IntHolder> l) result = await atomicFactory.TryCreateLifetimeAsync(1, k =>
             {
                 return Task.FromResult(new Scoped<IntHolder>(holder));
             });
 
-            result.r.Should().BeFalse();
-            result.l.Should().BeNull();
+            result.r.ShouldBeFalse();
+            result.l.ShouldBeNull();
 
-            holder.disposed.Should().BeTrue();
+            holder.disposed.ShouldBeTrue();
         }
 
         private static AsyncValueFactoryArg<int, int, Scoped<IntHolder>> CreateArgFactory(int arg)

--- a/BitFaster.Caching.UnitTests/Atomic/ScopedAtomicFactorySoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/ScopedAtomicFactorySoakTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Atomic
@@ -30,7 +30,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                         {
                             using (lifetime)
                             {
-                                lifetime.Value.IsDisposed.Should().BeFalse();
+                                lifetime.Value.IsDisposed.ShouldBeFalse();
                             }
 
                             break;
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                 }
             });
 
-            counters.Sum(x => x).Should().Be(items);
+            counters.Sum(x => x).ShouldBe(items);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
                         {
                             using (lifetime)
                             {
-                                lifetime.Value.IsDisposed.Should().BeFalse();
+                                lifetime.Value.IsDisposed.ShouldBeFalse();
                             }
 
                             break;

--- a/BitFaster.Caching.UnitTests/Atomic/ScopedAtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/ScopedAtomicFactoryTests.cs
@@ -1,6 +1,5 @@
-﻿
-using BitFaster.Caching.Atomic;
-using FluentAssertions;
+﻿using BitFaster.Caching.Atomic;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Atomic
@@ -13,9 +12,9 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var expectedDisposable = new Disposable();
             var sa = new ScopedAtomicFactory<int, Disposable>(expectedDisposable);
 
-            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(new Disposable()), out var lifetime).Should().BeTrue();
+            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(new Disposable()), out var lifetime).ShouldBeTrue();
 
-            lifetime.Value.Should().Be(expectedDisposable);
+            lifetime.Value.ShouldBe(expectedDisposable);
         }
 
         [Fact]
@@ -24,9 +23,9 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var expectedDisposable = new Disposable();
             var sa = new ScopedAtomicFactory<int, Disposable>();
 
-            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(expectedDisposable), out var lifetime).Should().BeTrue();
+            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(expectedDisposable), out var lifetime).ShouldBeTrue();
 
-            lifetime.Value.Should().Be(expectedDisposable);
+            lifetime.Value.ShouldBe(expectedDisposable);
         }
 
         [Fact]
@@ -35,10 +34,10 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var expectedDisposable = new Disposable();
             var sa = new ScopedAtomicFactory<int, Disposable>();
 
-            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(expectedDisposable), out var lifetime1).Should().BeTrue();
-            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(new Disposable()), out var lifetime2).Should().BeTrue();
+            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(expectedDisposable), out var lifetime1).ShouldBeTrue();
+            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(new Disposable()), out var lifetime2).ShouldBeTrue();
 
-            lifetime2.Value.Should().Be(expectedDisposable);
+            lifetime2.Value.ShouldBe(expectedDisposable);
         }
 
         [Fact]
@@ -50,11 +49,11 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var factory1 = new ValueFactoryArg<int, int, Scoped<Disposable>>((k, v) => { expectedDisposable.State = v; return new Scoped<Disposable>(expectedDisposable); }, 1);
             var factory2 = new ValueFactoryArg<int, int, Scoped<Disposable>>((k, v) => { expectedDisposable.State = v; return new Scoped<Disposable>(expectedDisposable); }, 2);
 
-            sa.TryCreateLifetime(1, factory1, out var lifetime1).Should().BeTrue();
-            sa.TryCreateLifetime(1, factory2, out var lifetime2).Should().BeTrue();
+            sa.TryCreateLifetime(1, factory1, out var lifetime1).ShouldBeTrue();
+            sa.TryCreateLifetime(1, factory2, out var lifetime2).ShouldBeTrue();
 
-            lifetime2.Value.Should().Be(expectedDisposable);
-            lifetime2.Value.State.Should().Be(1);
+            lifetime2.Value.ShouldBe(expectedDisposable);
+            lifetime2.Value.State.ShouldBe(1);
         }
 
         [Fact]
@@ -62,7 +61,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         {
             var sa = new ScopedAtomicFactory<int, Disposable>();
 
-            sa.ScopeIfCreated.Should().BeNull();
+            sa.ScopeIfCreated.ShouldBeNull();
         }
 
         [Fact]
@@ -71,16 +70,16 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var expectedDisposable = new Disposable();
             var sa = new ScopedAtomicFactory<int, Disposable>(expectedDisposable);
 
-            sa.ScopeIfCreated.Should().NotBeNull();
-            sa.ScopeIfCreated.TryCreateLifetime(out var lifetime).Should().BeTrue();
-            lifetime.Value.Should().Be(expectedDisposable);
+            sa.ScopeIfCreated.ShouldNotBeNull();
+            sa.ScopeIfCreated.TryCreateLifetime(out var lifetime).ShouldBeTrue();
+            lifetime.Value.ShouldBe(expectedDisposable);
         }
 
         [Fact]
         public void WhenNotInitTryCreateReturnsFalse()
         {
             var sa = new ScopedAtomicFactory<int, Disposable>();
-            sa.TryCreateLifetime(out var l).Should().BeFalse();
+            sa.TryCreateLifetime(out var l).ShouldBeFalse();
         }
 
         [Fact]
@@ -89,8 +88,8 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var expectedDisposable = new Disposable();
             var sa = new ScopedAtomicFactory<int, Disposable>(expectedDisposable);
 
-            sa.TryCreateLifetime(out var lifetime).Should().BeTrue();
-            lifetime.Value.Should().Be(expectedDisposable);
+            sa.TryCreateLifetime(out var lifetime).ShouldBeTrue();
+            lifetime.Value.ShouldBe(expectedDisposable);
         }
 
         [Fact]
@@ -99,7 +98,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var sa = new ScopedAtomicFactory<int, Disposable>();
             sa.Dispose();
 
-            sa.TryCreateLifetime(out var lifetime).Should().BeFalse();
+            sa.TryCreateLifetime(out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
@@ -108,7 +107,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var sa = new ScopedAtomicFactory<int, Disposable>(new Disposable());
             sa.Dispose();
 
-            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(new Disposable()), out var l).Should().BeFalse();
+            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(new Disposable()), out var l).ShouldBeFalse();
         }
 
         [Fact]
@@ -117,7 +116,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var sa = new ScopedAtomicFactory<int, Disposable>();
             sa.Dispose();
 
-            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(new Disposable()), out var l).Should().BeFalse();
+            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(new Disposable()), out var l).ShouldBeFalse();
         }
 
         [Fact]
@@ -126,17 +125,17 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var disposable = new Disposable();
             var sa = new ScopedAtomicFactory<int, Disposable>();
 
-            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(disposable), out var lifetime1).Should().BeTrue();
-            sa.TryCreateLifetime(1, k => null, out var lifetime2).Should().BeTrue();
+            sa.TryCreateLifetime(1, k => new Scoped<Disposable>(disposable), out var lifetime1).ShouldBeTrue();
+            sa.TryCreateLifetime(1, k => null, out var lifetime2).ShouldBeTrue();
 
             sa.Dispose();
-            disposable.IsDisposed.Should().BeFalse();
+            disposable.IsDisposed.ShouldBeFalse();
 
             lifetime1.Dispose();
-            disposable.IsDisposed.Should().BeFalse();
+            disposable.IsDisposed.ShouldBeFalse();
 
             lifetime2.Dispose();
-            disposable.IsDisposed.Should().BeTrue();
+            disposable.IsDisposed.ShouldBeTrue();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/BitFaster.Caching.UnitTests.csproj
+++ b/BitFaster.Caching.UnitTests/BitFaster.Caching.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net48;netcoreapp3.1;net6.0</TargetFrameworks>
@@ -10,20 +10,20 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="ObjectLayoutInspector" Version="0.1.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
   </ItemGroup>
     
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BitFaster.Caching.UnitTests/BitOpsTests.cs
+++ b/BitFaster.Caching.UnitTests/BitOpsTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using FluentAssertions;
+﻿using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -17,7 +12,7 @@ namespace BitFaster.Caching.UnitTests
         [InlineData(536870913, 1073741824)]
         public void IntCeilingPowerOfTwo(int input, int power)
         {
-            BitOps.CeilingPowerOfTwo(input).Should().Be(power);
+            BitOps.CeilingPowerOfTwo(input).ShouldBe(power);
         }
 
         [Theory]
@@ -28,7 +23,7 @@ namespace BitFaster.Caching.UnitTests
         [InlineData(34359738368, 34359738368)]
         public void LongCeilingPowerOfTwo(long input, long power)
         {
-            BitOps.CeilingPowerOfTwo(input).Should().Be(power);
+            BitOps.CeilingPowerOfTwo(input).ShouldBe(power);
         }
 
         [Theory]
@@ -39,7 +34,7 @@ namespace BitFaster.Caching.UnitTests
 
         public void UIntCeilingPowerOfTwo(uint input, uint power)
         {
-            BitOps.CeilingPowerOfTwo(input).Should().Be(power);
+            BitOps.CeilingPowerOfTwo(input).ShouldBe(power);
         }
 
         [Theory]
@@ -51,7 +46,7 @@ namespace BitFaster.Caching.UnitTests
 
         public void UlongCeilingPowerOfTwo(ulong input, ulong power)
         {
-            BitOps.CeilingPowerOfTwo(input).Should().Be(power);
+            BitOps.CeilingPowerOfTwo(input).ShouldBe(power);
         }
 
         [Theory]
@@ -65,7 +60,7 @@ namespace BitFaster.Caching.UnitTests
 
         public void LongTrailingZeroCount(long input, int count)
         {
-            BitOps.TrailingZeroCount(input).Should().Be(count);
+            BitOps.TrailingZeroCount(input).ShouldBe(count);
         }
 
         [Theory]
@@ -79,25 +74,25 @@ namespace BitFaster.Caching.UnitTests
 
         public void ULongTrailingZeroCount(ulong input, int count)
         {
-            BitOps.TrailingZeroCount(input).Should().Be(count);
+            BitOps.TrailingZeroCount(input).ShouldBe(count);
         }
 
         [Fact]
         public void IntBitCount()
         {
-            BitOps.BitCount(666).Should().Be(5);
+            BitOps.BitCount(666).ShouldBe(5);
         }
 
         [Fact]
         public void LongtBitCount()
         {
-            BitOps.BitCount(666L).Should().Be(5);
+            BitOps.BitCount(666L).ShouldBe(5);
         }
 
         [Fact]
         public void ULongtBitCount()
         {
-            BitOps.BitCount(666UL).Should().Be(5);
+            BitOps.BitCount(666UL).ShouldBe(5);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Buffers/MpmcBoundedBufferSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpmcBoundedBufferSoakTests.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -33,7 +33,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
                 {
                 }
 
-                buffer.Count.Should().Be(1024);
+                buffer.Count.ShouldBe(1024);
             });
         }
 
@@ -80,7 +80,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
                 while (!fill.IsCompleted)
                 {
                     int newcount = buffer.Count;
-                    newcount.Should().BeGreaterThanOrEqualTo(count);
+                    newcount.ShouldBeGreaterThanOrEqualTo(count);
                     count = newcount;
                 }
             });

--- a/BitFaster.Caching.UnitTests/Buffers/MpmcBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpmcBoundedBufferTests.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Buffers
@@ -19,19 +14,19 @@ namespace BitFaster.Caching.UnitTests.Buffers
         {
             Action constructor = () => { var x = new MpmcBoundedBuffer<int>(-1); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
         public void SizeIsPowerOfTwo()
         {
-            buffer.Capacity.Should().Be(16);
+            buffer.Capacity.ShouldBe(16);
         }
 
         [Fact]
         public void WhenBufferIsEmptyCountIsZero()
         {
-            buffer.Count.Should().Be(0);
+            buffer.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -39,22 +34,22 @@ namespace BitFaster.Caching.UnitTests.Buffers
         {
             // head < tail
             buffer.TryAdd(1);
-            buffer.Count.Should().Be(1);
+            buffer.Count.ShouldBe(1);
         }
 
         [Fact]
         public void WhenBufferHas15ItemCountIs15()
         {
-            buffer.TryAdd(0).Should().Be(BufferStatus.Success);
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Success);
+            buffer.TryAdd(0).ShouldBe(BufferStatus.Success);
+            buffer.TryTake(out var _).ShouldBe(BufferStatus.Success);
 
             for (var i = 0; i < 15; i++)
             {
-                buffer.TryAdd(0).Should().Be(BufferStatus.Success);
+                buffer.TryAdd(0).ShouldBe(BufferStatus.Success);
             }
 
             // head = 1, tail = 0 : head > tail
-            buffer.Count.Should().Be(15);
+            buffer.Count.ShouldBe(15);
         }
 
         [Fact]
@@ -62,24 +57,24 @@ namespace BitFaster.Caching.UnitTests.Buffers
         {
             for (var i = 0; i < 16; i++)
             {
-                buffer.TryAdd(i).Should().Be(BufferStatus.Success);
+                buffer.TryAdd(i).ShouldBe(BufferStatus.Success);
             }
 
-            buffer.TryAdd(666).Should().Be(BufferStatus.Full);
+            buffer.TryAdd(666).ShouldBe(BufferStatus.Full);
         }
 
         [Fact]
         public void WhenBufferIsEmptyTryTakeIsFalse()
         {
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Empty);
+            buffer.TryTake(out var _).ShouldBe(BufferStatus.Empty);
         }
 
         [Fact]
         public void WhenItemAddedItCanBeTaken()
         {
-            buffer.TryAdd(123).Should().Be(BufferStatus.Success);
-            buffer.TryTake(out var item).Should().Be(BufferStatus.Success);
-            item.Should().Be(123);
+            buffer.TryAdd(123).ShouldBe(BufferStatus.Success);
+            buffer.TryTake(out var item).ShouldBe(BufferStatus.Success);
+            item.ShouldBe(123);
         }
 
         [Fact]
@@ -88,12 +83,12 @@ namespace BitFaster.Caching.UnitTests.Buffers
             buffer.TryAdd(1);
             buffer.TryAdd(2);
 
-            buffer.Count.Should().Be(2);
+            buffer.Count.ShouldBe(2);
 
             buffer.Clear();
 
-            buffer.Count.Should().Be(0);
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Empty);
+            buffer.Count.ShouldBe(0);
+            buffer.TryTake(out var _).ShouldBe(BufferStatus.Empty);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferSoakTests.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -33,7 +33,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
                 {
                 }
 
-                buffer.Count.Should().Be(1024);
+                buffer.Count.ShouldBe(1024);
             });
         }
 
@@ -99,7 +99,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
                 while (!fill.IsCompleted)
                 {
                     int newcount = buffer.Count;
-                    newcount.Should().BeGreaterThanOrEqualTo(count);
+                    newcount.ShouldBeGreaterThanOrEqualTo(count);
                     count = newcount;
                 }
             });

--- a/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/MpscBoundedBufferTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using BitFaster.Caching.Buffers;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Buffers
@@ -14,19 +14,19 @@ namespace BitFaster.Caching.UnitTests.Buffers
         {
             Action constructor = () => { var x = new MpscBoundedBuffer<string>(-1); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
         public void SizeIsPowerOfTwo()
         {
-            buffer.Capacity.Should().Be(16);
+            buffer.Capacity.ShouldBe(16);
         }
 
         [Fact]
         public void WhenBufferIsEmptyCountIsZero()
         {
-            buffer.Count.Should().Be(0);
+            buffer.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -34,22 +34,22 @@ namespace BitFaster.Caching.UnitTests.Buffers
         {
             // head < tail
             buffer.TryAdd("1");
-            buffer.Count.Should().Be(1);
+            buffer.Count.ShouldBe(1);
         }
 
         [Fact]
         public void WhenBufferHas15ItemCountIs15()
         {
-            buffer.TryAdd("1").Should().Be(BufferStatus.Success);
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Success);
+            buffer.TryAdd("1").ShouldBe(BufferStatus.Success);
+            buffer.TryTake(out var _).ShouldBe(BufferStatus.Success);
 
             for (var i = 0; i < 15; i++)
             {
-                buffer.TryAdd("0").Should().Be(BufferStatus.Success);
+                buffer.TryAdd("0").ShouldBe(BufferStatus.Success);
             }
 
             // head = 1, tail = 0 : head > tail
-            buffer.Count.Should().Be(15);
+            buffer.Count.ShouldBe(15);
         }
 
         [Fact]
@@ -57,24 +57,24 @@ namespace BitFaster.Caching.UnitTests.Buffers
         {
             for (var i = 0; i < 16; i++)
             {
-                buffer.TryAdd(i.ToString()).Should().Be(BufferStatus.Success);
+                buffer.TryAdd(i.ToString()).ShouldBe(BufferStatus.Success);
             }
 
-            buffer.TryAdd("666").Should().Be(BufferStatus.Full);
+            buffer.TryAdd("666").ShouldBe(BufferStatus.Full);
         }
 
         [Fact]
         public void WhenBufferIsEmptyTryTakeIsFalse()
         {
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Empty);
+            buffer.TryTake(out var _).ShouldBe(BufferStatus.Empty);
         }
 
         [Fact]
         public void WhenItemAddedItCanBeTaken()
         {
-            buffer.TryAdd("123").Should().Be(BufferStatus.Success);
-            buffer.TryTake(out var item).Should().Be(BufferStatus.Success);
-            item.Should().Be("123");
+            buffer.TryAdd("123").ShouldBe(BufferStatus.Success);
+            buffer.TryTake(out var item).ShouldBe(BufferStatus.Success);
+            item.ShouldBe("123");
         }
 
         [Fact]
@@ -83,12 +83,12 @@ namespace BitFaster.Caching.UnitTests.Buffers
             buffer.TryAdd("1");
             buffer.TryAdd("2");
 
-            buffer.Count.Should().Be(2);
+            buffer.Count.ShouldBe(2);
 
             buffer.Clear();
 
-            buffer.Count.Should().Be(0);
-            buffer.TryTake(out var _).Should().Be(BufferStatus.Empty);
+            buffer.Count.ShouldBe(0);
+            buffer.TryTake(out var _).ShouldBe(BufferStatus.Empty);
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             var outputBuffer = new string[16];
             var output = new ArraySegment<string>(outputBuffer);
 
-            buffer.DrainTo(output).Should().Be(0);
+            buffer.DrainTo(output).ShouldBe(0);
         }
 
 #if NETCOREAPP3_0_OR_GREATER
@@ -110,11 +110,11 @@ namespace BitFaster.Caching.UnitTests.Buffers
 
             var outputBuffer = new string[16];
 
-            buffer.DrainTo(outputBuffer.AsSpan()).Should().Be(3);
+            buffer.DrainTo(outputBuffer.AsSpan()).ShouldBe(3);
 
-            outputBuffer[0].Should().Be("1");
-            outputBuffer[1].Should().Be("2");
-            outputBuffer[2].Should().Be("3");
+            outputBuffer[0].ShouldBe("1");
+            outputBuffer[1].ShouldBe("2");
+            outputBuffer[2].ShouldBe("3");
         }
 #endif
 
@@ -128,11 +128,11 @@ namespace BitFaster.Caching.UnitTests.Buffers
             var outputBuffer = new string[16];
             var output = new ArraySegment<string>(outputBuffer);
 
-            buffer.DrainTo(output).Should().Be(3);
+            buffer.DrainTo(output).ShouldBe(3);
 
-            outputBuffer[0].Should().Be("1");
-            outputBuffer[1].Should().Be("2");
-            outputBuffer[2].Should().Be("3");
+            outputBuffer[0].ShouldBe("1");
+            outputBuffer[1].ShouldBe("2");
+            outputBuffer[2].ShouldBe("3");
         }
 
         [Fact]
@@ -145,11 +145,11 @@ namespace BitFaster.Caching.UnitTests.Buffers
             var outputBuffer = new string[16];
             var output = new ArraySegment<string>(outputBuffer, 6, 10);
 
-            buffer.DrainTo(output).Should().Be(3);
+            buffer.DrainTo(output).ShouldBe(3);
 
-            outputBuffer[6].Should().Be("1");
-            outputBuffer[7].Should().Be("2");
-            outputBuffer[8].Should().Be("3");
+            outputBuffer[6].ShouldBe("1");
+            outputBuffer[7].ShouldBe("2");
+            outputBuffer[8].ShouldBe("3");
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Buffers/StripedMpscBufferTests.cs
+++ b/BitFaster.Caching.UnitTests/Buffers/StripedMpscBufferTests.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using BitFaster.Caching.Buffers;
-using FluentAssertions;
+﻿using BitFaster.Caching.Buffers;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Buffers
@@ -18,23 +13,23 @@ namespace BitFaster.Caching.UnitTests.Buffers
         [Fact]
         public void CapacityReturnsCapacity()
         {
-            buffer.Capacity.Should().Be(32);
+            buffer.Capacity.ShouldBe(32);
         }
 
         [Fact]
         public void CountReturnsCount()
         {
-            buffer.Count.Should().Be(0);
+            buffer.Count.ShouldBe(0);
 
             for (var i = 0; i < stripeCount; i++)
             {
                 for (var j = 0; j < bufferSize; j++)
                 {
-                    buffer.TryAdd(1.ToString()).Should().Be(BufferStatus.Success);
+                    buffer.TryAdd(1.ToString()).ShouldBe(BufferStatus.Success);
                 }
             }
 
-            buffer.Count.Should().Be(buffer.Capacity);
+            buffer.Count.ShouldBe(buffer.Capacity);
         }
 
         [Fact]
@@ -44,18 +39,18 @@ namespace BitFaster.Caching.UnitTests.Buffers
             {
                 for (var j = 0; j < bufferSize; j++)
                 {
-                    buffer.TryAdd(1.ToString()).Should().Be(BufferStatus.Success);
+                    buffer.TryAdd(1.ToString()).ShouldBe(BufferStatus.Success);
                 }
             }
 
-            buffer.TryAdd("1").Should().Be(BufferStatus.Full);
+            buffer.TryAdd("1").ShouldBe(BufferStatus.Full);
         }
 
         [Fact]
         public void WhenBufferIsEmptyDrainReturnsZero()
         {
             var array = new string[bufferSize];
-            buffer.DrainTo(array).Should().Be(0);
+            buffer.DrainTo(array).ShouldBe(0);
         }
 
         [Fact]
@@ -70,7 +65,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             }
 
             var array = new string[bufferSize * stripeCount];
-            buffer.DrainTo(array).Should().Be(stripeCount * bufferSize);
+            buffer.DrainTo(array).ShouldBe(stripeCount * bufferSize);
         }
 
         [Fact]
@@ -85,7 +80,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             }
 
             var array = new string[bufferSize];
-            buffer.DrainTo(array).Should().Be(bufferSize);
+            buffer.DrainTo(array).ShouldBe(bufferSize);
         }
 
         [Fact]
@@ -100,7 +95,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             }
 
             var array = new string[bufferSize+4];
-            buffer.DrainTo(array).Should().Be(bufferSize+4);
+            buffer.DrainTo(array).ShouldBe(bufferSize+4);
         }
 
         [Fact]
@@ -112,7 +107,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             }
 
             var array = new string[bufferSize * stripeCount];
-            buffer.DrainTo(array).Should().Be(bufferSize);
+            buffer.DrainTo(array).ShouldBe(bufferSize);
         }
 
         [Fact]
@@ -129,7 +124,7 @@ namespace BitFaster.Caching.UnitTests.Buffers
             buffer.Clear();
 
             var array = new string[bufferSize * stripeCount];
-            buffer.DrainTo(array).Should().Be(0);
+            buffer.DrainTo(array).ShouldBe(0);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheEventProxyBaseTests.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -28,7 +28,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.testCacheEvents.FireRemoved(1, new AtomicFactory<int, int>(1), ItemRemovedReason.Removed);
 
-            this.removedItems.First().Key.Should().Be(1);
+            this.removedItems.First().Key.ShouldBe(1);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.testCacheEvents.FireRemoved(1, new AtomicFactory<int, int>(1), ItemRemovedReason.Removed);
 
-            this.removedItems.Count.Should().Be(0);
+            this.removedItems.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.testCacheEvents.FireRemoved(1, new AtomicFactory<int, int>(1), ItemRemovedReason.Removed);
 
-            this.removedItems.First().Key.Should().Be(1);
+            this.removedItems.First().Key.ShouldBe(1);
         }
 
 // backcompat: remove conditional compile
@@ -63,9 +63,9 @@ namespace BitFaster.Caching.UnitTests
 
             this.testCacheEvents.FireUpdated(1, new AtomicFactory<int, int>(2), new AtomicFactory<int, int>(3));
 
-            this.updatedItems.First().Key.Should().Be(1);
-            this.updatedItems.First().OldValue.Should().Be(2);
-            this.updatedItems.First().NewValue.Should().Be(3);
+            this.updatedItems.First().Key.ShouldBe(1);
+            this.updatedItems.First().OldValue.ShouldBe(2);
+            this.updatedItems.First().NewValue.ShouldBe(3);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.testCacheEvents.FireUpdated(1, new AtomicFactory<int, int>(2), new AtomicFactory<int, int>(3));
 
-            this.updatedItems.Count.Should().Be(0);
+            this.updatedItems.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace BitFaster.Caching.UnitTests
 
             this.testCacheEvents.FireUpdated(1, new AtomicFactory<int, int>(2), new AtomicFactory<int, int>(3));
 
-            this.updatedItems.First().Key.Should().Be(1);
+            this.updatedItems.First().Key.ShouldBe(1);
         }
 #endif
         private void OnItemRemoved(object sender, ItemRemovedEventArgs<int, int> e)
@@ -156,9 +156,9 @@ namespace BitFaster.Caching.UnitTests
             this.testCacheEvents.FireUpdated(1, new AtomicFactory<int, int>(2), new AtomicFactory<int, int>(3));
 
 #if NETCOREAPP3_0_OR_GREATER
-            this.updatedItems.First().Key.Should().Be(1);
+            this.updatedItems.First().Key.ShouldBe(1);
 #else
-            this.updatedItems.Should().BeEmpty();
+            this.updatedItems.ShouldBeEmpty();
 #endif
         }
 

--- a/BitFaster.Caching.UnitTests/CacheEventsTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheEventsTests.cs
@@ -1,5 +1,4 @@
-﻿
-using Moq;
+﻿using Moq;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests

--- a/BitFaster.Caching.UnitTests/CacheMetricsTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheMetricsTests.cs
@@ -1,5 +1,4 @@
-﻿
-using FluentAssertions;
+﻿using Shouldly;
 using Moq;
 using Xunit;
 
@@ -15,7 +14,7 @@ namespace BitFaster.Caching.UnitTests
             var metrics = new Mock<ICacheMetrics>();
             metrics.CallBase = true;
 
-            metrics.Object.Updated.Should().Be(0);
+            metrics.Object.Updated.ShouldBe(0);
         }
     }
 #endif

--- a/BitFaster.Caching.UnitTests/CachePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/CachePolicyTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using Moq;
 using Xunit;
 
@@ -14,10 +14,10 @@ namespace BitFaster.Caching.UnitTests
 
             var cp = new CachePolicy(new Optional<IBoundedPolicy>(eviction.Object), new Optional<ITimePolicy>(expire.Object));
 
-            cp.Eviction.Value.Should().Be(eviction.Object);
-            cp.ExpireAfterWrite.Value.Should().Be(expire.Object);
-            cp.ExpireAfterAccess.HasValue.Should().BeFalse();
-            cp.ExpireAfter.HasValue.Should().BeFalse();
+            cp.Eviction.Value.ShouldBe(eviction.Object);
+            cp.ExpireAfterWrite.Value.ShouldBe(expire.Object);
+            cp.ExpireAfterAccess.HasValue.ShouldBeFalse();
+            cp.ExpireAfter.HasValue.ShouldBeFalse();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/CacheTests.cs
+++ b/BitFaster.Caching.UnitTests/CacheTests.cs
@@ -1,8 +1,7 @@
-﻿
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Threading.Tasks;
-using FluentAssertions;
+using System.Collections.Generic;
+using Shouldly;
 using Moq;
 using Xunit;
 
@@ -25,7 +24,7 @@ namespace BitFaster.Caching.UnitTests
             cache.Object.GetOrAdd(
                 1, 
                 (k, a) => k + a, 
-                2).Should().Be(3);
+                2).ShouldBe(3);
         }
 
         [Fact]
@@ -36,7 +35,7 @@ namespace BitFaster.Caching.UnitTests
 
             Action tryRemove = () => { cache.Object.TryRemove(1, out var value); };
 
-            tryRemove.Should().Throw<NotSupportedException>();
+            tryRemove.ShouldThrow<NotSupportedException>();
         }
 
         [Fact]
@@ -47,7 +46,7 @@ namespace BitFaster.Caching.UnitTests
 
             Action tryRemove = () => { cache.Object.TryRemove(new KeyValuePair<int, int>(1, 1)); };
 
-            tryRemove.Should().Throw<NotSupportedException>();
+            tryRemove.ShouldThrow<NotSupportedException>();
         }
 
         [Fact]
@@ -64,7 +63,7 @@ namespace BitFaster.Caching.UnitTests
                 (k, a) => Task.FromResult(k + a),
                 2);
             
-            r.Should().Be(3);
+            r.ShouldBe(3);
         }
 
         [Fact]
@@ -75,7 +74,7 @@ namespace BitFaster.Caching.UnitTests
 
             Action tryRemove = () => { cache.Object.TryRemove(1, out var value); };
 
-            tryRemove.Should().Throw<NotSupportedException>();
+            tryRemove.ShouldThrow<NotSupportedException>();
         }
 
         [Fact]
@@ -86,7 +85,7 @@ namespace BitFaster.Caching.UnitTests
 
             Action tryRemove = () => { cache.Object.TryRemove(new KeyValuePair<int, int>(1, 1)); };
 
-            tryRemove.Should().Throw<NotSupportedException>();
+            tryRemove.ShouldThrow<NotSupportedException>();
         }
 
         [Fact]
@@ -98,7 +97,7 @@ namespace BitFaster.Caching.UnitTests
             Func<int, Func<int, Scoped<Disposable>>, Lifetime<Disposable>> evaluate = (k, f) =>
                 {
                     var scope = f(k);
-                    scope.TryCreateLifetime(out var lifetime).Should().BeTrue();
+                    scope.TryCreateLifetime(out var lifetime).ShouldBeTrue();
                     return lifetime;
                 };
 
@@ -109,7 +108,7 @@ namespace BitFaster.Caching.UnitTests
                 (k, a) => new Scoped<Disposable>(new Disposable(k + a)),
                 2);
 
-            l.Value.State.Should().Be(3);
+            l.Value.State.ShouldBe(3);
         }
 
         [Fact]
@@ -121,7 +120,7 @@ namespace BitFaster.Caching.UnitTests
             Func<int, Func<int, Task<Scoped<Disposable>>>, ValueTask<Lifetime<Disposable>>> evaluate = async (k, f) =>
             {
                 var scope = await f(k);
-                scope.TryCreateLifetime(out var lifetime).Should().BeTrue();
+                scope.TryCreateLifetime(out var lifetime).ShouldBeTrue();
                 return lifetime;
             };
 
@@ -134,7 +133,7 @@ namespace BitFaster.Caching.UnitTests
                (k, a) => Task.FromResult(new Scoped<Disposable>(new Disposable(k + a))),
                2);
 
-            lifetime.Value.State.Should().Be(3);
+            lifetime.Value.State.ShouldBe(3);
         }
 #endif
     }

--- a/BitFaster.Caching.UnitTests/ConcurrentDictionarySizeTests.cs
+++ b/BitFaster.Caching.UnitTests/ConcurrentDictionarySizeTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -21,7 +21,7 @@ namespace BitFaster.Caching.UnitTests
         [InlineData(7199370, 7199370)]
         public void NextPrimeGreaterThan(int input, int nextPrime)
         {
-            ConcurrentDictionarySize.NextPrimeGreaterThan(input).Should().Be(nextPrime);
+            ConcurrentDictionarySize.NextPrimeGreaterThan(input).ShouldBe(nextPrime);
         }
 
         [Theory]
@@ -35,7 +35,7 @@ namespace BitFaster.Caching.UnitTests
         [InlineData(2003828731, 250478587)] // test overflow
         public void Estimate(int input, int optimal)
         {
-            ConcurrentDictionarySize.Estimate(input).Should().Be(optimal);
+            ConcurrentDictionarySize.Estimate(input).ShouldBe(optimal);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Counters/CounterSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Counters/CounterSoakTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using BitFaster.Caching.Counters;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Counters
@@ -21,7 +21,7 @@ namespace BitFaster.Caching.UnitTests.Counters
                 }
             });
 
-            adder.Count().Should().Be(400_000);
+            adder.Count().ShouldBe(400_000);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Counters/StripedLongAdderTests.cs
+++ b/BitFaster.Caching.UnitTests/Counters/StripedLongAdderTests.cs
@@ -1,5 +1,5 @@
 ﻿using BitFaster.Caching.Counters;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Counters
@@ -9,7 +9,7 @@ namespace BitFaster.Caching.UnitTests.Counters
         [Fact]
         public void InitialValueIsZero()
         {
-            new Counter().Count().Should().Be(0);
+            new Counter().Count().ShouldBe(0);
         }
 
         [Fact]
@@ -19,7 +19,7 @@ namespace BitFaster.Caching.UnitTests.Counters
 
             adder.Increment();
 
-            adder.Count().Should().Be(1);
+            adder.Count().ShouldBe(1);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Disposable.cs
+++ b/BitFaster.Caching.UnitTests/Disposable.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using FluentAssertions;
+using Shouldly;
 
 namespace BitFaster.Caching.UnitTests
 {
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.UnitTests
 
         public void Dispose()
         {
-            this.IsDisposed.Should().BeFalse();
+            this.IsDisposed.ShouldBeFalse();
             IsDisposed = true;
         }
     }

--- a/BitFaster.Caching.UnitTests/DisposableValueFactory.cs
+++ b/BitFaster.Caching.UnitTests/DisposableValueFactory.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BitFaster.Caching.UnitTests
+﻿namespace BitFaster.Caching.UnitTests
 {
     public class DisposableValueFactory
     {

--- a/BitFaster.Caching.UnitTests/DurationTests.cs
+++ b/BitFaster.Caching.UnitTests/DurationTests.cs
@@ -2,7 +2,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -25,24 +25,22 @@ namespace BitFaster.Caching.UnitTests
 #if NETCOREAPP3_0_OR_GREATER
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                // eps is 1/200 of a second
-                ulong eps = (ulong)(Stopwatch.Frequency / 200);
-                Duration.SinceEpoch().raw.Should().BeCloseTo(Stopwatch.GetTimestamp(), eps);
+                Duration.SinceEpoch().raw.ShouldBe(Stopwatch.GetTimestamp());
             }
             else
             {
-                Duration.SinceEpoch().raw.Should().BeCloseTo(Environment.TickCount64, 15);
+                Duration.SinceEpoch().raw.ShouldBe(Environment.TickCount64);
             }
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                Duration.SinceEpoch().raw.Should().BeCloseTo(Duration.GetTickCount64(), 15);
+                Duration.SinceEpoch().raw.ShouldBe(Duration.GetTickCount64());
             }
             else
             {
                 // eps is 1/200 of a second
                 ulong eps = (ulong)(Stopwatch.Frequency / 200);
-                Duration.SinceEpoch().raw.Should().BeCloseTo(Stopwatch.GetTimestamp(), eps);
+                Duration.SinceEpoch().raw.ShouldBe(Stopwatch.GetTimestamp());
             }
 #endif
         }
@@ -53,21 +51,21 @@ namespace BitFaster.Caching.UnitTests
 #if NETCOREAPP3_0_OR_GREATER
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                new Duration(100).ToTimeSpan().Should().BeCloseTo(new TimeSpan(100), TimeSpan.FromMilliseconds(50));
+                new Duration(100).ToTimeSpan().ShouldBe(new TimeSpan(100), TimeSpan.FromMilliseconds(50));
             }
             else
             {
-                new Duration(1000).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(10));
+                new Duration(1000).ToTimeSpan().ShouldBe(TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(10));
             }
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                new Duration(1000).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(10));
+                new Duration(1000).ToTimeSpan().ShouldBe(TimeSpan.FromMilliseconds(1000), TimeSpan.FromMilliseconds(10));
             }
             else
             {
                 // for Stopwatch.GetTimestamp() this is number of ticks
-                new Duration(1 * Stopwatch.Frequency).ToTimeSpan().Should().BeCloseTo(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10));
+                new Duration(1 * Stopwatch.Frequency).ToTimeSpan().ShouldBe(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(10));
             }
 #endif    
         }
@@ -79,23 +77,23 @@ namespace BitFaster.Caching.UnitTests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
-                    .Should().Be(Stopwatch.Frequency);
+                    .ShouldBe(Stopwatch.Frequency);
             }
             else
             {
                 Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
-                    .Should().Be((long)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                    .ShouldBe((long)TimeSpan.FromSeconds(1).TotalMilliseconds);
             }
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
-                    .Should().Be((long)TimeSpan.FromSeconds(1).TotalMilliseconds);
+                    .ShouldBe((long)TimeSpan.FromSeconds(1).TotalMilliseconds);
             }
             else
             {
                 Duration.FromTimeSpan(TimeSpan.FromSeconds(1)).raw
-                .Should().Be(Stopwatch.Frequency);
+                .ShouldBe(Stopwatch.Frequency);
             }
 #endif    
         }
@@ -105,7 +103,7 @@ namespace BitFaster.Caching.UnitTests
         {
             Duration.FromMilliseconds(2000)
                 .ToTimeSpan()
-                .Should().BeCloseTo(TimeSpan.FromMilliseconds(2000), TimeSpan.FromMilliseconds(50));
+                .ShouldBe(TimeSpan.FromMilliseconds(2000), TimeSpan.FromMilliseconds(50));
         }
 
         [Fact]
@@ -113,7 +111,7 @@ namespace BitFaster.Caching.UnitTests
         {
             Duration.FromSeconds(2)
                 .ToTimeSpan()
-                .Should().BeCloseTo(TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
+                .ShouldBe(TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(50));
         }
 
         [Fact]
@@ -121,7 +119,7 @@ namespace BitFaster.Caching.UnitTests
         {
             Duration.FromMinutes(2)
                 .ToTimeSpan()
-                .Should().BeCloseTo(TimeSpan.FromMinutes(2), TimeSpan.FromMilliseconds(100));
+                .ShouldBe(TimeSpan.FromMinutes(2), TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
@@ -129,7 +127,7 @@ namespace BitFaster.Caching.UnitTests
         {
             Duration.FromHours(2)
                 .ToTimeSpan()
-                .Should().BeCloseTo(TimeSpan.FromHours(2), TimeSpan.FromMilliseconds(100));
+                .ShouldBe(TimeSpan.FromHours(2), TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
@@ -137,7 +135,7 @@ namespace BitFaster.Caching.UnitTests
         {
             Duration.FromDays(2)
                 .ToTimeSpan()
-                .Should().BeCloseTo(TimeSpan.FromDays(2), TimeSpan.FromMilliseconds(100));
+                .ShouldBe(TimeSpan.FromDays(2), TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
@@ -145,7 +143,7 @@ namespace BitFaster.Caching.UnitTests
         {
             (Duration.FromDays(2) + Duration.FromDays(2))
                 .ToTimeSpan()
-                .Should().BeCloseTo(TimeSpan.FromDays(4), TimeSpan.FromMilliseconds(100));
+                .ShouldBe(TimeSpan.FromDays(4), TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
@@ -153,21 +151,21 @@ namespace BitFaster.Caching.UnitTests
         {
             (Duration.FromDays(4) - Duration.FromDays(2))
                 .ToTimeSpan()
-                .Should().BeCloseTo(TimeSpan.FromDays(2), TimeSpan.FromMilliseconds(100));
+                .ShouldBe(TimeSpan.FromDays(2), TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
         public void OperatorGreater()
         {
             (Duration.FromDays(4) > Duration.FromDays(2))
-                .Should().BeTrue();
+                .ShouldBeTrue();
         }
 
         [Fact]
         public void OperatorLess()
         {
             (Duration.FromDays(4) < Duration.FromDays(2))
-                .Should().BeFalse();
+                .ShouldBeFalse();
         }
 
         // This is for diagnostic purposes when tests run on different operating systems.

--- a/BitFaster.Caching.UnitTests/ExpireAfterAccessTests.cs
+++ b/BitFaster.Caching.UnitTests/ExpireAfterAccessTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentAssertions;
+﻿using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -17,25 +16,25 @@ namespace BitFaster.Caching.UnitTests
         [Fact]
         public void TimeToExpireReturnsCtorArg()
         {
-            expiryCalculator.TimeToExpire.Should().Be(expiry.ToTimeSpan());
+            expiryCalculator.TimeToExpire.ShouldBe(expiry.ToTimeSpan());
         }
 
         [Fact]
         public void AfterCreateReturnsTimeToExpire()
         { 
-            expiryCalculator.GetExpireAfterCreate(1, 2).Should().Be(expiry);
+            expiryCalculator.GetExpireAfterCreate(1, 2).ShouldBe(expiry);
         }
 
         [Fact]
         public void AfteReadReturnsTimeToExpire()
         {
-            expiryCalculator.GetExpireAfterRead(1, 2, Duration.SinceEpoch()).Should().Be(expiry);
+            expiryCalculator.GetExpireAfterRead(1, 2, Duration.SinceEpoch()).ShouldBe(expiry);
         }
 
         [Fact]
         public void AfteUpdateReturnsTimeToExpire()
         {
-            expiryCalculator.GetExpireAfterUpdate(1, 2, Duration.SinceEpoch()).Should().Be(expiry);
+            expiryCalculator.GetExpireAfterUpdate(1, 2, Duration.SinceEpoch()).ShouldBe(expiry);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/ExpireAfterWriteTests.cs
+++ b/BitFaster.Caching.UnitTests/ExpireAfterWriteTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using FluentAssertions;
+﻿using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -17,26 +16,26 @@ namespace BitFaster.Caching.UnitTests
         [Fact]
         public void TimeToExpireReturnsCtorArg()
         { 
-            expiryCalculator.TimeToExpire.Should().Be(expiry.ToTimeSpan());
+            expiryCalculator.TimeToExpire.ShouldBe(expiry.ToTimeSpan());
         }
 
         [Fact]
         public void AfterCreateReturnsTimeToExpire()
         {
-            expiryCalculator.GetExpireAfterCreate(1, 2).Should().Be(expiry);
+            expiryCalculator.GetExpireAfterCreate(1, 2).ShouldBe(expiry);
         }
 
         [Fact]
         public void AfteReadReturnsCurrentTimeToExpire()
         {
             var current = new Duration(123);
-            expiryCalculator.GetExpireAfterRead(1, 2, current).Should().Be(current);
+            expiryCalculator.GetExpireAfterRead(1, 2, current).ShouldBe(current);
         }
 
         [Fact]
         public void AfteUpdateReturnsTimeToExpire()
         {
-            expiryCalculator.GetExpireAfterUpdate(1, 2, Duration.SinceEpoch()).Should().Be(expiry);
+            expiryCalculator.GetExpireAfterUpdate(1, 2, Duration.SinceEpoch()).ShouldBe(expiry);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/CmSketchTests.cs
@@ -1,7 +1,6 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using BitFaster.Caching.Lfu;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lfu
@@ -40,11 +39,11 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 }
             }
 
-            baseline.Size.Should().Be(sketch.Size);
+            baseline.Size.ShouldBe(sketch.Size);
 
             for (int i = 0; i < 1_048_576; i++)
             {
-                sketch.EstimateFrequency(i).Should().Be(baseline.EstimateFrequency(i));
+                sketch.EstimateFrequency(i).ShouldBe(baseline.EstimateFrequency(i));
             }
         }
 
@@ -54,14 +53,14 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             sketch = new CmSketchCore<int, I>(0, EqualityComparer<int>.Default);
 
-            sketch.ResetSampleSize.Should().Be(10);
+            sketch.ResetSampleSize.ShouldBe(10);
         }
 
         [SkippableFact]
         public void WhenIncrementedOnceCountIsOne()
         {
             sketch.Increment(1);
-            sketch.EstimateFrequency(1).Should().Be(1);
+            sketch.EstimateFrequency(1).ShouldBe(1);
         }
 
         [SkippableFact]
@@ -72,7 +71,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 sketch.Increment(1);
             }
 
-            sketch.EstimateFrequency(1).Should().Be(15);
+            sketch.EstimateFrequency(1).ShouldBe(15);
         }
 
         [SkippableFact]
@@ -82,8 +81,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             sketch.Increment(1);
             sketch.Increment(2);
 
-            sketch.EstimateFrequency(1).Should().Be(2);
-            sketch.EstimateFrequency(2).Should().Be(1);
+            sketch.EstimateFrequency(1).ShouldBe(2);
+            sketch.EstimateFrequency(2).ShouldBe(1);
         }
 
         [SkippableFact]
@@ -99,15 +98,15 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
                 if (sketch.Size != i)
                 {
-                    i.Should().NotBe(1, "sketch should not be reset on the first iteration. Resize logic is broken");
+                    i.ShouldNotBe(1, "sketch should not be reset on the first iteration. Resize logic is broken");
 
                     reset = true;
                     break;
                 }
             }
 
-            reset.Should().BeTrue();
-            sketch.Size.Should().BeLessThan(10 * 64);
+            reset.ShouldBeTrue();
+            sketch.Size.ShouldBeLessThan(10 * 64);
         }
 
         [SkippableFact]
@@ -119,8 +118,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             sketch.Clear();
 
-            sketch.EstimateFrequency(1).Should().Be(0);
-            sketch.EstimateFrequency(2).Should().Be(0);
+            sketch.EstimateFrequency(1).ShouldBe(0);
+            sketch.EstimateFrequency(2).ShouldBe(0);
         }
 
         [SkippableFact]
@@ -150,19 +149,19 @@ namespace BitFaster.Caching.UnitTests.Lfu
             {
                 if ((i == 0) || (i == 1) || (i == 3) || (i == 5) || (i == 7) || (i == 9))
                 {
-                    popularity[i].Should().BeLessThanOrEqualTo(popularity[2]);
+                    popularity[i].ShouldBeLessThanOrEqualTo(popularity[2]);
                 }
                 else if (i == 2)
                 {
-                    popularity[2].Should().BeLessThanOrEqualTo(popularity[4]);
+                    popularity[2].ShouldBeLessThanOrEqualTo(popularity[4]);
                 }
                 else if (i == 4)
                 {
-                    popularity[4].Should().BeLessThanOrEqualTo(popularity[6]);
+                    popularity[4].ShouldBeLessThanOrEqualTo(popularity[6]);
                 }
                 else if (i == 6)
                 {
-                    popularity[6].Should().BeLessThanOrEqualTo(popularity[8]);
+                    popularity[6].ShouldBeLessThanOrEqualTo(popularity[8]);
                 }
             }
         }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
@@ -2,7 +2,7 @@
 using BitFaster.Caching.Atomic;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lfu
@@ -17,7 +17,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             Action constructor = () => { var x = b.Build(); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -27,7 +27,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lfu.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lfu.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .Build();
 
             var clfu = lfu as ConcurrentLfu<int, int>;
-            clfu.Scheduler.Should().BeOfType<NullScheduler>();
+            clfu.Scheduler.ShouldBeOfType<NullScheduler>();
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .Build();
 
             lfu.GetOrAdd("a", k => 1);
-            lfu.TryGet("A", out var value).Should().BeTrue();
+            lfu.TryGet("A", out var value).ShouldBeTrue();
         }
 
         [Fact]
@@ -59,9 +59,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithExpireAfterAccess(TimeSpan.FromSeconds(1))
                 .Build();
 
-            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.Should().BeTrue();
-            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.ShouldBeTrue();
+            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithExpireAfterWrite(TimeSpan.FromSeconds(2));
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -82,10 +82,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)))
                 .Build();
 
-            expireAfter.Policy.ExpireAfter.HasValue.Should().BeTrue();
+            expireAfter.Policy.ExpireAfter.HasValue.ShouldBeTrue();
 
-            expireAfter.Policy.ExpireAfterAccess.HasValue.Should().BeFalse();
-            expireAfter.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfter.Policy.ExpireAfterAccess.HasValue.ShouldBeFalse();
+            expireAfter.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -96,10 +96,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)))
                 .Build();
 
-            expireAfter.Policy.ExpireAfter.HasValue.Should().BeTrue();
+            expireAfter.Policy.ExpireAfter.HasValue.ShouldBeTrue();
 
-            expireAfter.Policy.ExpireAfterAccess.HasValue.Should().BeFalse();
-            expireAfter.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfter.Policy.ExpireAfterAccess.HasValue.ShouldBeFalse();
+            expireAfter.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
 
@@ -111,7 +111,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)));
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -122,7 +122,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)));
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)));
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -145,7 +145,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .AsScopedCache();
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithAtomicGetOrAdd();
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -169,7 +169,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .AsScopedCache();
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -182,7 +182,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithAtomicGetOrAdd();
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -193,9 +193,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .AsScopedCache()
                 .Build();
 
-            expireAfterWrite.Policy.ExpireAfterWrite.HasValue.Should().BeTrue();
-            expireAfterWrite.Policy.ExpireAfterWrite.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterWrite.Policy.ExpireAfterAccess.HasValue.Should().BeFalse();
+            expireAfterWrite.Policy.ExpireAfterWrite.HasValue.ShouldBeTrue();
+            expireAfterWrite.Policy.ExpireAfterWrite.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterWrite.Policy.ExpireAfterAccess.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -206,9 +206,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .AsScopedCache()
                 .Build();
 
-            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.Should().BeTrue();
-            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.ShouldBeTrue();
+            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -219,9 +219,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithAtomicGetOrAdd()
                 .Build();
 
-            expireAfterWrite.Policy.ExpireAfterWrite.HasValue.Should().BeTrue();
-            expireAfterWrite.Policy.ExpireAfterWrite.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterWrite.Policy.ExpireAfterAccess.HasValue.Should().BeFalse();
+            expireAfterWrite.Policy.ExpireAfterWrite.HasValue.ShouldBeTrue();
+            expireAfterWrite.Policy.ExpireAfterWrite.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterWrite.Policy.ExpireAfterAccess.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -232,9 +232,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithAtomicGetOrAdd()
                 .Build();
 
-            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.Should().BeTrue();
-            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.ShouldBeTrue();
+            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -246,9 +246,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithAtomicGetOrAdd()
                 .Build();
 
-            expireAfterWrite.Policy.ExpireAfterWrite.HasValue.Should().BeTrue();
-            expireAfterWrite.Policy.ExpireAfterWrite.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterWrite.Policy.ExpireAfterAccess.HasValue.Should().BeFalse();
+            expireAfterWrite.Policy.ExpireAfterWrite.HasValue.ShouldBeTrue();
+            expireAfterWrite.Policy.ExpireAfterWrite.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterWrite.Policy.ExpireAfterAccess.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -260,9 +260,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithAtomicGetOrAdd()
                 .Build();
 
-            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.Should().BeTrue();
-            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.ShouldBeTrue();
+            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         // 1
@@ -274,8 +274,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeOfType<ScopedCache<int, Disposable>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.ShouldBeOfType<ScopedCache<int, Disposable>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 2
@@ -287,7 +287,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeOfType<AtomicFactoryCache<int, int>>();
+            lru.ShouldBeOfType<AtomicFactoryCache<int, int>>();
         }
 
         // 3
@@ -299,7 +299,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IAsyncCache<int, int>>();
+            lru.ShouldBeAssignableTo<IAsyncCache<int, int>>();
         }
 
         // 4
@@ -312,8 +312,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeOfType<AtomicFactoryScopedCache<int, Disposable>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.ShouldBeOfType<AtomicFactoryScopedCache<int, Disposable>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 5
@@ -326,8 +326,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeOfType<AtomicFactoryScopedCache<int, Disposable>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.ShouldBeOfType<AtomicFactoryScopedCache<int, Disposable>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 6
@@ -340,9 +340,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
 
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 7
@@ -355,8 +355,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 8
@@ -369,7 +369,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IAsyncCache<int, int>>();
+            lru.ShouldBeAssignableTo<IAsyncCache<int, int>>();
         }
 
         // 9
@@ -382,7 +382,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IAsyncCache<int, int>>();
+            lru.ShouldBeAssignableTo<IAsyncCache<int, int>>();
         }
 
         // 10
@@ -396,7 +396,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 11
@@ -410,7 +410,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 12
@@ -424,7 +424,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 13
@@ -438,7 +438,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 14
@@ -452,7 +452,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 15
@@ -466,7 +466,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuCoreTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuCoreTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.UnitTests.Retry;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lfu
@@ -29,7 +29,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         [Fact]
         public void EvictionPolicyCapacityReturnsCapacity()
         {
-            lfu.Policy.Eviction.Value.Capacity.Should().Be(capacity);
+            lfu.Policy.Eviction.Value.Capacity.ShouldBe(capacity);
         }
 
         [Fact]
@@ -38,8 +38,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var result1 = lfu.GetOrAdd(1, valueFactory.Create);
             var result2 = lfu.GetOrAdd(1, valueFactory.Create);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 #if NETCOREAPP3_0_OR_GREATER
         [Fact]
@@ -48,8 +48,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var result1 = lfu.GetOrAdd(1, valueFactory.Create, 9);
             var result2 = lfu.GetOrAdd(1, valueFactory.Create, 17);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 #endif
         [Fact]
@@ -59,8 +59,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var result1 = await asyncLfu.GetOrAddAsync(1, valueFactory.CreateAsync);
             var result2 = await asyncLfu.GetOrAddAsync(1, valueFactory.CreateAsync);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
 #if NETCOREAPP3_0_OR_GREATER
@@ -71,8 +71,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var result1 = await asyncLfu.GetOrAddAsync(1, valueFactory.CreateAsync, 9);
             var result2 = await asyncLfu.GetOrAddAsync(1, valueFactory.CreateAsync, 17);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 #endif
 
@@ -82,8 +82,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             lfu.GetOrAdd(1, k => k);
             lfu.AddOrUpdate(1, 2);
 
-            lfu.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(2);
+            lfu.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(2);
         }
 
         [RetryFact]
@@ -91,8 +91,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu.AddOrUpdate(1, 2);
 
-            lfu.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(2);
+            lfu.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(2);
         }
 
 
@@ -101,8 +101,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu.GetOrAdd(1, k => k);
 
-            lfu.TryRemove(1).Should().BeTrue();
-            lfu.TryGet(1, out _).Should().BeFalse();
+            lfu.TryRemove(1).ShouldBeTrue();
+            lfu.TryGet(1, out _).ShouldBeFalse();
         }
 
 #if NETCOREAPP3_0_OR_GREATER
@@ -111,8 +111,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu.GetOrAdd(1, valueFactory.Create);
 
-            lfu.TryRemove(1, out var value).Should().BeTrue();
-            value.Should().Be(1);
+            lfu.TryRemove(1, out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -120,8 +120,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu.GetOrAdd(1, k => k);
 
-            lfu.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
-            lfu.TryGet(1, out _).Should().BeFalse();
+            lfu.TryRemove(new KeyValuePair<int, int>(1, 1)).ShouldBeTrue();
+            lfu.TryGet(1, out _).ShouldBeFalse();
         }
 
         [Fact]
@@ -129,8 +129,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu.GetOrAdd(1, k => k);
 
-            lfu.TryRemove(new KeyValuePair<int, int>(1, 2)).Should().BeFalse();
-            lfu.TryGet(1, out var value).Should().BeTrue();
+            lfu.TryRemove(new KeyValuePair<int, int>(1, 2)).ShouldBeFalse();
+            lfu.TryGet(1, out var value).ShouldBeTrue();
         }
 #endif
  
@@ -142,8 +142,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             lfu.Clear();
 
-            lfu.Count.Should().Be(0);
-            lfu.TryGet(1, out var _).Should().BeFalse();
+            lfu.Count.ShouldBe(0);
+            lfu.TryGet(1, out var _).ShouldBeFalse();
         }
 
         [Fact]
@@ -155,12 +155,12 @@ namespace BitFaster.Caching.UnitTests.Lfu
             }
             DoMaintenance<int, int>(lfu);
 
-            lfu.Count.Should().Be(20);
+            lfu.Count.ShouldBe(20);
 
             lfu.Policy.Eviction.Value.Trim(5);
             DoMaintenance<int, int>(lfu);
 
-            lfu.Count.Should().Be(15);
+            lfu.Count.ShouldBe(15);
         }
 
         [Fact]
@@ -170,10 +170,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
             lfu.GetOrAdd(2, k => k);
 
             var enumerator = lfu.GetEnumerator();
-            enumerator.MoveNext().Should().BeTrue();
-            enumerator.Current.Should().Be(new KeyValuePair<int, int>(1, 1));
-            enumerator.MoveNext().Should().BeTrue();
-            enumerator.Current.Should().Be(new KeyValuePair<int, int>(2, 2));
+            enumerator.MoveNext().ShouldBeTrue();
+            enumerator.Current.ShouldBe(new KeyValuePair<int, int>(1, 1));
+            enumerator.MoveNext().ShouldBeTrue();
+            enumerator.Current.ShouldBe(new KeyValuePair<int, int>(2, 2));
         }
 
         [Fact]
@@ -183,7 +183,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             lfu.GetOrAdd(2, k => k);
 
             var enumerable = (IEnumerable)lfu;
-            enumerable.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
+            enumerable.ShouldBe(new[] { new KeyValuePair<int, int>(1, 1), new KeyValuePair<int, int>(2, 2) });
         }
     }
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -107,7 +107,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             this.output.WriteLine($"Cache misses {cache.Metrics.Value.Misses} (sampled {samplePercent}%)");
             this.output.WriteLine($"Maintenance ops {cache.Scheduler.RunCount}");
 
-            cache.Metrics.Value.Misses.Should().Be(iterations);
+            cache.Metrics.Value.Misses.ShouldBe(iterations);
         }
 
         private void VerifyHits(ConcurrentLfu<int, int> cache, int iterations, int minSamples)
@@ -140,7 +140,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 this.output.WriteLine($"Error: {cache.Scheduler.LastException.Value}");
             }
 
-            cache.Metrics.Value.Hits.Should().BeGreaterThanOrEqualTo(minSamples);
+            cache.Metrics.Value.Hits.ShouldBeGreaterThanOrEqualTo(minSamples);
 
             // verify this doesn't block or throw
             var b = cache.Scheduler as BackgroundThreadScheduler;
@@ -287,7 +287,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             this.output.WriteLine($"Cache misses {cache.Metrics.Value.Misses} (sampled {samplePercent}%)");
             this.output.WriteLine($"Maintenance ops {cache.Scheduler.RunCount}");
 
-            cache.Metrics.Value.Misses.Should().Be(loopIterations * threads);
+            cache.Metrics.Value.Misses.ShouldBe(loopIterations * threads);
             RunIntegrityCheck(cache, this.output);
         }
 
@@ -308,7 +308,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             for (var i = 0; i < 100_000; i++)
             {
                 cache.AddOrUpdate(5, "a");
-                cache.TryGet(5, out _).Should().BeTrue("key 'a' should not be deleted");
+                cache.TryGet(5, out _).ShouldBeTrue("key 'a' should not be deleted");
                 cache.AddOrUpdate(5, "x");
             }
 
@@ -422,8 +422,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
 
             // buffers should be empty after maintenance
-            this.readBuffer.Count.Should().Be(0);
-            this.writeBuffer.Count.Should().Be(0);
+            this.readBuffer.Count.ShouldBe(0);
+            this.writeBuffer.Count.ShouldBe(0);
 
             // all the items in the LRUs must exist in the dictionary.
             // no items should be marked as removed after maintenance has run
@@ -435,7 +435,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             VerifyDictionaryInLrus();
 
             // cache must be within capacity
-            cache.Count.Should().BeLessThanOrEqualTo(cache.Capacity, "capacity out of valid range");
+            cache.Count.ShouldBeLessThanOrEqualTo(cache.Capacity, "capacity out of valid range");
         }
 
         private void VerifyLruInDictionary(LfuNodeList<K, V> lfuNodes, ITestOutputHelper output)
@@ -444,10 +444,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             while (node != null) 
             {
-                node.WasRemoved.Should().BeFalse();
-                node.WasDeleted.Should().BeFalse();
+                node.WasRemoved.ShouldBeFalse();
+                node.WasDeleted.ShouldBeFalse();
 
-                cache.TryGet(node.Key, out _).Should().BeTrue($"Orphaned node with key {node.Key} detected.");
+                cache.TryGet(node.Key, out _).ShouldBeTrue($"Orphaned node with key {node.Key} detected.");
 
                 node = node.Next;
             }
@@ -458,7 +458,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             foreach (var kvp in this.cache)
             {
                 var exists = Exists(kvp, this.windowLru) || Exists(kvp, this.probationLru) || Exists(kvp, this.protectedLru);
-                exists.Should().BeTrue($"key {kvp.Key} must exist in LRU lists");
+                exists.ShouldBeTrue($"key {kvp.Key} must exist in LRU lists");
             }
         }
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using BitFaster.Caching.UnitTests.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -31,7 +29,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             Action constructor = () => { var x = new ConcurrentLfu<int, string>(2); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -39,7 +37,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             var x = new ConcurrentLfu<int, string>(3);
 
-            x.Capacity.Should().Be(3);
+            x.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -47,14 +45,14 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             Action constructor = () => { var x = new ConcurrentLfu<int, string>(0, 20, new ForegroundScheduler(), EqualityComparer<int>.Default); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
         public void DefaultSchedulerIsThreadPool()
         {
             var cache = new ConcurrentLfu<int, int>(20);
-            cache.Scheduler.Should().BeOfType<ThreadPoolScheduler>();
+            cache.Scheduler.ShouldBeOfType<ThreadPoolScheduler>();
         }
 
         [Fact]
@@ -63,8 +61,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var result1 = cache.GetOrAdd(1, valueFactory.Create);
             var result2 = cache.GetOrAdd(1, valueFactory.Create);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -73,8 +71,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var result1 = cache.GetOrAdd(1, valueFactory.Create, 9);
             var result2 = cache.GetOrAdd(1, valueFactory.Create, 17);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -83,8 +81,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var result1 = await cache.GetOrAddAsync(1, valueFactory.CreateAsync);
             var result2 = await cache.GetOrAddAsync(1, valueFactory.CreateAsync);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -93,8 +91,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var result1 = await cache.GetOrAddAsync(1, valueFactory.CreateAsync, 9);
             var result2 = await cache.GetOrAddAsync(1, valueFactory.CreateAsync, 17);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -113,7 +111,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
             LogLru();
 
-            cache.Count.Should().Be(20);
+            cache.Count.ShouldBe(20);
         }
 
         [Fact]
@@ -131,8 +129,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             dcache.DoMaintenance();
             LogLru();
 
-            dcache.Count.Should().Be(20);
-            disposables.Count(d => d.IsDisposed).Should().Be(5);
+            dcache.Count.ShouldBe(20);
+            disposables.Count(d => d.IsDisposed).ShouldBe(5);
         }
 
         // protected 15
@@ -185,16 +183,16 @@ namespace BitFaster.Caching.UnitTests.Lfu
             // W[24] Protected[4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 20, 21, 22, 23] Probation[1, 2, 3, 25]
             // W[24] Protected[5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 20, 21, 22, 23, 25] Probation[1, 2, 3, 4]
 
-            cache.Count.Should().Be(20);
+            cache.Count.ShouldBe(20);
 
             // W [24] Protected [5,6,7,8,9,10,11,12,13,14,20,21,22,23,25] Probation []
             cache.Trim(4);
             cache.DoMaintenance();
             LogLru();
 
-            cache.TryGet(1, out var value1).Should().BeFalse();
-            cache.TryGet(2, out var value2).Should().BeFalse();
-            cache.Count.Should().Be(16);
+            cache.TryGet(1, out var value1).ShouldBeFalse();
+            cache.TryGet(2, out var value2).ShouldBeFalse();
+            cache.Count.ShouldBe(16);
         }
 
         [Fact]
@@ -230,7 +228,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
             LogLru();
 
-            cache.TryGet(16, out var value1).Should().BeTrue();
+            cache.TryGet(16, out var value1).ShouldBeTrue();
         }
 
         // when probation item is written it is moved to protected
@@ -247,7 +245,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             LogLru();
 
             // W [24] Protected [16] Probation [2,6,7,8,9,10,11,12,13,14,15,17,18,19,20,21,22,23]
-            cache.TryUpdate(16, -16).Should().BeTrue();
+            cache.TryUpdate(16, -16).ShouldBeTrue();
             cache.DoMaintenance();
             LogLru();
 
@@ -267,7 +265,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
             LogLru();
 
-            cache.TryGet(16, out var value1).Should().BeTrue();
+            cache.TryGet(16, out var value1).ShouldBeTrue();
         }
 
         [Fact]
@@ -302,7 +300,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
             LogLru();
 
-            cache.TryGet(7, out var _).Should().BeTrue();
+            cache.TryGet(7, out var _).ShouldBeTrue();
         }
 
         [Fact]
@@ -327,7 +325,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             // W [19] Protected [8,9,7] Probation [0,1,2,3,4,5,6,10,11,12,13,14,15,16,17,18]
             // element 7 now moved to back of LRU
-            cache.TryUpdate(7, -7).Should().BeTrue();
+            cache.TryUpdate(7, -7).ShouldBeTrue();
             cache.DoMaintenance();
             LogLru();
 
@@ -337,7 +335,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
             LogLru();
 
-            cache.TryGet(7, out var _).Should().BeTrue();
+            cache.TryGet(7, out var _).ShouldBeTrue();
         }
 
         [Fact]
@@ -402,8 +400,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
             LogLru();
 
-            cache.TryGet(666, out var _).Should().BeTrue();
-            cache.TryGet(667, out var _).Should().BeTrue();
+            cache.TryGet(666, out var _).ShouldBeTrue();
+            cache.TryGet(667, out var _).ShouldBeTrue();
 
             this.output.WriteLine($"Scheduler ran {cache.Scheduler.RunCount} times.");
         }
@@ -415,18 +413,18 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache = new ConcurrentLfu<int, int>(1, 20, scheduler, EqualityComparer<int>.Default);
 
             cache.GetOrAdd(1, k => k);
-            scheduler.RunCount.Should().Be(1);
+            scheduler.RunCount.ShouldBe(1);
             cache.DoMaintenance();
 
             for (int i = 0; i < ConcurrentLfu<int, int>.DefaultBufferSize; i++)
             {
-                scheduler.RunCount.Should().Be(1);
+                scheduler.RunCount.ShouldBe(1);
                 cache.GetOrAdd(1, k => k);
             }
 
             // read buffer is now full, next read triggers maintenance
             cache.GetOrAdd(1, k => k);
-            scheduler.RunCount.Should().Be(2);
+            scheduler.RunCount.ShouldBe(2);
         }
 
         [Fact]
@@ -436,7 +434,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache = new ConcurrentLfu<int, int>(1, 20, scheduler, EqualityComparer<int>.Default);
 
             cache.GetOrAdd(1, k => k);
-            scheduler.RunCount.Should().Be(1);
+            scheduler.RunCount.ShouldBe(1);
             cache.DoMaintenance();
 
             for (int i = 0; i < ConcurrentLfu<int, int>.DefaultBufferSize * 2; i++)
@@ -446,7 +444,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             cache.DoMaintenance();
 
-            cache.Metrics.Value.Hits.Should().Be(ConcurrentLfu<int, int>.DefaultBufferSize);
+            cache.Metrics.Value.Hits.ShouldBe(ConcurrentLfu<int, int>.DefaultBufferSize);
         }
 
         [Fact]
@@ -462,7 +460,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
 
             // remove the item but don't flush, it is now in the write buffer and maintenance is scheduled
-            cache.TryRemove(-1).Should().BeTrue();
+            cache.TryRemove(-1).ShouldBeTrue();
 
             // add buffer size items, last iteration will invoke maintenance on the foreground since write
             // buffer is full and test scheduler did not do any work
@@ -473,7 +471,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             // pending write (to remove -1) should be flushed by the 128th write calling maintenance
             // directly within AfterWrite
-            cache.TryGet(-1, out var _).Should().BeFalse();
+            cache.TryGet(-1, out var _).ShouldBeFalse();
         }
 
 // backcompat: remove conditional compile
@@ -487,7 +485,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache = new ConcurrentLfu<int, int>(1, capacity, scheduler, EqualityComparer<int>.Default);
 
             cache.GetOrAdd(1, k => k);
-            scheduler.RunCount.Should().Be(1);
+            scheduler.RunCount.ShouldBe(1);
             cache.DoMaintenance();
 
             for (int i = 0; i < bufferSize * 2; i++)
@@ -497,32 +495,32 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             cache.DoMaintenance();
 
-            cache.Metrics.Value.Updated.Should().Be(bufferSize);
+            cache.Metrics.Value.Updated.ShouldBe(bufferSize);
         }
 #endif
 
         [Fact]
         public void EvictionPolicyReturnsCapacity()
         {
-            cache.Policy.Eviction.Value.Capacity.Should().Be(20);
+            cache.Policy.Eviction.Value.Capacity.ShouldBe(20);
         }
 
         [Fact]
         public void ExpireAfterWriteIsDisabled()
         {
-            cache.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            cache.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
         public void EventsAreDisabled()
         {
-            cache.Events.HasValue.Should().BeFalse();
+            cache.Events.HasValue.ShouldBeFalse();
         }
 
         [Fact]
         public void MetricsAreEnabled()
         {
-            cache.Metrics.HasValue.Should().BeTrue();
+            cache.Metrics.HasValue.ShouldBeTrue();
         }
 
         [Fact]
@@ -533,9 +531,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             cache.DoMaintenance();
 
-            cache.Metrics.Value.HitRatio.Should().Be(0.5);
-            cache.Metrics.Value.Hits.Should().Be(1);
-            cache.Metrics.Value.Misses.Should().Be(1);
+            cache.Metrics.Value.HitRatio.ShouldBe(0.5);
+            cache.Metrics.Value.Hits.ShouldBe(1);
+            cache.Metrics.Value.Misses.ShouldBe(1);
         }
 
         [Fact]
@@ -553,41 +551,41 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             cache.DoMaintenance();
 
-            cache.Metrics.Value.Evicted.Should().Be(5);
+            cache.Metrics.Value.Evicted.ShouldBe(5);
         }
 
         [Fact]
         public void WhenItemsAddedKeysContainsTheKeys()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.GetOrAdd(1, k => k);
             cache.GetOrAdd(2, k => k);
-            cache.Keys.Should().BeEquivalentTo(new[] { 1, 2 });
+            cache.Keys.ShouldBe(new[] { 1, 2 });
         }
 
         [Fact]
         public void WhenItemsAddedGenericEnumerateContainsKvps()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.GetOrAdd(1, k => k + 1);
             cache.GetOrAdd(2, k => k + 1);
 
             var enumerator = cache.GetEnumerator();
-            enumerator.MoveNext().Should().BeTrue();
-            enumerator.Current.Should().Be(new KeyValuePair<int, int>(1, 2));
-            enumerator.MoveNext().Should().BeTrue();
-            enumerator.Current.Should().Be(new KeyValuePair<int, int>(2, 3));
+            enumerator.MoveNext().ShouldBeTrue();
+            enumerator.Current.ShouldBe(new KeyValuePair<int, int>(1, 2));
+            enumerator.MoveNext().ShouldBeTrue();
+            enumerator.Current.ShouldBe(new KeyValuePair<int, int>(2, 3));
         }
 
         [Fact]
         public void WhenItemsAddedEnumerateContainsKvps()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.GetOrAdd(1, k => k + 1);
             cache.GetOrAdd(2, k => k + 1);
 
             var enumerable = (IEnumerable)cache;
-            enumerable.Should().BeEquivalentTo(new[] { new KeyValuePair<int, int>(1, 2), new KeyValuePair<int, int>(2, 3) });
+            enumerable.ShouldBe(new[] { new KeyValuePair<int, int>(1, 2), new KeyValuePair<int, int>(2, 3) });
         }
 
         [Fact]
@@ -596,8 +594,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.GetOrAdd(1, k => k);
             cache.AddOrUpdate(1, 2);
 
-            cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(2);
+            cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(2);
         }
 
         [Fact]
@@ -609,8 +607,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             lfu2.AddOrUpdate(1, new Guid(1, 0, 0, b));
             lfu2.AddOrUpdate(1, new Guid(2, 0, 0, b));
 
-            lfu2.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(new Guid(2, 0, 0, b));
+            lfu2.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(new Guid(2, 0, 0, b));
         }
 
         [Fact]
@@ -618,8 +616,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             cache.AddOrUpdate(1, 2);
 
-            cache.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(2);
+            cache.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(2);
         }
 
         [Fact]
@@ -627,8 +625,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             cache.GetOrAdd(1, k => k);
 
-            cache.TryRemove(1).Should().BeTrue();
-            cache.TryGet(1, out _).Should().BeFalse();
+            cache.TryRemove(1).ShouldBeTrue();
+            cache.TryGet(1, out _).ShouldBeFalse();
         }
 
         [Fact]
@@ -636,8 +634,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             cache.GetOrAdd(1, valueFactory.Create);
 
-            cache.TryRemove(1, out var value).Should().BeTrue();
-            value.Should().Be(1);
+            cache.TryRemove(1, out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -645,8 +643,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             cache.GetOrAdd(1, k => k);
 
-            cache.TryRemove(new KeyValuePair<int, int>(1, 1)).Should().BeTrue();
-            cache.TryGet(1, out _).Should().BeFalse();
+            cache.TryRemove(new KeyValuePair<int, int>(1, 1)).ShouldBeTrue();
+            cache.TryGet(1, out _).ShouldBeFalse();
         }
 
         [Fact]
@@ -654,8 +652,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             cache.GetOrAdd(1, k => k);
 
-            cache.TryRemove(new KeyValuePair<int, int>(1, 2)).Should().BeFalse();
-            cache.TryGet(1, out var value).Should().BeTrue();
+            cache.TryRemove(new KeyValuePair<int, int>(1, 2)).ShouldBeFalse();
+            cache.TryGet(1, out var value).ShouldBeTrue();
         }
 
         [Fact]
@@ -666,10 +664,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             dcache.GetOrAdd(1, k => disposable);
 
-            dcache.TryRemove(1).Should().BeTrue();
+            dcache.TryRemove(1).ShouldBeTrue();
             dcache.DoMaintenance();
 
-            disposable.IsDisposed.Should().BeTrue();
+            disposable.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -677,16 +675,16 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             cache.GetOrAdd(1, k => k);
 
-            cache.TryRemove(1).Should().BeTrue();
+            cache.TryRemove(1).ShouldBeTrue();
             cache.DoMaintenance();
 
-            cache.Metrics.Value.Evicted.Should().Be(1);
+            cache.Metrics.Value.Evicted.ShouldBe(1);
         }
 
         [Fact]
         public void WhenItemDoesNotExistTryRemoveIsFalse()
         {
-            cache.TryRemove(1).Should().BeFalse();
+            cache.TryRemove(1).ShouldBeFalse();
         }
 
         // OnWrite handles the case where a node is removed while the write buffer contains the node
@@ -702,17 +700,17 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.TryUpdate(1, 2);
 
             // immediately remove
-            cache.TryRemove(1).Should().BeTrue();
+            cache.TryRemove(1).ShouldBeTrue();
 
             cache.DoMaintenance();
 
-            cache.TryGet(1, out var _).Should().BeFalse();
+            cache.TryGet(1, out var _).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenItemDoesNotExistTryUpdateIsFalse()
         {
-            cache.TryUpdate(1, 2).Should().BeFalse();
+            cache.TryUpdate(1, 2).ShouldBeFalse();
         }
 
         [Fact]
@@ -720,9 +718,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             // use foreground so that any null ref exceptions will surface
             var lfu = new ConcurrentLfu<int, string>(1, 20, new ForegroundScheduler(), EqualityComparer<int>.Default);
-            lfu.GetOrAdd(1, _ => null).Should().BeNull();
+            lfu.GetOrAdd(1, _ => null).ShouldBeNull();
             lfu.AddOrUpdate(1, null);
-            lfu.TryRemove(1).Should().BeTrue();
+            lfu.TryRemove(1).ShouldBeTrue();
         }
 
         [Fact]
@@ -733,8 +731,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             cache.Clear();
 
-            cache.Count.Should().Be(0);
-            cache.TryGet(1, out var _).Should().BeFalse();
+            cache.Count.ShouldBe(0);
+            cache.TryGet(1, out var _).ShouldBeFalse();
         }
 
         [Fact]
@@ -755,7 +753,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             }
 
             // there should be no iteration of the loop where count != 0
-            overflow.Should().Be(0);
+            overflow.ShouldBe(0);
         }
 
         [Fact]
@@ -767,12 +765,12 @@ namespace BitFaster.Caching.UnitTests.Lfu
             }
             cache.DoMaintenance();
 
-            cache.Count.Should().Be(20);
+            cache.Count.ShouldBe(20);
 
             cache.Trim(5);
             cache.DoMaintenance();
 
-            cache.Count.Should().Be(15);
+            cache.Count.ShouldBe(15);
         }
 
         [Fact]
@@ -792,8 +790,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.DoMaintenance();
 
             // The trim takes effect before all the writes are replayed by the maintenance thread.
-            cache.Metrics.Value.Evicted.Should().Be(10);
-            cache.Count.Should().Be(15);
+            cache.Metrics.Value.Evicted.ShouldBe(10);
+            cache.Count.ShouldBe(15);
 
             this.output.WriteLine($"Count {cache.Count}");
             this.output.WriteLine($"Keys {string.Join(",", cache.Keys.Select(k => k.ToString()))}");

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuSoakTests.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lfu;
 using Xunit;

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using BitFaster.Caching.UnitTests.Retry;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lfu
@@ -50,8 +49,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 TimeSpan.FromSeconds(2),
                 cache =>
                 { 
-                    cache.TryGet(1, out var value).Should().BeTrue();
-                    cache.TryGet(1, out value).Should().BeTrue();
+                    cache.TryGet(1, out var value).ShouldBeTrue();
+                    cache.TryGet(1, out value).ShouldBeTrue();
                 }
             );
         }
@@ -63,35 +62,35 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             lfu.GetOrAdd("foo", k => 1);
 
-            lfu.TryGet("FOO", out var value).Should().BeTrue();
-            value.Should().Be(1);
+            lfu.TryGet("FOO", out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
         public void MetricsHasValueIsTrue()
         {
             var x = new ConcurrentTLfu<int, int>(3, new TestExpiryCalculator<int, int>());
-            x.Metrics.HasValue.Should().BeTrue();
+            x.Metrics.HasValue.ShouldBeTrue();
         }
 
         [Fact]
         public void EventsHasValueIsFalse()
         {
             var x = new ConcurrentTLfu<int, int>(3, new TestExpiryCalculator<int, int>());
-            x.Events.HasValue.Should().BeFalse();
+            x.Events.HasValue.ShouldBeFalse();
         }
 
         [Fact]
         public void DefaultSchedulerIsThreadPool()
         {
-            lfu.Scheduler.Should().BeOfType<ThreadPoolScheduler>();
+            lfu.Scheduler.ShouldBeOfType<ThreadPoolScheduler>();
         }
 
         [Fact]
         public void WhenCalculatorIsAfterWritePolicyIsAfterWrite()
         { 
-            lfu.Policy.ExpireAfterWrite.HasValue.Should().BeTrue();
-            lfu.Policy.ExpireAfterWrite.Value.TimeToLive.Should().Be(timeToLive);
+            lfu.Policy.ExpireAfterWrite.HasValue.ShouldBeTrue();
+            lfu.Policy.ExpireAfterWrite.Value.TimeToLive.ShouldBe(timeToLive);
         }
 
         [Fact]
@@ -99,8 +98,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu = new ConcurrentTLfu<int, string>(capacity, new ExpireAfterAccess<int, string>(timeToLive));
 
-            lfu.Policy.ExpireAfterAccess.HasValue.Should().BeTrue();
-            lfu.Policy.ExpireAfterAccess.Value.TimeToLive.Should().Be(timeToLive);
+            lfu.Policy.ExpireAfterAccess.HasValue.ShouldBeTrue();
+            lfu.Policy.ExpireAfterAccess.Value.TimeToLive.ShouldBe(timeToLive);
         }
 
         [Fact]
@@ -108,8 +107,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu = new ConcurrentTLfu<int, string>(capacity, new TestExpiryCalculator<int, string>());
 
-            lfu.Policy.ExpireAfter.HasValue.Should().BeTrue();
-            (lfu as ITimePolicy).TimeToLive.Should().Be(TimeSpan.Zero);
+            lfu.Policy.ExpireAfter.HasValue.ShouldBeTrue();
+            (lfu as ITimePolicy).TimeToLive.ShouldBe(TimeSpan.Zero);
         }
 
         [Fact]
@@ -121,8 +120,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             lfu.GetOrAdd(1, k => "1");
 
-            lfu.Policy.ExpireAfter.Value.TryGetTimeToExpire(1, out var timeToExpire).Should().BeTrue();
-            timeToExpire.Should().BeCloseTo(TimeSpan.FromMinutes(1), TimeSpan.FromMilliseconds(50));
+            lfu.Policy.ExpireAfter.Value.TryGetTimeToExpire(1, out var timeToExpire).ShouldBeTrue();
+            timeToExpire.ShouldBe(TimeSpan.FromMinutes(1), TimeSpan.FromMilliseconds(50));
         }
 
         [Fact]
@@ -130,7 +129,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu = new ConcurrentTLfu<int, string>(capacity, new TestExpiryCalculator<int, string>());
 
-            lfu.Policy.ExpireAfter.Value.TryGetTimeToExpire(1, out _).Should().BeFalse();
+            lfu.Policy.ExpireAfter.Value.TryGetTimeToExpire(1, out _).ShouldBeFalse();
         }
 
         [Fact]
@@ -138,7 +137,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu = new ConcurrentTLfu<int, string>(capacity, new TestExpiryCalculator<int, string>());
 
-            lfu.Policy.ExpireAfter.Value.TryGetTimeToExpire("string", out _).Should().BeFalse();
+            lfu.Policy.ExpireAfter.Value.TryGetTimeToExpire("string", out _).ShouldBeFalse();
         }
 
         // policy can expire after write
@@ -148,7 +147,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             lfu.GetOrAdd(1, valueFactory.Create);
 
-            lfu.TryGet(1, out var value).Should().BeTrue();
+            lfu.TryGet(1, out var value).ShouldBeTrue();
         }
 
         [RetryFact]
@@ -164,7 +163,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 timeToLive.MultiplyBy(ttlWaitMlutiplier),
                 lfu =>
                 {
-                    lfu.TryGet(1, out var value).Should().BeFalse();
+                    lfu.TryGet(1, out var value).ShouldBeFalse();
                 }
             );
         }
@@ -185,7 +184,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                     // This is a bit flaky below 2 secs pause - seems like it doesnt always
                     // remove the item
                     lfu.Policy.ExpireAfterWrite.Value.TrimExpired();
-                    lfu.Count.Should().Be(0);
+                    lfu.Count.ShouldBe(0);
                 }
             );
         }
@@ -208,7 +207,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
                     // If we defer computing time to the maintenance loop, we
                     // need to call maintenance here for the timestamp to be updated
                     lfu.DoMaintenance();
-                    lfu.TryGet(1, out var value).Should().BeTrue();
+                    lfu.TryGet(1, out var value).ShouldBeTrue();
                 }
             );
         }

--- a/BitFaster.Caching.UnitTests/Lfu/LfuCapacityPartitionTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/LfuCapacityPartitionTests.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Lfu;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,14 +22,14 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             Action constructor = () => { var partition = new LfuCapacityPartition(2); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
         public void CapacityReturnsCapacity()
         {
             var partition = new LfuCapacityPartition(123);
-            partition.Capacity.Should().Be(123);
+            partition.Capacity.ShouldBe(123);
         }
 
         [Theory]
@@ -41,9 +39,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             var partition = new LfuCapacityPartition(capacity);
 
-            partition.Window.Should().Be(expectedWindow);
-            partition.Protected.Should().Be(expectedProtected);
-            partition.Probation.Should().Be(expectedProbation);
+            partition.Window.ShouldBe(expectedWindow);
+            partition.Protected.ShouldBe(expectedProtected);
+            partition.Probation.ShouldBe(expectedProbation);
         }
 
         [Fact]
@@ -60,8 +58,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 SetHitRate(partition, metrics, max, 0.1);
             }
 
-            partition.Window.Should().Be(80);
-            partition.Protected.Should().Be(16);
+            partition.Window.ShouldBe(80);
+            partition.Protected.ShouldBe(16);
         }
 
         [Fact]
@@ -102,7 +100,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             var minWindow = last50.Min();
             var maxWindow = last50.Max();
 
-            (maxWindow - minWindow).Should().BeLessThanOrEqualTo(1);
+            (maxWindow - minWindow).ShouldBeLessThanOrEqualTo(1);
         }
 
         [Fact]
@@ -166,13 +164,13 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             public void AssertWindowIncreased(LfuCapacityPartition p)
             {
-                p.Window.Should().BeGreaterThan(prev);
+                p.Window.ShouldBeGreaterThan(prev);
                 prev = p.Window;
             }
 
             public void AssertWindowDecreased(LfuCapacityPartition p)
             {
-                p.Window.Should().BeLessThan(prev);
+                p.Window.ShouldBeLessThan(prev);
                 prev = p.Window;
             }
         }

--- a/BitFaster.Caching.UnitTests/Lfu/LfuInfoTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/LfuInfoTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using BitFaster.Caching.Lfu.Builder;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lfu
@@ -12,7 +12,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             var info = new LfuInfo<int>();
 
-            info.GetExpiry<string>().Should().BeNull();
+            info.GetExpiry<string>().ShouldBeNull();
         }
 
         [Fact]
@@ -23,7 +23,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             info.SetExpiry<int>(new TestExpiryCalculator<int, int>());
 
             Action act = () => info.GetExpiry<string>();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/LfuNodeListTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/LfuNodeListTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using BitFaster.Caching.Lfu;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lfu
@@ -13,7 +13,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             var list = new LfuNodeList<int, int>();
             Action remove = () => { list.RemoveFirst(); };
-            remove.Should().Throw<InvalidOperationException>();
+            remove.ShouldThrow<InvalidOperationException>();
         }
 #endif
 
@@ -22,7 +22,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             var list = new LfuNodeList<int, int>();
 
-            list.Last.Should().BeNull();
+            list.Last.ShouldBeNull();
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             list.AddLast(node1);
             list.AddLast(node2);
 
-            list.Last.Should().BeSameAs(node2);
+            list.Last.ShouldBeSameAs(node2);
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             list.AddLast(node1);
             list.AddLast(node2);
 
-            node2.Previous.Should().BeSameAs(node1);
+            node2.Previous.ShouldBeSameAs(node1);
         }
 
         [Fact]
@@ -61,7 +61,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             list.AddLast(node1);
             list.AddLast(node2);
 
-            node1.Previous.Should().BeNull();
+            node1.Previous.ShouldBeNull();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/TestScheduler.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/TestScheduler.cs
@@ -1,9 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Scheduler;
 
 namespace BitFaster.Caching.UnitTests.Lfu

--- a/BitFaster.Caching.UnitTests/Lru/AfterAccessPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/AfterAccessPolicyTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
 using System.Threading.Tasks;
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { new AfterAccessPolicy<int, int>(TimeSpan.MaxValue); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -23,20 +23,20 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { new AfterAccessPolicy<int, int>(TimeSpan.Zero); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
         public void WhenTtlIsMaxSetAsMax()
         {
             var policy = new AfterAccessPolicy<int, int>(Duration.MaxRepresentable);
-            policy.TimeToLive.Should().BeCloseTo(Duration.MaxRepresentable, TimeSpan.FromMilliseconds(20));
+            policy.TimeToLive.ShouldBe(Duration.MaxRepresentable, TimeSpan.FromMilliseconds(20));
         }
 
         [Fact]
         public void TimeToLiveShouldBeTenSecs()
         {
-            this.policy.TimeToLive.Should().Be(TimeSpan.FromSeconds(10));
+            this.policy.TimeToLive.ShouldBe(TimeSpan.FromSeconds(10));
         }
 
         [Fact]
@@ -44,8 +44,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.Key.Should().Be(1);
-            item.Value.Should().Be(2);
+            item.Key.ShouldBe(1);
+            item.Value.ShouldBe(2);
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.TickCount.Should().BeCloseTo(Duration.SinceEpoch().raw, DurationTests.epsilon);
+            item.TickCount.ShouldBe(Duration.SinceEpoch().raw);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Touch(item);
 
-            item.WasAccessed.Should().BeTrue();
+            item.WasAccessed.ShouldBeTrue();
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             this.policy.ShouldDiscard(item); // set the time in the policy
             this.policy.Touch(item);
 
-            item.TickCount.Should().BeGreaterThan(tc);
+            item.TickCount.ShouldBeGreaterThan(tc);
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Update(item);
 
-            item.TickCount.Should().BeGreaterThan(tc);
+            item.TickCount.ShouldBeGreaterThan(tc);
         }
 
         [Fact]
@@ -100,7 +100,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(11).raw;
 
-            this.policy.ShouldDiscard(item).Should().BeTrue();
+            this.policy.ShouldDiscard(item).ShouldBeTrue();
         }
 
         [Fact]
@@ -110,13 +110,13 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(9).raw;
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item).ShouldBeFalse();
         }
 
         [Fact]
         public void CanDiscardIsTrue()
         {
-            this.policy.CanDiscard().Should().BeTrue();
+            this.policy.CanDiscard().ShouldBeTrue();
         }
 
         [Theory]
@@ -128,7 +128,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -140,7 +140,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -152,7 +152,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item).ShouldBe(expectedDestination);
         }
 
         private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)

--- a/BitFaster.Caching.UnitTests/Lru/CacheExtTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/CacheExtTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -14,10 +14,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var cache = new ClassicLru<int, string>(5);
             var cache2 = (ICacheExt<int, string>)cache;
-            cache2.GetOrAdd(42, static (k, i) => (k + i).ToString(), 1).Should().Be("43");
-            cache2.TryRemove(43, out _).Should().BeFalse();
+            cache2.GetOrAdd(42, static (k, i) => (k + i).ToString(), 1).ShouldBe("43");
+            cache2.TryRemove(43, out _).ShouldBeFalse();
             var first = cache2.First();
-            cache2.TryRemove(first).Should().BeTrue();
+            cache2.TryRemove(first).ShouldBeTrue();
         }
 
         [Fact]
@@ -28,10 +28,10 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .Build();
             
             var cache2 = (ICacheExt<int, string>)cache;
-            cache2.GetOrAdd(42, static (k, i) => (k + i).ToString(), 1).Should().Be("43");
-            cache2.TryRemove(43, out _).Should().BeFalse();
+            cache2.GetOrAdd(42, static (k, i) => (k + i).ToString(), 1).ShouldBe("43");
+            cache2.TryRemove(43, out _).ShouldBeFalse();
             var first = cache2.First();
-            cache2.TryRemove(first).Should().BeTrue();
+            cache2.TryRemove(first).ShouldBeTrue();
         }
 
         [Fact]
@@ -43,10 +43,10 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .Build();
             
             var cache2 = (ICacheExt<int, string>)cache;
-            cache2.GetOrAdd(42, static (k, i) => (k + i).ToString(), 1).Should().Be("43");
-            cache2.TryRemove(43, out _).Should().BeFalse();
+            cache2.GetOrAdd(42, static (k, i) => (k + i).ToString(), 1).ShouldBe("43");
+            cache2.TryRemove(43, out _).ShouldBeFalse();
             var first = cache2.First();
-            cache2.TryRemove(first).Should().BeTrue();
+            cache2.TryRemove(first).ShouldBeTrue();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/CapacityPartitionExtensionsTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/CapacityPartitionExtensionsTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -18,7 +14,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             Action validate = () => { p.Validate(); };
 
-            validate.Should().NotThrow();
+            validate.ShouldNotThrow();
         }
 
         [Fact]
@@ -28,7 +24,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             Action validate = () => { p.Validate(); };
 
-            validate.Should().Throw<ArgumentOutOfRangeException>();
+            validate.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -38,7 +34,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             Action validate = () => { p.Validate(); };
 
-            validate.Should().Throw<ArgumentOutOfRangeException>();
+            validate.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -48,7 +44,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             Action validate = () => { p.Validate(); };
 
-            validate.Should().Throw<ArgumentOutOfRangeException>();
+            validate.ShouldThrow<ArgumentOutOfRangeException>();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ClassicLruTests.cs
@@ -1,9 +1,8 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using System.Collections;
@@ -22,7 +21,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new ClassicLru<int, string>(0, 3, EqualityComparer<int>.Default); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -30,7 +29,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new ClassicLru<int, string>(1, 2, EqualityComparer<int>.Default); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -38,7 +37,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new ClassicLru<int, string>(1, 3, null); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -46,50 +45,50 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new ClassicLru<int, int>(3);
 
-            x.GetOrAdd(1, k => k).Should().Be(1);
+            x.GetOrAdd(1, k => k).ShouldBe(1);
         }
 
         [Fact]
         public void WhenCtorCapacityArgIs3CapacityIs3()
         {
-            new ClassicLru<int, int>(3).Capacity.Should().Be(3);
+            new ClassicLru<int, int>(3).Capacity.ShouldBe(3);
         }
 
         [Fact]
         public void WhenItemIsAddedCountIsCorrect()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             lru.GetOrAdd(1, valueFactory.Create);
-            lru.Count.Should().Be(1);
+            lru.Count.ShouldBe(1);
         }
 
         [Fact]
         public void WhenItemsAddedKeysContainsTheKeys()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             lru.GetOrAdd(1, valueFactory.Create);
             lru.GetOrAdd(2, valueFactory.Create);
-            lru.Keys.Should().BeEquivalentTo(new[] { 1, 2 });
+            lru.Keys.ShouldBe(new[] { 1, 2 });
         }
 
         [Fact]
         public void WhenItemsAddedGenericEnumerateContainsKvps()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             lru.GetOrAdd(1, valueFactory.Create);
             lru.GetOrAdd(2, valueFactory.Create);
-            lru.Should().BeEquivalentTo(new[] { new KeyValuePair<int, string>(1, "1"), new KeyValuePair<int, string>(2, "2") });
+            lru.ShouldBe(new[] { new KeyValuePair<int, string>(1, "1"), new KeyValuePair<int, string>(2, "2") });
         }
 
         [Fact]
         public void WhenItemsAddedEnumerateContainsKvps()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             lru.GetOrAdd(1, valueFactory.Create);
             lru.GetOrAdd(2, valueFactory.Create);
 
             var enumerable = (IEnumerable)lru;
-            enumerable.Should().BeEquivalentTo(new[] { new KeyValuePair<int, string>(1, "1"), new KeyValuePair<int, string>(2, "2") });
+            enumerable.ShouldBe(new[] { new KeyValuePair<int, string>(1, "1"), new KeyValuePair<int, string>(2, "2") });
         }
 
         [Fact]
@@ -98,8 +97,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            result.Should().Be(true);
-            value.Should().Be("1");
+            result.ShouldBe(true);
+            value.ShouldBe("1");
         }
 
         [Fact]
@@ -108,14 +107,14 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(2, out var value);
 
-            result.Should().Be(false);
-            value.Should().BeNull();
+            result.ShouldBe(false);
+            value.ShouldBeNull();
         }
 
         [Fact]
         public void MetricsAreEnabled()
         {
-            lru.Metrics.HasValue.Should().BeTrue();
+            lru.Metrics.HasValue.ShouldBeTrue();
         }
 
         [Fact]
@@ -124,7 +123,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            lru.Metrics.Value.HitRatio.Should().Be(0.5);
+            lru.Metrics.Value.HitRatio.ShouldBe(0.5);
         }
 
         [Fact]
@@ -133,7 +132,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            lru.Metrics.Value.Hits.Should().Be(1);
+            lru.Metrics.Value.Hits.ShouldBe(1);
         }
 
         [Fact]
@@ -142,7 +141,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            lru.Metrics.Value.Total.Should().Be(2);
+            lru.Metrics.Value.Total.ShouldBe(2);
         }
 
         [Fact]
@@ -151,13 +150,13 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            lru.Metrics.Value.Misses.Should().Be(1);
+            lru.Metrics.Value.Misses.ShouldBe(1);
         }
 
         [Fact]
         public void EventsAreEnabled()
         {
-            lru.Events.HasValue.Should().BeFalse();
+            lru.Events.HasValue.ShouldBeFalse();
         }
 
         private void OnItemRemoved(object sender, ItemRemovedEventArgs<int, string> e)
@@ -168,7 +167,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void ExpireAfterWriteIsDisabled()
         {
-            lru.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            lru.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -177,8 +176,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = lru.GetOrAdd(1, valueFactory.Create);
             var result2 = lru.GetOrAdd(1, valueFactory.Create);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
 
@@ -188,8 +187,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = lru.GetOrAdd(1, valueFactory.Create, "x");
             var result2 = lru.GetOrAdd(1, valueFactory.Create, "y");
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -198,8 +197,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync);
             var result2 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -208,8 +207,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync, "x");
             var result2 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync, "y");
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -218,10 +217,10 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = lru.GetOrAdd(1, valueFactory.Create);
             var result2 = lru.GetOrAdd(2, valueFactory.Create);
 
-            valueFactory.timesCalled.Should().Be(2);
+            valueFactory.timesCalled.ShouldBe(2);
 
-            result1.Should().Be("1");
-            result2.Should().Be("2");
+            result1.ShouldBe("1");
+            result2.ShouldBe("2");
         }
 
         [Fact]
@@ -230,10 +229,10 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync);
             var result2 = await lru.GetOrAddAsync(2, valueFactory.CreateAsync);
 
-            valueFactory.timesCalled.Should().Be(2);
+            valueFactory.timesCalled.ShouldBe(2);
 
-            result1.Should().Be("1");
-            result2.Should().Be("2");
+            result1.ShouldBe("1");
+            result2.ShouldBe("2");
         }
 
         [Fact]
@@ -244,8 +243,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lru.GetOrAdd(i, valueFactory.Create);
             }
 
-            lru.Count.Should().Be(capacity);
-            valueFactory.timesCalled.Should().Be(capacity + 1);
+            lru.Count.ShouldBe(capacity);
+            valueFactory.timesCalled.ShouldBe(capacity + 1);
         }
 
         [Fact]
@@ -256,8 +255,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 await lru.GetOrAddAsync(i, valueFactory.CreateAsync);
             }
 
-            lru.Count.Should().Be(capacity);
-            valueFactory.timesCalled.Should().Be(capacity + 1);
+            lru.Count.ShouldBe(capacity);
+            valueFactory.timesCalled.ShouldBe(capacity + 1);
         }
 
         [Fact]
@@ -269,23 +268,23 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lru.GetOrAdd(i, valueFactory.Create);
             }
 
-            valueFactory.timesCalled.Should().Be(capacity);
+            valueFactory.timesCalled.ShouldBe(capacity);
 
             // request 0, now item 1 is to be evicted
             lru.GetOrAdd(0, valueFactory.Create);
-            valueFactory.timesCalled.Should().Be(capacity);
+            valueFactory.timesCalled.ShouldBe(capacity);
 
             // request next item after last, verify value factory was called
             lru.GetOrAdd(capacity, valueFactory.Create);
-            valueFactory.timesCalled.Should().Be(capacity + 1);
+            valueFactory.timesCalled.ShouldBe(capacity + 1);
 
             // request 0, verify value factory not called
             lru.GetOrAdd(0, valueFactory.Create);
-            valueFactory.timesCalled.Should().Be(capacity + 1);
+            valueFactory.timesCalled.ShouldBe(capacity + 1);
 
             // request 1, verify value factory is called (and it was therefore not cached)
             lru.GetOrAdd(1, valueFactory.Create);
-            valueFactory.timesCalled.Should().Be(capacity + 2);
+            valueFactory.timesCalled.ShouldBe(capacity + 2);
         }
 
         [Fact]
@@ -297,12 +296,12 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lru.GetOrAdd(i, valueFactory.Create);
             }
 
-            lru.Metrics.Value.Evicted.Should().Be(0);
+            lru.Metrics.Value.Evicted.ShouldBe(0);
 
             // request 0, now item 1 is to be evicted
             lru.GetOrAdd(4, valueFactory.Create);
 
-            lru.Metrics.Value.Evicted.Should().Be(1);
+            lru.Metrics.Value.Evicted.ShouldBe(1);
         }
 
         [Fact]
@@ -316,8 +315,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruOfDisposable.GetOrAdd(i, disposableValueFactory.Create);
             }
 
-            disposableValueFactory.Items[0].IsDisposed.Should().BeTrue();
-            disposableValueFactory.Items[1].IsDisposed.Should().BeFalse();
+            disposableValueFactory.Items[0].IsDisposed.ShouldBeTrue();
+            disposableValueFactory.Items[1].IsDisposed.ShouldBeFalse();
         }
 
         [Fact]
@@ -331,8 +330,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 await lruOfDisposable.GetOrAddAsync(i, disposableValueFactory.CreateAsync);
             }
 
-            disposableValueFactory.Items[0].IsDisposed.Should().BeTrue();
-            disposableValueFactory.Items[1].IsDisposed.Should().BeFalse();
+            disposableValueFactory.Items[0].IsDisposed.ShouldBeTrue();
+            disposableValueFactory.Items[1].IsDisposed.ShouldBeFalse();
         }
 
         [Fact]
@@ -340,7 +339,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryGet(2, out var result).Should().Be(false);
+            lru.TryGet(2, out var result).ShouldBe(false);
         }
 
         [Fact]
@@ -349,8 +348,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
 
             bool result = lru.TryGet(1, out var value);
-            result.Should().Be(true);
-            value.Should().Be("1");
+            result.ShouldBe(true);
+            value.ShouldBe("1");
         }
 
         [Fact]
@@ -358,8 +357,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryRemove(1).Should().BeTrue();
-            lru.TryGet(1, out var value).Should().BeFalse();
+            lru.TryRemove(1).ShouldBeTrue();
+            lru.TryGet(1, out var value).ShouldBeFalse();
         }
 
         [Fact]
@@ -367,8 +366,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryRemove(1, out var value).Should().BeTrue();
-            value.Should().Be("1");
+            lru.TryRemove(1, out var value).ShouldBeTrue();
+            value.ShouldBe("1");
         }
 
         [Fact]
@@ -376,8 +375,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryRemove(new KeyValuePair<int, string>(1, "1")).Should().BeTrue();
-            lru.TryGet(1, out var value).Should().BeFalse();
+            lru.TryRemove(new KeyValuePair<int, string>(1, "1")).ShouldBeTrue();
+            lru.TryGet(1, out var value).ShouldBeFalse();
         }
 
         [Fact]
@@ -385,8 +384,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryRemove(new KeyValuePair<int, string>(1, "2")).Should().BeFalse();
-            lru.TryGet(1, out var value).Should().BeTrue();
+            lru.TryRemove(new KeyValuePair<int, string>(1, "2")).ShouldBeFalse();
+            lru.TryGet(1, out var value).ShouldBeTrue();
         }
 
         [Fact]
@@ -398,7 +397,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lruOfDisposable.GetOrAdd(1, disposableValueFactory.Create);
             lruOfDisposable.TryRemove(1);
 
-            disposableValueFactory.Items[1].IsDisposed.Should().BeTrue();
+            disposableValueFactory.Items[1].IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -406,7 +405,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryRemove(2).Should().BeFalse();
+            lru.TryRemove(2).ShouldBeFalse();
         }
 
         [Fact]
@@ -414,10 +413,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryUpdate(1, "2").Should().BeTrue();
+            lru.TryUpdate(1, "2").ShouldBeTrue();
 
             lru.TryGet(1, out var value);
-            value.Should().Be("2");
+            value.ShouldBe("2");
         }
 
         [Fact]
@@ -425,7 +424,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryUpdate(2, "3").Should().BeFalse();
+            lru.TryUpdate(2, "3").ShouldBeFalse();
         }
 
 // backcompat: remove conditional compile
@@ -435,9 +434,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryUpdate(1, "2").Should().BeTrue();
+            lru.TryUpdate(1, "2").ShouldBeTrue();
 
-            lru.Metrics.Value.Updated.Should().Be(1);
+            lru.Metrics.Value.Updated.ShouldBe(1);
         }
 
         [Fact]
@@ -445,9 +444,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryUpdate(2, "3").Should().BeFalse();
+            lru.TryUpdate(2, "3").ShouldBeFalse();
 
-            lru.Metrics.Value.Updated.Should().Be(0);
+            lru.Metrics.Value.Updated.ShouldBe(0);
         }
 #endif
 
@@ -456,8 +455,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.AddOrUpdate(1, "1");
 
-            lru.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be("1");
+            lru.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe("1");
         }
 
         [Fact]
@@ -466,8 +465,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(1, "1");
             lru.AddOrUpdate(1, "2");
 
-            lru.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be("2");
+            lru.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe("2");
         }
 
         [Fact]
@@ -479,8 +478,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(4, "4");
 
             // verify first item added is removed
-            lru.Count.Should().Be(3);
-            lru.TryGet(1, out var value).Should().BeFalse();
+            lru.Count.ShouldBe(3);
+            lru.TryGet(1, out _).ShouldBeFalse();
         }
 
         [Fact]
@@ -496,17 +495,17 @@ namespace BitFaster.Caching.UnitTests.Lru
             }
 
             // first item is evicted and disposed
-            items[0].IsDisposed.Should().BeTrue();
+            items[0].IsDisposed.ShouldBeTrue();
 
             // all other items are not disposed
-            items.Skip(1).All(i => i.IsDisposed == false).Should().BeTrue();
+            items.Skip(1).All(i => i.IsDisposed == false).ShouldBeTrue();
         }
 
         [Fact]
         public void WhenCacheIsEmptyClearIsNoOp()
         {
             lru.Clear();
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -515,7 +514,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(1, "1");
             lru.AddOrUpdate(2, "2");
             lru.Clear();
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -532,19 +531,19 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruOfDisposable.Clear();
 
-            items.All(i => i.IsDisposed == true).Should().BeTrue();
+            items.All(i => i.IsDisposed == true).ShouldBeTrue();
         }
 
         [Fact]
         public void WhenTrimCountIsZeroThrows()
-        { 
-            lru.Invoking(l => lru.Trim(0)).Should().Throw<ArgumentOutOfRangeException>();
+        {
+            Should.Throw<ArgumentOutOfRangeException>(() => lru.Trim(0));
         }
 
         [Fact]
         public void WhenTrimCountIsMoreThanCapacityThrows()
         {
-            lru.Invoking(l => lru.Trim(capacity + 1)).Should().Throw<ArgumentOutOfRangeException>();
+            Should.Throw<ArgumentOutOfRangeException>(() => lru.Trim(capacity + 1));
         }
 
         [Theory]
@@ -563,7 +562,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Trim(trimCount);
 
-            lru.Keys.Should().BeEquivalentTo(expected);
+            lru.Keys.ShouldBe(expected);
         }
 
         [Fact]
@@ -586,10 +585,10 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruOfDisposable.Trim(2);
 
-            items[0].IsDisposed.Should().BeTrue();
-            items[1].IsDisposed.Should().BeTrue();
-            items[2].IsDisposed.Should().BeFalse();
-            items[3].IsDisposed.Should().BeFalse();
+            items[0].IsDisposed.ShouldBeTrue();
+            items[1].IsDisposed.ShouldBeTrue();
+            items[2].IsDisposed.ShouldBeFalse();
+            items[3].IsDisposed.ShouldBeFalse();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruAfterAccessTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruAfterAccessTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.UnitTests.Retry;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -37,13 +37,13 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void CanExpireIsTrue()
         {
-            this.lru.Policy.ExpireAfterAccess.HasValue.Should().BeTrue();
+            this.lru.Policy.ExpireAfterAccess.HasValue.ShouldBeTrue();
         }
 
         [Fact]
         public void TimeToLiveIsCtorArg()
         {
-            this.lru.Policy.ExpireAfterAccess.Value.TimeToLive.Should().Be(timeToLive);
+            this.lru.Policy.ExpireAfterAccess.Value.TimeToLive.ShouldBe(timeToLive);
         }
 
         [RetryFact]
@@ -51,7 +51,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryGet(1, out var value).Should().BeTrue();
+            lru.TryGet(1, out var value).ShouldBeTrue();
         }
 
         [RetryFact]
@@ -67,7 +67,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 timeToLive.MultiplyBy(ttlWaitMlutiplier),
                 lru =>
                 {
-                    lru.TryGet(1, out var value).Should().BeFalse();
+                    lru.TryGet(1, out var value).ShouldBeFalse();
                 }
             );
         }
@@ -86,7 +86,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lru =>
                 {
                     lru.TryUpdate(1, "3");
-                    lru.TryGet(1, out var value).Should().BeTrue();
+                    lru.TryGet(1, out var value).ShouldBeTrue();
                 }
             );
         }
@@ -120,12 +120,12 @@ namespace BitFaster.Caching.UnitTests.Lru
                 TimeSpan.FromMilliseconds(50),
                 lru =>
                 {
-                    lru.TryGet(1, out _).Should().BeTrue($"First");
+                    lru.TryGet(1, out _).ShouldBeTrue($"First");
                 }, 
                 TimeSpan.FromMilliseconds(75),
                 lru =>
                 {
-                    lru.TryGet(1, out var value).Should().BeTrue($"Second");
+                    lru.TryGet(1, out var value).ShouldBeTrue($"Second");
                 }
             );
         }
@@ -150,15 +150,15 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruEvents.GetOrAdd(i + 1, i => i + 1);
             }
 
-            removedItems.Count.Should().Be(2);
+            removedItems.Count.ShouldBe(2);
 
-            removedItems[0].Key.Should().Be(1);
-            removedItems[0].Value.Should().Be(2);
-            removedItems[0].Reason.Should().Be(ItemRemovedReason.Evicted);
+            removedItems[0].Key.ShouldBe(1);
+            removedItems[0].Value.ShouldBe(2);
+            removedItems[0].Reason.ShouldBe(ItemRemovedReason.Evicted);
 
-            removedItems[1].Key.Should().Be(4);
-            removedItems[1].Value.Should().Be(5);
-            removedItems[1].Reason.Should().Be(ItemRemovedReason.Evicted);
+            removedItems[1].Key.ShouldBe(4);
+            removedItems[1].Value.ShouldBe(5);
+            removedItems[1].Reason.ShouldBe(ItemRemovedReason.Evicted);
         }
 
         [RetryFact]
@@ -190,7 +190,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 {
                     lru.Policy.ExpireAfterAccess.Value.TrimExpired();
 
-                    lru.Count.Should().Be(0);
+                    lru.Count.ShouldBe(0);
                 }
             );
         }
@@ -221,7 +221,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
                   lru.Policy.ExpireAfterAccess.Value.TrimExpired();
 
-                  lru.Count.Should().Be(3);
+                  lru.Count.ShouldBe(3);
               }
           );
         }
@@ -244,7 +244,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 {
                     lru.Policy.Eviction.Value.Trim(1);
 
-                    lru.Count.Should().Be(0);
+                    lru.Count.ShouldBe(0);
                 }
             );
         }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruAfterDiscreteTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruAfterDiscreteTests.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.UnitTests.Retry;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -39,21 +39,21 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenKeyIsWrongTypeTryGetTimeToExpireIsFalse()
         {
-            lru.Policy.ExpireAfter.Value.TryGetTimeToExpire("foo", out _).Should().BeFalse();
+            lru.Policy.ExpireAfter.Value.TryGetTimeToExpire("foo", out _).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryGetTimeToExpireIsFalse()
         {
-            lru.Policy.ExpireAfter.Value.TryGetTimeToExpire(1, out _).Should().BeFalse();
+            lru.Policy.ExpireAfter.Value.TryGetTimeToExpire(1, out _).ShouldBeFalse();
         }
 
         [RetryFact]
         public void WhenKeyExistsTryGetTimeToExpireReturnsExpiryTime()
         {
             lru.GetOrAdd(1, k => "1");
-            lru.Policy.ExpireAfter.Value.TryGetTimeToExpire(1, out var expiry).Should().BeTrue();
-            expiry.Should().BeCloseTo(TestExpiryCalculator<int, string>.DefaultTimeToExpire.ToTimeSpan(), delta);
+            lru.Policy.ExpireAfter.Value.TryGetTimeToExpire(1, out var expiry).ShouldBeTrue();
+            expiry.ShouldBe(TestExpiryCalculator<int, string>.DefaultTimeToExpire.ToTimeSpan(), delta);
         }
 
         [RetryFact]
@@ -69,7 +69,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 TestExpiryCalculator<int, string>.DefaultTimeToExpire.MultiplyBy(ttlWaitMlutiplier),
                 lru =>
                 {
-                    lru.TryGet(1, out var value).Should().BeFalse();
+                    lru.TryGet(1, out var value).ShouldBeFalse();
                 }
             );
         }
@@ -88,7 +88,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lru =>
                 {
                     lru.TryUpdate(1, "3");
-                    lru.TryGet(1, out var value).Should().BeTrue();
+                    lru.TryGet(1, out var value).ShouldBeTrue();
                 }
             );
         }
@@ -118,12 +118,12 @@ namespace BitFaster.Caching.UnitTests.Lru
                 TimeSpan.FromMilliseconds(50),
                 lru =>
                 {
-                    lru.TryGet(1, out _).Should().BeTrue($"First");
+                    lru.TryGet(1, out _).ShouldBeTrue($"First");
                 },
                 TimeSpan.FromMilliseconds(75),
                 lru =>
                 {
-                    lru.TryGet(1, out var value).Should().BeTrue($"Second");
+                    lru.TryGet(1, out var value).ShouldBeTrue($"Second");
                 }
             );
         }
@@ -150,15 +150,15 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruEvents.GetOrAdd(i + 1, i => $"{i + 1}");
             }
 
-            removedItems.Count.Should().Be(2);
+            removedItems.Count.ShouldBe(2);
 
-            removedItems[0].Key.Should().Be(1);
-            removedItems[0].Value.Should().Be("2");
-            removedItems[0].Reason.Should().Be(ItemRemovedReason.Evicted);
+            removedItems[0].Key.ShouldBe(1);
+            removedItems[0].Value.ShouldBe("2");
+            removedItems[0].Reason.ShouldBe(ItemRemovedReason.Evicted);
 
-            removedItems[1].Key.Should().Be(4);
-            removedItems[1].Value.Should().Be("5");
-            removedItems[1].Reason.Should().Be(ItemRemovedReason.Evicted);
+            removedItems[1].Key.ShouldBe(4);
+            removedItems[1].Value.ShouldBe("5");
+            removedItems[1].Reason.ShouldBe(ItemRemovedReason.Evicted);
         }
 
         [RetryFact]
@@ -190,7 +190,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 {
                     lru.Policy.ExpireAfter.Value.TrimExpired();
 
-                    lru.Count.Should().Be(0);
+                    lru.Count.ShouldBe(0);
                 }
             );
         }
@@ -221,7 +221,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
                   lru.Policy.ExpireAfter.Value.TrimExpired();
 
-                  lru.Count.Should().Be(3);
+                  lru.Count.ShouldBe(3);
               }
           );
         }
@@ -244,7 +244,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 {
                     lru.Policy.Eviction.Value.Trim(1);
 
-                    lru.Count.Should().Be(0);
+                    lru.Count.ShouldBe(0);
                 }
             );
         }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruBuilderTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Atomic;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -14,7 +14,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             ICache<int, int> lru = new ConcurrentLruBuilder<int, int>()
                 .Build();
 
-            lru.Should().BeOfType<FastConcurrentLru<int, int>>();
+            lru.ShouldBeOfType<FastConcurrentLru<int, int>>();
         }
 
         [Fact]
@@ -24,7 +24,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithMetrics()
                 .Build();
 
-            lru.Should().BeOfType<ConcurrentLru<int, int>>();
+            lru.ShouldBeOfType<ConcurrentLru<int, int>>();
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithExpireAfterWrite(TimeSpan.FromSeconds(1))
                 .Build();
 
-            lru.Should().BeOfType<FastConcurrentTLru<int, int>>();
+            lru.ShouldBeOfType<FastConcurrentTLru<int, int>>();
         }
 
         [Fact]
@@ -45,8 +45,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                  .WithMetrics()
                  .Build();
 
-            lru.Should().BeOfType<ConcurrentTLru<int, int>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(128);
+            lru.ShouldBeOfType<ConcurrentTLru<int, int>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(128);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .AsAsyncCache()
                 .Build();
 
-            lru.Should().BeOfType<FastConcurrentLru<int, int>>();
+            lru.ShouldBeOfType<FastConcurrentLru<int, int>>();
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .AsAsyncCache()
                 .Build();
 
-            lru.Should().BeOfType<ConcurrentLru<int, int>>();
+            lru.ShouldBeOfType<ConcurrentLru<int, int>>();
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .AsAsyncCache()
                 .Build();
 
-            lru.Should().BeOfType<FastConcurrentTLru<int, int>>();
+            lru.ShouldBeOfType<FastConcurrentTLru<int, int>>();
         }
 
         [Fact]
@@ -90,8 +90,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                  .AsAsyncCache()
                  .Build();
 
-            lru.Should().BeOfType<ConcurrentTLru<int, int>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(128);
+            lru.ShouldBeOfType<ConcurrentTLru<int, int>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(128);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .Build();
 
             fastLru.GetOrAdd("a", k => 1);
-            fastLru.TryGet("A", out var value).Should().BeTrue();
+            fastLru.TryGet("A", out var value).ShouldBeTrue();
         }
 
         [Fact]
@@ -113,7 +113,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             Action constructor = () => { var x = b.Build(); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(new FavorWarmPartition(6))
                 .Build();
 
-            lru.Policy.Eviction.Value.Capacity.Should().Be(6);
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(6);
         }
 
         [Fact]
@@ -143,10 +143,10 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithExpireAfterAccess(TimeSpan.FromSeconds(1))
                 .Build();
 
-            expireAfterAccess.Metrics.HasValue.Should().BeFalse();
-            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.Should().BeTrue();
-            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfterAccess.Metrics.HasValue.ShouldBeFalse();
+            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.ShouldBeTrue();
+            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -157,10 +157,10 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithMetrics()
                 .Build();
 
-            expireAfterAccess.Metrics.HasValue.Should().BeTrue();
-            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.Should().BeTrue();
-            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
-            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfterAccess.Metrics.HasValue.ShouldBeTrue();
+            expireAfterAccess.Policy.ExpireAfterAccess.HasValue.ShouldBeTrue();
+            expireAfterAccess.Policy.ExpireAfterAccess.Value.TimeToLive.ShouldBe(TimeSpan.FromSeconds(1));
+            expireAfterAccess.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithExpireAfterWrite(TimeSpan.FromSeconds(2));
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -181,11 +181,11 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)))
                 .Build();
 
-            expireAfter.Metrics.HasValue.Should().BeFalse();
-            expireAfter.Policy.ExpireAfter.HasValue.Should().BeTrue();
+            expireAfter.Metrics.HasValue.ShouldBeFalse();
+            expireAfter.Policy.ExpireAfter.HasValue.ShouldBeTrue();
 
-            expireAfter.Policy.ExpireAfterAccess.HasValue.Should().BeFalse();
-            expireAfter.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfter.Policy.ExpireAfterAccess.HasValue.ShouldBeFalse();
+            expireAfter.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -196,11 +196,11 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)))
                 .Build();
 
-            expireAfter.Metrics.HasValue.Should().BeFalse();
-            expireAfter.Policy.ExpireAfter.HasValue.Should().BeTrue();
+            expireAfter.Metrics.HasValue.ShouldBeFalse();
+            expireAfter.Policy.ExpireAfter.HasValue.ShouldBeTrue();
 
-            expireAfter.Policy.ExpireAfterAccess.HasValue.Should().BeFalse();
-            expireAfter.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfter.Policy.ExpireAfterAccess.HasValue.ShouldBeFalse();
+            expireAfter.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -211,11 +211,11 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithMetrics()
                 .Build();
 
-            expireAfter.Metrics.HasValue.Should().BeTrue();
-            expireAfter.Policy.ExpireAfter.HasValue.Should().BeTrue();
+            expireAfter.Metrics.HasValue.ShouldBeTrue();
+            expireAfter.Policy.ExpireAfter.HasValue.ShouldBeTrue();
 
-            expireAfter.Policy.ExpireAfterAccess.HasValue.Should().BeFalse();
-            expireAfter.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            expireAfter.Policy.ExpireAfterAccess.HasValue.ShouldBeFalse();
+            expireAfter.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -226,7 +226,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)));
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -237,7 +237,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)));
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -249,7 +249,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithExpireAfter(new TestExpiryCalculator<string, int>((k, v) => Duration.FromMinutes(5)));
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -260,7 +260,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .AsScopedCache();
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -272,7 +272,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithAtomicGetOrAdd();
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -284,7 +284,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .AsScopedCache();
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithAtomicGetOrAdd();
 
             Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            act.ShouldThrow<InvalidOperationException>();
         }
 
         //  There are 15 combinations to test:
@@ -359,8 +359,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeOfType<ScopedCache<int, Disposable>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.ShouldBeOfType<ScopedCache<int, Disposable>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 2
@@ -372,7 +372,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeOfType<AtomicFactoryCache<int, int>>();
+            lru.ShouldBeOfType<AtomicFactoryCache<int, int>>();
         }
 
         // 3
@@ -384,7 +384,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IAsyncCache<int, int>>();
+            lru.ShouldBeAssignableTo<IAsyncCache<int, int>>();
         }
 
         // 4
@@ -397,8 +397,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeOfType<AtomicFactoryScopedCache<int, Disposable>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.ShouldBeOfType<AtomicFactoryScopedCache<int, Disposable>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 5
@@ -411,8 +411,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeOfType<AtomicFactoryScopedCache<int, Disposable>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.ShouldBeOfType<AtomicFactoryScopedCache<int, Disposable>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 6
@@ -425,9 +425,9 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
 
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 7
@@ -440,8 +440,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
-            lru.Policy.Eviction.Value.Capacity.Should().Be(3);
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.Policy.Eviction.Value.Capacity.ShouldBe(3);
         }
 
         // 8
@@ -454,7 +454,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IAsyncCache<int, int>>();
+            lru.ShouldBeAssignableTo<IAsyncCache<int, int>>();
         }
 
         // 9
@@ -467,7 +467,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IAsyncCache<int, int>>();
+            lru.ShouldBeAssignableTo<IAsyncCache<int, int>>();
         }
 
         // 10
@@ -481,7 +481,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 11
@@ -495,7 +495,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 12
@@ -509,7 +509,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 13
@@ -523,7 +523,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 14
@@ -537,7 +537,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
 
         // 15
@@ -551,7 +551,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 .WithCapacity(3)
                 .Build();
 
-            lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
+            lru.ShouldBeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruSoakTests.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 using Xunit.Abstractions;
-using static BitFaster.Caching.UnitTests.Lru.LruItemSoakTests;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
@@ -43,7 +41,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 this.testOutputHelper.WriteLine(string.Join(" ", lru.Keys));
 
                 // allow +/- 1 variance for capacity
-                lru.Count.Should().BeInRange(7, 10);
+                lru.Count.ShouldBeInRange(7, 10);
                 RunIntegrityCheck();
             }
         }
@@ -64,7 +62,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 this.testOutputHelper.WriteLine(string.Join(" ", lru.Keys));
 
                 // allow +/- 1 variance for capacity
-                lru.Count.Should().BeInRange(7, 10);
+                lru.Count.ShouldBeInRange(7, 10);
                 RunIntegrityCheck();
             }
         }
@@ -86,7 +84,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 this.testOutputHelper.WriteLine(string.Join(" ", lru.Keys));
 
                 // allow +/- 1 variance for capacity
-                lru.Count.Should().BeInRange(7, 10);
+                lru.Count.ShouldBeInRange(7, 10);
                 RunIntegrityCheck();
             }
         }
@@ -108,7 +106,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 this.testOutputHelper.WriteLine(string.Join(" ", lru.Keys));
 
                 // allow +/- 1 variance for capacity
-                lru.Count.Should().BeInRange(7, 10);
+                lru.Count.ShouldBeInRange(7, 10);
                 RunIntegrityCheck();
             }
         }
@@ -234,7 +232,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 }
             });
 
-            cache.Metrics.Value.Evicted.Should().Be(0);
+            cache.Metrics.Value.Evicted.ShouldBe(0);
         }
 
         [Fact]
@@ -253,7 +251,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             for (var i = 0; i < 100_000; i++)
             {
                 lru.AddOrUpdate(5, "a");
-                lru.TryGet(5, out _).Should().BeTrue("key 'a' should not be deleted");
+                lru.TryGet(5, out _).ShouldBeTrue("key 'a' should not be deleted");
                 lru.AddOrUpdate(5, "x");
             }
 

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentLruTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
 using System.Collections;
@@ -46,7 +46,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new ConcurrentLru<int, string>(0, 3, EqualityComparer<int>.Default); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new ConcurrentLru<int, string>(1, 2, EqualityComparer<int>.Default); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             ICapacityPartition partition = null;
             Action constructor = () => { var x = new ConcurrentLru<int, string>(1, partition, EqualityComparer<int>.Default); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             var p = new TestCapacityPartition { Cold = 2, Warm = 0, Hot = 2 };
             Action constructor = () => { var x = new ConcurrentLru<int, string>(1, p, EqualityComparer<int>.Default); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new ConcurrentLru<int, string>(1, 3, null); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -93,9 +93,9 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lru.GetOrAdd(i, x => x);
             }
 
-            lru.HotCount.Should().Be(1);
-            lru.ColdCount.Should().Be(1);
-            lru.Capacity.Should().Be(4);
+            lru.HotCount.ShouldBe(1);
+            lru.ColdCount.ShouldBe(1);
+            lru.Capacity.ShouldBe(4);
         }
 
         [Fact]
@@ -108,9 +108,9 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lru.GetOrAdd(i, x => x);
             }
 
-            lru.HotCount.Should().Be(1);
-            lru.ColdCount.Should().Be(2);
-            lru.Capacity.Should().Be(5);
+            lru.HotCount.ShouldBe(1);
+            lru.ColdCount.ShouldBe(2);
+            lru.Capacity.ShouldBe(5);
         }
 
         [Fact]
@@ -118,52 +118,52 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new ConcurrentLru<int, int>(3);
 
-            x.GetOrAdd(1, k => k).Should().Be(1);
+            x.GetOrAdd(1, k => k).ShouldBe(1);
         }
 
         [Fact]
         public void WhenItemIsAddedCountIsCorrect()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             lru.GetOrAdd(1, valueFactory.Create);
-            lru.Count.Should().Be(1);
+            lru.Count.ShouldBe(1);
         }
 
         [Fact]
         public async Task WhenItemIsAddedCountIsCorrectAsync()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             await lru.GetOrAddAsync(0, valueFactory.CreateAsync);
-            lru.Count.Should().Be(1);
+            lru.Count.ShouldBe(1);
         }
 
         [Fact]
         public void WhenItemsAddedKeysContainsTheKeys()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             lru.GetOrAdd(1, valueFactory.Create);
             lru.GetOrAdd(2, valueFactory.Create);
-            lru.Keys.Should().BeEquivalentTo(new[] { 1, 2 });
+            lru.Keys.ShouldBe(new[] { 1, 2 });
         }
 
         [Fact]
         public void WhenItemsAddedGenericEnumerateContainsKvps()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             lru.GetOrAdd(1, valueFactory.Create);
             lru.GetOrAdd(2, valueFactory.Create);
-            lru.Should().BeEquivalentTo(new[] { new KeyValuePair<int, string>(1, "1"), new KeyValuePair<int, string>(2, "2") });
+            lru.ShouldBe(new[] { new KeyValuePair<int, string>(1, "1"), new KeyValuePair<int, string>(2, "2") });
         }
 
         [Fact]
         public void WhenItemsAddedEnumerateContainsKvps()
         {
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
             lru.GetOrAdd(1, valueFactory.Create);
             lru.GetOrAdd(2, valueFactory.Create);
 
             var enumerable = (IEnumerable)lru;
-            enumerable.Should().BeEquivalentTo(new[] { new KeyValuePair<int, string>(1, "1"), new KeyValuePair<int, string>(2, "2") });
+            enumerable.ShouldBe(new[] { new KeyValuePair<int, string>(1, "1"), new KeyValuePair<int, string>(2, "2") });
         }
 
         [Fact]
@@ -171,7 +171,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             this.Warmup();
 
-            this.lru.Count.Should().Be(9);
+            this.lru.Count.ShouldBe(9);
         }
 
         [Fact]
@@ -180,8 +180,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            result.Should().Be(true);
-            value.Should().Be("1");
+            result.ShouldBe(true);
+            value.ShouldBe("1");
         }
 
         [Fact]
@@ -190,14 +190,14 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(2, out var value);
 
-            result.Should().Be(false);
-            value.Should().BeNull();
+            result.ShouldBe(false);
+            value.ShouldBeNull();
         }
 
         [Fact]
         public void MetricsAreEnabled()
         {
-            lru.Metrics.HasValue.Should().BeTrue();
+            lru.Metrics.HasValue.ShouldBeTrue();
         }
 
         [Fact]
@@ -206,7 +206,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            lru.Metrics.Value.HitRatio.Should().Be(0.5);
+            lru.Metrics.Value.HitRatio.ShouldBe(0.5);
         }
 
         [Fact]
@@ -215,7 +215,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            lru.Metrics.Value.Total.Should().Be(2);
+            lru.Metrics.Value.Total.ShouldBe(2);
         }
 
         [Fact]
@@ -228,13 +228,13 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(1, valueFactory.Create);
             bool result = lru.TryGet(1, out var value);
 
-            m.Value.HitRatio.Should().Be(0.5);
+            m.Value.HitRatio.ShouldBe(0.5);
         }
 
         [Fact]
         public void ExpireAfterWriteHasValueIsFalse()
         {
-            this.lru.Policy.ExpireAfterWrite.HasValue.Should().BeFalse();
+            this.lru.Policy.ExpireAfterWrite.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -243,8 +243,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = lru.GetOrAdd(1, valueFactory.Create);
             var result2 = lru.GetOrAdd(1, valueFactory.Create);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -253,8 +253,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = lru.GetOrAdd(1, valueFactory.Create, "x");
             var result2 = lru.GetOrAdd(1, valueFactory.Create, "y");
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -263,8 +263,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync);
             var result2 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync);
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -273,8 +273,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync, "x");
             var result2 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync, "y");
 
-            valueFactory.timesCalled.Should().Be(1);
-            result1.Should().Be(result2);
+            valueFactory.timesCalled.ShouldBe(1);
+            result1.ShouldBe(result2);
         }
 
         [Fact]
@@ -283,10 +283,10 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = lru.GetOrAdd(1, valueFactory.Create);
             var result2 = lru.GetOrAdd(2, valueFactory.Create);
 
-            valueFactory.timesCalled.Should().Be(2);
+            valueFactory.timesCalled.ShouldBe(2);
 
-            result1.Should().Be("1");
-            result2.Should().Be("2");
+            result1.ShouldBe("1");
+            result2.ShouldBe("2");
         }
 
         [Fact]
@@ -295,10 +295,10 @@ namespace BitFaster.Caching.UnitTests.Lru
             var result1 = await lru.GetOrAddAsync(1, valueFactory.CreateAsync);
             var result2 = await lru.GetOrAddAsync(2, valueFactory.CreateAsync);
 
-            valueFactory.timesCalled.Should().Be(2);
+            valueFactory.timesCalled.ShouldBe(2);
 
-            result1.Should().Be("1");
-            result2.Should().Be("2");
+            result1.ShouldBe("1");
+            result2.ShouldBe("2");
         }
 
         [Fact]
@@ -308,8 +308,8 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             var result = lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.Count.Should().Be(9);
-            valueFactory.timesCalled.Should().Be(10);
+            lru.Count.ShouldBe(9);
+            valueFactory.timesCalled.ShouldBe(10);
         }
 
         [Fact]
@@ -327,8 +327,8 @@ namespace BitFaster.Caching.UnitTests.Lru
                 }
             }
 
-            lru.Count.Should().Be(capacity);
-            valueFactory.timesCalled.Should().Be(capacity + 1);
+            lru.Count.ShouldBe(capacity);
+            valueFactory.timesCalled.ShouldBe(capacity + 1);
         }
 
         [Fact]
@@ -348,7 +348,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 }
 
                 testOutputHelper.WriteLine($"Total: {lru.Count} Hot: {lru.HotCount} Warm: {lru.WarmCount} Cold: {lru.ColdCount}");
-                lru.Count.Should().BeLessOrEqualTo(capacity + 1);
+                lru.Count.ShouldBeLessThanOrEqualTo(capacity + 1);
             }
         }
 
@@ -394,7 +394,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                     lru.GetOrAdd(j, valueFactory.Create);
                 }
 
-                lru.Count.Should().BeLessOrEqualTo(capacity + 1, $"Total: {lru.Count} Hot: {lru.HotCount} Warm: {lru.WarmCount} Cold: {lru.ColdCount}");
+                lru.Count.ShouldBeLessThanOrEqualTo(capacity + 1, $"Total: {lru.Count} Hot: {lru.HotCount} Warm: {lru.WarmCount} Cold: {lru.ColdCount}");
             }
         }
 
@@ -415,7 +415,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(8, valueFactory.Create);
             lru.GetOrAdd(9, valueFactory.Create);
 
-            lru.TryGet(0, out var value).Should().BeFalse();
+            lru.TryGet(0, out var value).ShouldBeFalse();
         }
 
         [Fact]
@@ -436,7 +436,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(8, valueFactory.Create);
             lru.GetOrAdd(9, valueFactory.Create);
 
-            lru.TryGet(0, out var value).Should().BeTrue();
+            lru.TryGet(0, out var value).ShouldBeTrue();
         }
 
         [Fact]
@@ -459,7 +459,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(8, valueFactory.Create);
             lru.GetOrAdd(9, valueFactory.Create);
 
-            lru.TryGet(0, out var value).Should().BeTrue();
+            lru.TryGet(0, out var value).ShouldBeTrue();
         }
 
         [Fact]
@@ -482,7 +482,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(8, valueFactory.Create);
             lru.GetOrAdd(9, valueFactory.Create);
 
-            lru.TryGet(0, out var value).Should().BeFalse();
+            lru.TryGet(0, out var value).ShouldBeFalse();
         }
 
         [Fact]
@@ -508,14 +508,14 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(9, valueFactory.Create);
 
             // verify 0 is present, but don't touch it
-            lru.Keys.Should().Contain(0);
+            lru.Keys.ShouldContain(0);
 
             // push 7,8,9 to cold, evict 0
             lru.GetOrAdd(10, valueFactory.Create);
             lru.GetOrAdd(11, valueFactory.Create);
             lru.GetOrAdd(12, valueFactory.Create);
 
-            lru.TryGet(0, out var value).Should().BeFalse();
+            lru.TryGet(0, out var value).ShouldBeFalse();
         }
 
         [Fact]
@@ -541,14 +541,14 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.GetOrAdd(9, valueFactory.Create);
 
             // Touch 0
-            lru.TryGet(0, out var value).Should().BeTrue();
+            lru.TryGet(0, out var value).ShouldBeTrue();
 
             // push 7,8,9 to cold, cycle 0 back to warm
             lru.GetOrAdd(10, valueFactory.Create);
             lru.GetOrAdd(11, valueFactory.Create);
             lru.GetOrAdd(12, valueFactory.Create);
 
-            lru.TryGet(0, out value).Should().BeTrue();
+            lru.TryGet(0, out value).ShouldBeTrue();
         }
 
         [Fact]
@@ -562,22 +562,22 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruOfDisposable.GetOrAdd(i, disposableValueFactory.Create);
             }
 
-            disposableValueFactory.Items[0].IsDisposed.Should().BeTrue();
+            disposableValueFactory.Items[0].IsDisposed.ShouldBeTrue();
 
-            disposableValueFactory.Items[1].IsDisposed.Should().BeFalse();
-            disposableValueFactory.Items[2].IsDisposed.Should().BeFalse();
-            disposableValueFactory.Items[3].IsDisposed.Should().BeFalse();
-            disposableValueFactory.Items[4].IsDisposed.Should().BeFalse();
-            disposableValueFactory.Items[5].IsDisposed.Should().BeFalse();
-            disposableValueFactory.Items[6].IsDisposed.Should().BeFalse();
+            disposableValueFactory.Items[1].IsDisposed.ShouldBeFalse();
+            disposableValueFactory.Items[2].IsDisposed.ShouldBeFalse();
+            disposableValueFactory.Items[3].IsDisposed.ShouldBeFalse();
+            disposableValueFactory.Items[4].IsDisposed.ShouldBeFalse();
+            disposableValueFactory.Items[5].IsDisposed.ShouldBeFalse();
+            disposableValueFactory.Items[6].IsDisposed.ShouldBeFalse();
         }
 
         [Fact]
         public void WhenAddingNullValueCanBeAddedAndRemoved()
         {
-            lru.GetOrAdd(1, _ => null).Should().BeNull();
+            lru.GetOrAdd(1, _ => null).ShouldBeNull();
             lru.AddOrUpdate(1, null);
-            lru.TryRemove(1).Should().BeTrue();
+            lru.TryRemove(1).ShouldBeTrue();
         }
 
         [Fact]
@@ -595,15 +595,15 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruEvents.GetOrAdd(i + 1, i => i + 1);
             }
 
-            removedItems.Count.Should().Be(2);
+            removedItems.Count.ShouldBe(2);
 
-            removedItems[0].Key.Should().Be(1);
-            removedItems[0].Value.Should().Be(2);
-            removedItems[0].Reason.Should().Be(ItemRemovedReason.Evicted);
+            removedItems[0].Key.ShouldBe(1);
+            removedItems[0].Value.ShouldBe(2);
+            removedItems[0].Reason.ShouldBe(ItemRemovedReason.Evicted);
 
-            removedItems[1].Key.Should().Be(4);
-            removedItems[1].Value.Should().Be(5);
-            removedItems[1].Reason.Should().Be(ItemRemovedReason.Evicted);
+            removedItems[1].Key.ShouldBe(4);
+            removedItems[1].Value.ShouldBe(5);
+            removedItems[1].Reason.ShouldBe(ItemRemovedReason.Evicted);
         }
 
         [Fact]
@@ -613,7 +613,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.lru.GetOrAdd(1, valueFactory.Create);
 
-            this.lru.Metrics.Value.Evicted.Should().Be(1);
+            this.lru.Metrics.Value.Evicted.ShouldBe(1);
         }
 
         [Fact]
@@ -629,7 +629,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruEvents.GetOrAdd(i + 1, i => i + 1);
             }
 
-            removedItems.Count.Should().Be(0);
+            removedItems.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -637,8 +637,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryRemove(1).Should().BeTrue();
-            lru.TryGet(1, out var value).Should().BeFalse();
+            lru.TryRemove(1).ShouldBeTrue();
+            lru.TryGet(1, out var value).ShouldBeFalse();
         }
 
         [Fact]
@@ -646,8 +646,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryRemove(1, out var value).Should().BeTrue();
-            value.Should().Be("1");
+            lru.TryRemove(1, out var value).ShouldBeTrue();
+            value.ShouldBe("1");
         }
 
         [Fact]
@@ -659,7 +659,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lruOfDisposable.GetOrAdd(1, disposableValueFactory.Create);
             lruOfDisposable.TryRemove(1);
 
-            disposableValueFactory.Items[1].IsDisposed.Should().BeTrue();
+            disposableValueFactory.Items[1].IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -670,12 +670,12 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruEvents.GetOrAdd(1, i => i + 2);
 
-            lruEvents.TryRemove(1).Should().BeTrue();
+            lruEvents.TryRemove(1).ShouldBeTrue();
 
-            removedItems.Count().Should().Be(1);
-            removedItems[0].Key.Should().Be(1);
-            removedItems[0].Value.Should().Be(3);
-            removedItems[0].Reason.Should().Be(ItemRemovedReason.Removed);
+            removedItems.Count().ShouldBe(1);
+            removedItems[0].Key.ShouldBe(1);
+            removedItems[0].Value.ShouldBe(3);
+            removedItems[0].Reason.ShouldBe(ItemRemovedReason.Removed);
         }
 
         [Fact]
@@ -683,7 +683,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryRemove(2).Should().BeFalse();
+            lru.TryRemove(2).ShouldBeFalse();
         }
 
         [Fact]
@@ -695,7 +695,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 // Because TryRemove leaves the item in the queue, when it is eventually removed
                 // from the cold queue, it should not remove the newly created value.
                 lru.GetOrAdd(1, valueFactory.Create);
-                lru.TryGet(1, out var value).Should().BeTrue();
+                lru.TryGet(1, out var value).ShouldBeTrue();
                 lru.TryRemove(1);
             }
         }
@@ -705,10 +705,10 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryUpdate(1, "2").Should().BeTrue();
+            lru.TryUpdate(1, "2").ShouldBeTrue();
 
             lru.TryGet(1, out var value);
-            value.Should().Be("2");
+            value.ShouldBe("2");
         }
 
         [Fact]
@@ -721,7 +721,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lruOfDisposable.GetOrAdd(1, disposableValueFactory.Create);
             lruOfDisposable.TryUpdate(1, newValue);
 
-            disposableValueFactory.Items[1].IsDisposed.Should().BeTrue();
+            disposableValueFactory.Items[1].IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -729,7 +729,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryUpdate(2, "3").Should().BeFalse();
+            lru.TryUpdate(2, "3").ShouldBeFalse();
         }
 
 // backcompat: remove conditional compile
@@ -739,9 +739,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryUpdate(1, "2").Should().BeTrue();
+            lru.TryUpdate(1, "2").ShouldBeTrue();
 
-            lru.Metrics.Value.Updated.Should().Be(1);
+            lru.Metrics.Value.Updated.ShouldBe(1);
         }
 
         [Fact]
@@ -749,9 +749,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryUpdate(2, "3").Should().BeFalse();
+            lru.TryUpdate(2, "3").ShouldBeFalse();
 
-            lru.Metrics.Value.Updated.Should().Be(0);
+            lru.Metrics.Value.Updated.ShouldBe(0);
         }
 #endif
         [Fact]
@@ -759,8 +759,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.AddOrUpdate(1, "1");
 
-            lru.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be("1");
+            lru.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe("1");
         }
 
         [Fact]
@@ -769,8 +769,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(1, "1");
             lru.AddOrUpdate(1, "2");
 
-            lru.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be("2");
+            lru.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe("2");
         }
 
         [Fact]
@@ -782,8 +782,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru2.AddOrUpdate(1, new Guid(1, 0, 0, b));
             lru2.AddOrUpdate(1, new Guid(2, 0, 0, b));
 
-            lru2.TryGet(1, out var value).Should().BeTrue();
-            value.Should().Be(new Guid(2, 0, 0, b));
+            lru2.TryGet(1, out var value).ShouldBeTrue();
+            value.ShouldBe(new Guid(2, 0, 0, b));
         }
 
         [Fact]
@@ -796,7 +796,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lruOfDisposable.GetOrAdd(1, disposableValueFactory.Create);
             lruOfDisposable.AddOrUpdate(1, newValue);
 
-            disposableValueFactory.Items[1].IsDisposed.Should().BeTrue();
+            disposableValueFactory.Items[1].IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -807,8 +807,8 @@ namespace BitFaster.Caching.UnitTests.Lru
             lru.AddOrUpdate(3, "3");
             lru.AddOrUpdate(4, "4");
 
-            lru.HotCount.Should().Be(3);
-            lru.WarmCount.Should().Be(1); // items must have been enqueued and cycled for one of them to reach the warm queue
+            lru.HotCount.ShouldBe(3);
+            lru.WarmCount.ShouldBe(1); // items must have been enqueued and cycled for one of them to reach the warm queue
         }
 
 // backcompat: remove conditional compile
@@ -824,10 +824,10 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruEvents.AddOrUpdate(1, 3);
 
-            this.updatedItems.Count.Should().Be(1);
-            this.updatedItems[0].Key.Should().Be(1);
-            this.updatedItems[0].OldValue.Should().Be(2);
-            this.updatedItems[0].NewValue.Should().Be(3);
+            this.updatedItems.Count.ShouldBe(1);
+            this.updatedItems[0].Key.ShouldBe(1);
+            this.updatedItems[0].OldValue.ShouldBe(2);
+            this.updatedItems[0].NewValue.ShouldBe(3);
         }
 
         [Fact]
@@ -841,10 +841,10 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruEvents.TryUpdate(1, 3);
 
-            this.updatedItems.Count.Should().Be(1);
-            this.updatedItems[0].Key.Should().Be(1);
-            this.updatedItems[0].OldValue.Should().Be(2);
-            this.updatedItems[0].NewValue.Should().Be(3);
+            this.updatedItems.Count.ShouldBe(1);
+            this.updatedItems[0].Key.ShouldBe(1);
+            this.updatedItems[0].OldValue.ShouldBe(2);
+            this.updatedItems[0].NewValue.ShouldBe(3);
         }
 
         [Fact]
@@ -859,7 +859,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             lruEvents.AddOrUpdate(1, 2);
             lruEvents.AddOrUpdate(1, 2);
 
-            updatedItems.Count.Should().Be(0);
+            updatedItems.Count.ShouldBe(0);
         }
 #endif
 
@@ -867,7 +867,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void WhenCacheIsEmptyClearIsNoOp()
         {
             lru.Clear();
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -878,12 +878,12 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Clear();
 
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
 
             // verify queues are purged
-            lru.HotCount.Should().Be(0);
-            lru.WarmCount.Should().Be(0);
-            lru.ColdCount.Should().Be(0);
+            lru.HotCount.ShouldBe(0);
+            lru.WarmCount.ShouldBe(0);
+            lru.ColdCount.ShouldBe(0);
         }
 
         // This is a special case:
@@ -905,7 +905,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Clear();
 
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
         }
 
         [Theory]
@@ -939,12 +939,12 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.testOutputHelper.WriteLine("LRU " + string.Join(" ", lru.Keys));
 
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
 
             // verify queues are purged
-            lru.HotCount.Should().Be(0);
-            lru.WarmCount.Should().Be(0);
-            lru.ColdCount.Should().Be(0);
+            lru.HotCount.ShouldBe(0);
+            lru.WarmCount.ShouldBe(0);
+            lru.ColdCount.ShouldBe(0);
         }
 
         [Fact]
@@ -956,14 +956,14 @@ namespace BitFaster.Caching.UnitTests.Lru
             }
 
             lru.Clear();
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
 
             for (int i = 0; i < 20; i++)
             { 
                 lru.GetOrAdd(i, k => k.ToString()); 
             }
 
-            lru.Count.Should().Be(capacity.Hot + capacity.Warm + capacity.Cold);
+            lru.Count.ShouldBe(capacity.Hot + capacity.Warm + capacity.Cold);
         }
 
         [Fact]
@@ -975,14 +975,14 @@ namespace BitFaster.Caching.UnitTests.Lru
             }
 
             lru.Trim(6);
-            lru.Count.Should().Be(3);
+            lru.Count.ShouldBe(3);
 
             for (int i = 0; i < 20; i++)
             {
                 lru.GetOrAdd(i, k => k.ToString());
             }
 
-            lru.Count.Should().Be(capacity.Hot + capacity.Warm + capacity.Cold);
+            lru.Count.ShouldBe(capacity.Hot + capacity.Warm + capacity.Cold);
         }
 
         [Fact]
@@ -999,7 +999,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruOfDisposable.Clear();
 
-            items.All(i => i.IsDisposed == true).Should().BeTrue();
+            items.All(i => i.IsDisposed == true).ShouldBeTrue();
         }
 
         [Fact]
@@ -1015,24 +1015,24 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruEvents.Clear();
 
-            removedItems.Count.Should().Be(6);
+            removedItems.Count.ShouldBe(6);
 
             for (int i = 0; i < 6; i++)
             {
-                removedItems[i].Reason.Should().Be(ItemRemovedReason.Cleared);
+                removedItems[i].Reason.ShouldBe(ItemRemovedReason.Cleared);
             }
         }
 
         [Fact]
         public void WhenTrimCountIsZeroThrows()
         {
-            lru.Invoking(l => lru.Trim(0)).Should().Throw<ArgumentOutOfRangeException>();
+            Should.Throw<ArgumentOutOfRangeException>(() => lru.Trim(0));
         }
 
         [Fact]
         public void WhenTrimCountIsMoreThanCapacityThrows()
         {
-            lru.Invoking(l => lru.Trim(hotCap + warmCap + coldCap + 1)).Should().Throw<ArgumentOutOfRangeException>();
+            Should.Throw<ArgumentOutOfRangeException>(() => lru.Trim(hotCap + warmCap + coldCap + 1));
         }
 
         [Theory]
@@ -1070,7 +1070,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Trim(trimCount);
 
-            lru.Keys.Should().BeEquivalentTo(expected);
+            lru.Keys.ShouldBe(expected);
         }
 
         [Theory]
@@ -1102,7 +1102,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Trim(itemCount);
 
-            lru.Keys.Should().BeEquivalentTo(expected);
+            lru.Keys.ShouldBe(expected);
         }
 
         [Theory]
@@ -1127,7 +1127,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Trim(itemCount);
 
-            lru.Keys.Should().BeEquivalentTo(expected);
+            lru.Keys.ShouldBe(expected);
         }
 
         [Theory]
@@ -1173,7 +1173,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             this.testOutputHelper.WriteLine("LRU " + string.Join(" ", lru.Keys));
             this.testOutputHelper.WriteLine("exp " + string.Join(" ", expected));
 
-            lru.Keys.Should().BeEquivalentTo(expected);
+            lru.Keys.ShouldBe(expected);
         }
 
         [Theory]
@@ -1207,12 +1207,12 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.testOutputHelper.WriteLine("LRU " + string.Join(" ", lru.Keys));
 
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
 
             // verify queues are purged
-            lru.HotCount.Should().Be(0);
-            lru.WarmCount.Should().Be(0);
-            lru.ColdCount.Should().Be(0);
+            lru.HotCount.ShouldBe(0);
+            lru.WarmCount.ShouldBe(0);
+            lru.ColdCount.ShouldBe(0);
         }
 
         [Theory]
@@ -1240,12 +1240,12 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.testOutputHelper.WriteLine("LRU " + string.Join(" ", lru.Keys));
 
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
 
             // verify queues are purged
-            lru.HotCount.Should().Be(0);
-            lru.WarmCount.Should().Be(0);
-            lru.ColdCount.Should().Be(0);
+            lru.HotCount.ShouldBe(0);
+            lru.WarmCount.ShouldBe(0);
+            lru.ColdCount.ShouldBe(0);
         }
 
         [Fact]
@@ -1262,10 +1262,10 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruOfDisposable.Trim(2);
 
-            items[0].IsDisposed.Should().BeTrue();
-            items[1].IsDisposed.Should().BeTrue();
-            items[2].IsDisposed.Should().BeFalse();
-            items[3].IsDisposed.Should().BeFalse();
+            items[0].IsDisposed.ShouldBeTrue();
+            items[1].IsDisposed.ShouldBeTrue();
+            items[2].IsDisposed.ShouldBeFalse();
+            items[3].IsDisposed.ShouldBeFalse();
         }
 
         [Fact]
@@ -1281,15 +1281,15 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lruEvents.Trim(2);
 
-            removedItems.Count.Should().Be(2);
+            removedItems.Count.ShouldBe(2);
 
-            removedItems[0].Key.Should().Be(1);
-            removedItems[0].Value.Should().Be(2);
-            removedItems[0].Reason.Should().Be(ItemRemovedReason.Trimmed);
+            removedItems[0].Key.ShouldBe(1);
+            removedItems[0].Value.ShouldBe(2);
+            removedItems[0].Reason.ShouldBe(ItemRemovedReason.Trimmed);
 
-            removedItems[1].Key.Should().Be(2);
-            removedItems[1].Value.Should().Be(3);
-            removedItems[1].Reason.Should().Be(ItemRemovedReason.Trimmed);
+            removedItems[1].Key.ShouldBe(2);
+            removedItems[1].Value.ShouldBe(3);
+            removedItems[1].Reason.ShouldBe(ItemRemovedReason.Trimmed);
         }
 
 
@@ -1339,9 +1339,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         public void Validate()
         {
             // queue counters must be consistent with queues
-            this.hotQueue.Count.Should().Be(cache.HotCount, "hot queue has a corrupted count");
-            this.warmQueue.Count.Should().Be(cache.WarmCount, "warm queue has a corrupted count");
-            this.coldQueue.Count.Should().Be(cache.ColdCount, "cold queue has a corrupted count");
+            this.hotQueue.Count.ShouldBe(cache.HotCount, "hot queue has a corrupted count");
+            this.warmQueue.Count.ShouldBe(cache.WarmCount, "warm queue has a corrupted count");
+            this.coldQueue.Count.ShouldBe(cache.ColdCount, "cold queue has a corrupted count");
 
             // cache contents must be consistent with queued items
             ValidateQueue(cache, this.hotQueue, "hot");
@@ -1349,7 +1349,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             ValidateQueue(cache, this.coldQueue, "cold");
 
             // cache must be within capacity
-            cache.Count.Should().BeLessThanOrEqualTo(cache.Capacity + 1, "capacity out of valid range");
+            cache.Count.ShouldBeLessThanOrEqualTo(cache.Capacity + 1, "capacity out of valid range");
         }
 
         private void ValidateQueue(ConcurrentLruCore<K, V, I, P, T> cache, ConcurrentQueue<I> queue, string queueName)
@@ -1365,12 +1365,12 @@ namespace BitFaster.Caching.UnitTests.Lru
                     {
                         hotQueue.Union(warmQueue).Union(coldQueue)
                             .Any(i => i.Key.Equals(item.Key) && !i.WasRemoved)
-                            .Should().BeTrue($"{queueName} removed item {item.Key} was not removed");
+                            .ShouldBeTrue($"{queueName} removed item {item.Key} was not removed");
                     }
                 }
                 else
                 {
-                    dictionary.TryGetValue(item.Key, out var value).Should().BeTrue($"{queueName} item {item.Key} was not present");
+                    dictionary.TryGetValue(item.Key, out var value).ShouldBeTrue($"{queueName} item {item.Key} was not present");
                 }
             }
         }

--- a/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ConcurrentTLruTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
 using System.Collections.Generic;
@@ -39,13 +39,13 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void CanExpireIsTrue()
         {
-            this.lru.Policy.ExpireAfterWrite.HasValue.Should().BeTrue();
+            this.lru.Policy.ExpireAfterWrite.HasValue.ShouldBeTrue();
         }
 
         [Fact]
         public void TimeToLiveIsCtorArg()
         {
-            this.lru.Policy.ExpireAfterWrite.Value.TimeToLive.Should().Be(timeToLive);
+            this.lru.Policy.ExpireAfterWrite.Value.TimeToLive.ShouldBe(timeToLive);
         }
 
         [RetryFact]
@@ -53,7 +53,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             lru.GetOrAdd(1, valueFactory.Create);
 
-            lru.TryGet(1, out var value).Should().BeTrue();
+            lru.TryGet(1, out var value).ShouldBeTrue();
         }
 
         [RetryFact]
@@ -69,7 +69,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 timeToLive.MultiplyBy(ttlWaitMlutiplier),
                 lru =>
                 {
-                    lru.TryGet(1, out var value).Should().BeFalse();
+                    lru.TryGet(1, out var value).ShouldBeFalse();
                 }
             );
         }
@@ -88,7 +88,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lru =>
                 {
                     lru.TryUpdate(1, "3");
-                    lru.TryGet(1, out var value).Should().BeTrue();
+                    lru.TryGet(1, out var value).ShouldBeTrue();
                 }
             );
         }
@@ -108,15 +108,15 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruEvents.GetOrAdd(i + 1, i => i + 1);
             }
 
-            removedItems.Count.Should().Be(2);
+            removedItems.Count.ShouldBe(2);
 
-            removedItems[0].Key.Should().Be(1);
-            removedItems[0].Value.Should().Be(2);
-            removedItems[0].Reason.Should().Be(ItemRemovedReason.Evicted);
+            removedItems[0].Key.ShouldBe(1);
+            removedItems[0].Value.ShouldBe(2);
+            removedItems[0].Reason.ShouldBe(ItemRemovedReason.Evicted);
 
-            removedItems[1].Key.Should().Be(4);
-            removedItems[1].Value.Should().Be(5);
-            removedItems[1].Reason.Should().Be(ItemRemovedReason.Evicted);
+            removedItems[1].Key.ShouldBe(4);
+            removedItems[1].Value.ShouldBe(5);
+            removedItems[1].Reason.ShouldBe(ItemRemovedReason.Evicted);
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 lruEvents.GetOrAdd(i + 1, i => i + 1);
             }
 
-            removedItems.Count.Should().Be(0);
+            removedItems.Count.ShouldBe(0);
         }
 
         [RetryFact]
@@ -163,9 +163,9 @@ namespace BitFaster.Caching.UnitTests.Lru
                 {
                     lru.Policy.ExpireAfterWrite.Value.TrimExpired();
 
-                    lru.HotCount.Should().Be(0);
-                    lru.WarmCount.Should().Be(0);
-                    lru.ColdCount.Should().Be(0);
+                    lru.HotCount.ShouldBe(0);
+                    lru.WarmCount.ShouldBe(0);
+                    lru.ColdCount.ShouldBe(0);
                 }
             );
         }
@@ -204,10 +204,10 @@ namespace BitFaster.Caching.UnitTests.Lru
                         lru.GetOrAdd(i, k => k.ToString());
                     }
 
-                    lru.Count.Should().Be(lru.Policy.Eviction.Value.Capacity);
+                    lru.Count.ShouldBe(lru.Policy.Eviction.Value.Capacity);
 
                     var total = lru.HotCount + lru.WarmCount + lru.ColdCount;
-                    total.Should().Be(lru.Policy.Eviction.Value.Capacity);
+                    total.ShouldBe(lru.Policy.Eviction.Value.Capacity);
                 }
             );
         }
@@ -238,10 +238,10 @@ namespace BitFaster.Caching.UnitTests.Lru
 
                   lru.Policy.ExpireAfterWrite.Value.TrimExpired();
 
-                  lru.Count.Should().Be(3);
+                  lru.Count.ShouldBe(3);
 
                   var total = lru.HotCount + lru.WarmCount + lru.ColdCount;
-                  total.Should().Be(3);
+                  total.ShouldBe(3);
               }
           );
         }
@@ -264,11 +264,11 @@ namespace BitFaster.Caching.UnitTests.Lru
                 {
                     lru.Policy.Eviction.Value.Trim(1);
 
-                    lru.Count.Should().Be(0);
+                    lru.Count.ShouldBe(0);
 
-                    lru.HotCount.Should().Be(0);
-                    lru.WarmCount.Should().Be(0);
-                    lru.ColdCount.Should().Be(0);
+                    lru.HotCount.ShouldBe(0);
+                    lru.WarmCount.ShouldBe(0);
+                    lru.ColdCount.ShouldBe(0);
                 }
             );
         }
@@ -289,7 +289,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 timeToLive.MultiplyBy(ttlWaitMlutiplier),
                 lru =>
                 {
-                    lru.Count.Should().Be(0);
+                    lru.Count.ShouldBe(0);
                 }
             );
         }
@@ -310,7 +310,7 @@ namespace BitFaster.Caching.UnitTests.Lru
                 timeToLive.MultiplyBy(ttlWaitMlutiplier),
                 lru =>
                 {
-                    lru.Should().BeEquivalentTo(Array.Empty<KeyValuePair<int, string>>());
+                    lru.ShouldBe(Array.Empty<KeyValuePair<int, string>>());
                 }
             );
         }
@@ -320,7 +320,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new ConcurrentTLru<int, int>(3, TimeSpan.FromSeconds(1));
 
-            x.Capacity.Should().Be(3);
+            x.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -328,7 +328,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new ConcurrentTLru<int, int>(1, 3, EqualityComparer<int>.Default, TimeSpan.FromSeconds(1));
 
-            x.Capacity.Should().Be(3);
+            x.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -336,7 +336,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new ConcurrentTLru<int, int>(1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, TimeSpan.FromSeconds(1));
 
-            x.Capacity.Should().Be(3);
+            x.Capacity.ShouldBe(3);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/DiscretePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/DiscretePolicyTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -22,13 +22,13 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action act = () => new DiscretePolicy<int, int>(null);
 
-            act.Should().Throw<ArgumentNullException>();
+            act.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
         public void TimeToLiveShouldBeZero()
         {
-            this.policy.TimeToLive.Should().Be(TimeSpan.Zero);
+            this.policy.TimeToLive.ShouldBe(TimeSpan.Zero);
         }
 
         [Fact]
@@ -38,17 +38,17 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             expiryCalculator.ExpireAfterCreate = (k, v) => 
             {
-                k.Should().Be(1);
-                v.Should().Be(2);
+                k.ShouldBe(1);
+                v.ShouldBe(2);
                 return timeToExpire;
             };
             
             var item = this.policy.CreateItem(1, 2);
 
-            item.Key.Should().Be(1);
-            item.Value.Should().Be(2);
+            item.Key.ShouldBe(1);
+            item.Value.ShouldBe(2);
 
-            item.TickCount.Should().BeCloseTo(timeToExpire.raw + Duration.SinceEpoch().raw, DurationTests.epsilon);
+            item.TickCount.ShouldBe(timeToExpire.raw + Duration.SinceEpoch().raw);
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Touch(item);
 
-            item.WasAccessed.Should().BeTrue();
+            item.WasAccessed.ShouldBeTrue();
         }
 
         [Fact]
@@ -72,7 +72,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             this.policy.ShouldDiscard(item); // set the time in the policy
             this.policy.Touch(item);
 
-            item.TickCount.Should().BeGreaterThan(tc);
+            item.TickCount.ShouldBeGreaterThan(tc);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Update(item);
 
-            item.TickCount.Should().BeGreaterThan(tc);
+            item.TickCount.ShouldBeGreaterThan(tc);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             item.TickCount = item.TickCount - Duration.FromMilliseconds(11).raw;
 
-            this.policy.ShouldDiscard(item).Should().BeTrue();
+            this.policy.ShouldDiscard(item).ShouldBeTrue();
         }
 
         [Fact]
@@ -105,13 +105,13 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             item.TickCount = item.TickCount - Duration.FromMilliseconds(9).raw;
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item).ShouldBeFalse();
         }
 
         [Fact]
         public void CanDiscardIsTrue()
         {
-            this.policy.CanDiscard().Should().BeTrue();
+            this.policy.CanDiscard().ShouldBeTrue();
         }
 
 
@@ -124,7 +124,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -136,7 +136,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -148,7 +148,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item).ShouldBe(expectedDestination);
         }
 
         private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)

--- a/BitFaster.Caching.UnitTests/Lru/DisposableItem.cs
+++ b/BitFaster.Caching.UnitTests/Lru/DisposableItem.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {

--- a/BitFaster.Caching.UnitTests/Lru/DisposableValueFactory.cs
+++ b/BitFaster.Caching.UnitTests/Lru/DisposableValueFactory.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace BitFaster.Caching.UnitTests.Lru

--- a/BitFaster.Caching.UnitTests/Lru/EqualCapacityPartitionTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/EqualCapacityPartitionTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -16,7 +12,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new EqualCapacityPartition(2); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Theory]
@@ -28,9 +24,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var p = new EqualCapacityPartition(totalCapacity);
 
-            p.Hot.Should().Be(expectedHot);
-            p.Warm.Should().Be(expectedWarm);
-            p.Cold.Should().Be(expectedCold);
+            p.Hot.ShouldBe(expectedHot);
+            p.Warm.ShouldBe(expectedWarm);
+            p.Cold.ShouldBe(expectedCold);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/FastConcurrentLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/FastConcurrentLruTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
 using System.Collections.Generic;
@@ -15,8 +15,8 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.GetOrAdd("foo", k => 1);
 
-            lru.TryGet("FOO", out var value).Should().BeTrue();
-            value.Should().Be(1);
+            lru.TryGet("FOO", out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -24,7 +24,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new FastConcurrentLru<int, int>(3);
 
-            x.Capacity.Should().Be(3);
+            x.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new FastConcurrentLru<int, int>(1, new EqualCapacityPartition(3), EqualityComparer<int>.Default);
 
-            x.Capacity.Should().Be(3);
+            x.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new FastConcurrentLru<int, int>(3);
 
-            x.Metrics.HasValue.Should().BeFalse();
+            x.Metrics.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new FastConcurrentLru<int, int>(3);
 
-            x.Events.HasValue.Should().BeFalse();
+            x.Events.HasValue.ShouldBeFalse();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/FastConcurrentTLruTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/FastConcurrentTLruTests.cs
@@ -1,8 +1,7 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Xunit;
 using System.Threading.Tasks;
 
@@ -17,8 +16,8 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.GetOrAdd("foo", k => 1);
 
-            lru.TryGet("FOO", out var value).Should().BeTrue();
-            value.Should().Be(1);
+            lru.TryGet("FOO", out var value).ShouldBeTrue();
+            value.ShouldBe(1);
         }
 
         [Fact]
@@ -26,7 +25,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new FastConcurrentTLru<int, int>(3, TimeSpan.FromSeconds(1));
 
-            x.Capacity.Should().Be(3);
+            x.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -34,7 +33,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new FastConcurrentTLru<int, int>(1, new EqualCapacityPartition(3), EqualityComparer<int>.Default, TimeSpan.FromSeconds(1));
 
-            x.Capacity.Should().Be(3);
+            x.Capacity.ShouldBe(3);
         }
 
         [Fact]
@@ -51,7 +50,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             lru.Policy.ExpireAfterWrite.Value.TrimExpired();
 
-            lru.Count.Should().Be(0);
+            lru.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -59,7 +58,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new FastConcurrentTLru<int, int>(3, TimeSpan.FromSeconds(1));
 
-            x.Metrics.HasValue.Should().BeFalse();
+            x.Metrics.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -67,7 +66,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var x = new FastConcurrentTLru<int, int>(3, TimeSpan.FromSeconds(1));
 
-            x.Events.HasValue.Should().BeFalse();
+            x.Events.HasValue.ShouldBeFalse();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/FavorWarmPartitionTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/FavorWarmPartitionTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -16,7 +12,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new FavorWarmPartition(2); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -24,7 +20,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new FavorWarmPartition(5, 0.0); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -32,7 +28,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { var x = new FavorWarmPartition(5, 1.0); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Theory]
@@ -52,9 +48,9 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var p = new FavorWarmPartition(totalCapacity);
 
-            p.Hot.Should().Be(expectedHot);
-            p.Warm.Should().Be(expectedWarm);
-            p.Cold.Should().Be(expectedCold);
+            p.Hot.ShouldBe(expectedHot);
+            p.Warm.ShouldBe(expectedWarm);
+            p.Cold.ShouldBe(expectedCold);
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/LruInfoTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/LruInfoTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using BitFaster.Caching.Lru.Builder;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -12,7 +12,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var info = new LruInfo<int>();
 
-            info.GetExpiry<string>().Should().BeNull();
+            info.GetExpiry<string>().ShouldBeNull();
         }
 
         [Fact]
@@ -23,7 +23,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             info.SetExpiry<int>(new TestExpiryCalculator<int, int>());
 
             Action act = () => info.GetExpiry<string>();
-            act.Should().Throw<InvalidOperationException>();           
+            act.ShouldThrow<InvalidOperationException>();           
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/LruItemMemoryLayoutDumps.cs
+++ b/BitFaster.Caching.UnitTests/Lru/LruItemMemoryLayoutDumps.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using BitFaster.Caching.Lru;
+﻿using BitFaster.Caching.Lru;
 using ObjectLayoutInspector;
 using Xunit;
 using Xunit.Abstractions;

--- a/BitFaster.Caching.UnitTests/Lru/LruPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/LruPolicyTests.cs
@@ -1,8 +1,6 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -14,7 +12,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void TimeToLiveIsInfinite()
         {
-            this.policy.TimeToLive.Should().Be(new TimeSpan(0, 0, 0, 0, -1));
+            this.policy.TimeToLive.ShouldBe(new TimeSpan(0, 0, 0, 0, -1));
         }
 
         [Fact]
@@ -22,8 +20,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.Key.Should().Be(1);
-            item.Value.Should().Be(2);
+            item.Key.ShouldBe(1);
+            item.Value.ShouldBe(2);
         }
 
         [Fact]
@@ -31,7 +29,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.WasAccessed.Should().BeFalse();
+            item.WasAccessed.ShouldBeFalse();
         }
 
         [Fact]
@@ -42,7 +40,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Touch(item);
 
-            item.WasAccessed.Should().BeTrue();
+            item.WasAccessed.ShouldBeTrue();
         }
 
         [Fact]
@@ -50,7 +48,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item).ShouldBeFalse();
         }
 
         [Fact]
@@ -59,13 +57,13 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.WasAccessed = true;
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item).ShouldBeFalse();
         }
 
         [Fact]
         public void CanDiscardIsFalse()
         {
-            this.policy.CanDiscard().Should().BeFalse();
+            this.policy.CanDiscard().ShouldBeFalse();
         }
 
         [Theory]
@@ -75,7 +73,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -85,7 +83,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -95,7 +93,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item).ShouldBe(expectedDestination);
         }
 
         private LruItem<int, int> CreateItem(bool wasAccessed)

--- a/BitFaster.Caching.UnitTests/Lru/NoTelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/NoTelemetryPolicyTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using Xunit;
 
@@ -11,61 +11,61 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void HitRatioIsZero()
         {
-            counter.HitRatio.Should().Be(0);
+            counter.HitRatio.ShouldBe(0);
         }
 
         [Fact]
         public void TotalIsZero()
         {
-            counter.Total.Should().Be(0);
+            counter.Total.ShouldBe(0);
         }
 
         [Fact]
         public void HitsIsZero()
         {
-            counter.Hits.Should().Be(0);
+            counter.Hits.ShouldBe(0);
         }
 
         [Fact]
         public void MissesIsZero()
         {
-            counter.Misses.Should().Be(0);
+            counter.Misses.ShouldBe(0);
         }
 
         [Fact]
         public void UpdatedIsZero()
         {
-            counter.Updated.Should().Be(0);
+            counter.Updated.ShouldBe(0);
         }
 
         [Fact]
         public void EvictedIsZero()
         {
-            counter.Evicted.Should().Be(0);
+            counter.Evicted.ShouldBe(0);
         }
 
         [Fact]
         public void IncrementHitCountIsNoOp()
         {
-            counter.Invoking(c => c.IncrementHit()).Should().NotThrow();
+            Should.NotThrow(() => counter.IncrementHit());
         }
 
         [Fact]
         public void IncrementTotalCountIsNoOp()
         {
-            counter.Invoking(c => c.IncrementMiss()).Should().NotThrow();
+            Should.NotThrow(() => counter.IncrementMiss());
         }
 
         [Fact]
         public void OnItemUpdatedIsNoOp()
         {
-            counter.Invoking(c => c.OnItemUpdated(1, 2, 3)).Should().NotThrow();
+            Should.NotThrow(() => counter.OnItemUpdated(1, 2, 3));
         }
 
         [Fact]
         public void OnItemRemovedIsNoOp()
         {
-            counter.Invoking(c => c.OnItemRemoved(1, 2, ItemRemovedReason.Evicted)).Should().NotThrow();
+            Should.NotThrow(() => counter.OnItemRemoved(1, 2, ItemRemovedReason.Evicted));
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lru/StopwatchTickConverterTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/StopwatchTickConverterTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Lru
@@ -12,7 +12,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         { 
             var timespan = TimeSpan.FromSeconds(1);
 
-            StopwatchTickConverter.FromTicks(StopwatchTickConverter.ToTicks(timespan)).Should().BeCloseTo(timespan, TimeSpan.FromMilliseconds(20));
+            StopwatchTickConverter.FromTicks(StopwatchTickConverter.ToTicks(timespan)).ShouldBe(timespan, TimeSpan.FromMilliseconds(20));
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
+++ b/BitFaster.Caching.UnitTests/Lru/TLruTickCount64PolicyTests .cs
@@ -1,6 +1,6 @@
 ﻿#if NETCOREAPP3_1_OR_GREATER
 
-using FluentAssertions;
+using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
 using System.Threading.Tasks;
@@ -18,7 +18,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { new TLruLongTicksPolicy<int, int>(TimeSpan.MaxValue); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -26,20 +26,20 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { new TLruLongTicksPolicy<int, int>(TimeSpan.Zero); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
         public void WhenTtlIsMaxSetAsMax()
         {
             var policy = new TLruLongTicksPolicy<int, int>(Duration.MaxRepresentable);
-            policy.TimeToLive.Should().BeCloseTo(Duration.MaxRepresentable, TimeSpan.FromMilliseconds(20));
+            policy.TimeToLive.ShouldBe(Duration.MaxRepresentable, TimeSpan.FromMilliseconds(20));
         }
 
         [Fact]
         public void TimeToLiveShouldBeTenSecs()
         {
-            this.policy.TimeToLive.Should().Be(TimeSpan.FromSeconds(10));
+            this.policy.TimeToLive.ShouldBe(TimeSpan.FromSeconds(10));
         }
 
         [Fact]
@@ -47,8 +47,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.Key.Should().Be(1);
-            item.Value.Should().Be(2);
+            item.Key.ShouldBe(1);
+            item.Value.ShouldBe(2);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.TickCount.Should().BeCloseTo(Duration.SinceEpoch().raw, DurationTests.epsilon);
+            item.TickCount.ShouldBe(Duration.SinceEpoch().raw);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Touch(item);
 
-            item.WasAccessed.Should().BeTrue();
+            item.WasAccessed.ShouldBeTrue();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Update(item);
 
-            item.TickCount.Should().BeGreaterThan(tc);
+            item.TickCount.ShouldBeGreaterThan(tc);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(11).raw;
 
-            this.policy.ShouldDiscard(item).Should().BeTrue();
+            this.policy.ShouldDiscard(item).ShouldBeTrue();
         }
 
         [Fact]
@@ -98,13 +98,13 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(9).raw;
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item).ShouldBeFalse();
         }
 
         [Fact]
         public void CanDiscardIsTrue()
         {
-            this.policy.CanDiscard().Should().BeTrue();
+            this.policy.CanDiscard().ShouldBeTrue();
         }
 
         [Theory]
@@ -116,7 +116,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -128,7 +128,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -140,7 +140,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item).ShouldBe(expectedDestination);
         }
 
         private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)
@@ -163,7 +163,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var time = TimeSpan.FromSeconds(10);
             var ticks = TLruLongTicksPolicy<int, int>.ToTicks(time);
-            TLruLongTicksPolicy<int, int>.FromTicks(ticks).Should().Be(time);
+            TLruLongTicksPolicy<int, int>.FromTicks(ticks).ShouldBe(time);
         }
 
         // backcompat: remove (methods only added for TLruLongTicksPolicy)
@@ -172,7 +172,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action toTicks = () => { TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.Zero); };
 
-            toTicks.Should().Throw<ArgumentOutOfRangeException>();
+            toTicks.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         // backcompat: remove (methods only added for TLruLongTicksPolicy)
@@ -181,7 +181,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action toTicks = () => { TLruLongTicksPolicy<int, int>.ToTicks(TimeSpan.MaxValue); };
 
-            toTicks.Should().Throw<ArgumentOutOfRangeException>();
+            toTicks.ShouldThrow<ArgumentOutOfRangeException>();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TelemetryPolicyTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System.Collections.Generic;
 using Xunit;
@@ -19,25 +19,25 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void WhenHitTotalIs1()
         {
-            telemetryPolicy.Total.Should().Be(0);
+            telemetryPolicy.Total.ShouldBe(0);
             telemetryPolicy.IncrementHit();
-            telemetryPolicy.Total.Should().Be(1);
+            telemetryPolicy.Total.ShouldBe(1);
         }
 
         [Fact]
         public void WhenHitHitsIs1()
         {
-            telemetryPolicy.Hits.Should().Be(0);
+            telemetryPolicy.Hits.ShouldBe(0);
             telemetryPolicy.IncrementHit();
-            telemetryPolicy.Hits.Should().Be(1);
+            telemetryPolicy.Hits.ShouldBe(1);
         }
 
         [Fact]
         public void WhenMissMissesIs1()
         {
-            telemetryPolicy.Misses.Should().Be(0);
+            telemetryPolicy.Misses.ShouldBe(0);
             telemetryPolicy.IncrementMiss();
-            telemetryPolicy.Misses.Should().Be(1);
+            telemetryPolicy.Misses.ShouldBe(1);
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             telemetryPolicy.IncrementHit();
 
-            telemetryPolicy.HitRatio.Should().Be(1.0);
+            telemetryPolicy.HitRatio.ShouldBe(1.0);
         }
 
         [Fact]
@@ -54,13 +54,13 @@ namespace BitFaster.Caching.UnitTests.Lru
             telemetryPolicy.IncrementMiss();
             telemetryPolicy.IncrementHit();
 
-            telemetryPolicy.HitRatio.Should().Be(0.5);
+            telemetryPolicy.HitRatio.ShouldBe(0.5);
         }
 
         [Fact]
         public void WhenTotalCountIsZeroRatioReturnsZero()
         {
-            telemetryPolicy.HitRatio.Should().Be(0.0);
+            telemetryPolicy.HitRatio.ShouldBe(0.0);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             telemetryPolicy.OnItemUpdated(1, 2, 3);
 
-            telemetryPolicy.Updated.Should().Be(1);
+            telemetryPolicy.Updated.ShouldBe(1);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             telemetryPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
 
-            telemetryPolicy.Evicted.Should().Be(1);
+            telemetryPolicy.Evicted.ShouldBe(1);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             telemetryPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Removed);
 
-            telemetryPolicy.Evicted.Should().Be(0);
+            telemetryPolicy.Evicted.ShouldBe(0);
         }
 
         [Fact]
@@ -96,10 +96,10 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             telemetryPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
 
-            eventList.Should().HaveCount(1);
-            eventList[0].Key.Should().Be(1);
-            eventList[0].Value.Should().Be(2);
-            eventList[0].Reason.Should().Be(ItemRemovedReason.Evicted);
+            eventList.Count.ShouldBe(1);
+            eventList[0].Key.ShouldBe(1);
+            eventList[0].Value.ShouldBe(2);
+            eventList[0].Reason.ShouldBe(ItemRemovedReason.Evicted);
         }
 
         [Fact]
@@ -113,8 +113,8 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             telemetryPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
 
-            eventSourceList.Should().HaveCount(1);
-            eventSourceList[0].Should().Be(this);
+            eventSourceList.Count.ShouldBe(1);
+            eventSourceList[0].ShouldBe(this);
         }
 
         [Fact]
@@ -126,10 +126,10 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             telemetryPolicy.OnItemUpdated(1, 2, 3);
 
-            eventList.Should().HaveCount(1);
-            eventList[0].Key.Should().Be(1);
-            eventList[0].OldValue.Should().Be(2);
-            eventList[0].NewValue.Should().Be(3);
+            eventList.Count.ShouldBe(1);
+            eventList[0].Key.ShouldBe(1);
+            eventList[0].OldValue.ShouldBe(2);
+            eventList[0].NewValue.ShouldBe(3);
         }
 
         [Fact]
@@ -143,8 +143,8 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             telemetryPolicy.OnItemUpdated(1, 2, 3);
 
-            eventSourceList.Should().HaveCount(1);
-            eventSourceList[0].Should().Be(this);
+            eventSourceList.Count.ShouldBe(1);
+            eventSourceList[0].ShouldBe(this);
         }
 
 // backcompat: remove 
@@ -157,7 +157,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             Action act = () => policy.Object.OnItemUpdated(1, 2, 3);
 
-            act.Should().NotThrow();
+            act.ShouldNotThrow();
         }
 #endif
     }

--- a/BitFaster.Caching.UnitTests/Lru/TestCapacityPartition.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TestCapacityPartition.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using BitFaster.Caching.Lru;
+﻿using BitFaster.Caching.Lru;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {

--- a/BitFaster.Caching.UnitTests/Lru/TlruDateTimePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruDateTimePolicyTests.cs
@@ -1,10 +1,6 @@
-﻿using FluentAssertions;
-using FluentAssertions.Extensions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -17,7 +13,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void TimeToLiveShouldBeTenSecs()
         {
-            this.policy.TimeToLive.Should().Be(TimeSpan.FromSeconds(10));
+            this.policy.TimeToLive.ShouldBe(TimeSpan.FromSeconds(10));
         }
 
         [Fact]
@@ -25,8 +21,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.Key.Should().Be(1);
-            item.Value.Should().Be(2);
+            item.Key.ShouldBe(1);
+            item.Value.ShouldBe(2);
         }
 
         [Fact]
@@ -34,7 +30,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.TimeStamp.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMilliseconds(100));
+            item.TimeStamp.ShouldBe(DateTime.UtcNow, TimeSpan.FromMilliseconds(100));
         }
 
         [Fact]
@@ -45,7 +41,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Touch(item);
 
-            item.WasAccessed.Should().BeTrue();
+            item.WasAccessed.ShouldBeTrue();
         }
 
         [Fact]
@@ -58,7 +54,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Update(item);
 
-            item.TimeStamp.Should().BeAfter(ts);
+            item.TimeStamp.ShouldBeGreaterThan(ts);
         }
 
         [Fact]
@@ -67,7 +63,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.TimeStamp = DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(11));
 
-            this.policy.ShouldDiscard(item).Should().BeTrue();
+            this.policy.ShouldDiscard(item).ShouldBeTrue();
         }
 
         [Fact]
@@ -76,13 +72,13 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.TimeStamp = DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(9));
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item).ShouldBeFalse();
         }
 
         [Fact]
         public void CanDiscardIsTrue()
         { 
-            this.policy.CanDiscard().Should().BeTrue();
+            this.policy.CanDiscard().ShouldBeTrue();
         }
 
         [Theory]
@@ -94,7 +90,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -106,7 +102,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -118,7 +114,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item).ShouldBe(expectedDestination);
         }
 
         private TimeStampedLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)

--- a/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruStopwatchPolicyTests.cs
@@ -1,10 +1,10 @@
-﻿using FluentAssertions;
-using BitFaster.Caching.Lru;
-using System;
+﻿using System;
 using System.Threading.Tasks;
-using Xunit;
 using System.Diagnostics;
+using Xunit;
+using BitFaster.Caching.Lru;
 using BitFaster.Caching.UnitTests.Retry;
+using Shouldly;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
@@ -19,7 +19,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { new TLruLongTicksPolicy<int, int>(TimeSpan.Zero); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -27,7 +27,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             Action constructor = () => { new TLruLongTicksPolicy<int, int>(TimeSpan.MaxValue); };
 
-            constructor.Should().Throw<ArgumentOutOfRangeException>();
+            constructor.ShouldThrow<ArgumentOutOfRangeException>();
         }
 
         [Fact]
@@ -35,13 +35,13 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var ttl = Duration.MaxRepresentable;
 
-            new TLruLongTicksPolicy<int, int>(ttl).TimeToLive.Should().BeCloseTo(ttl, TimeSpan.FromSeconds(1));
+            new TLruLongTicksPolicy<int, int>(ttl).TimeToLive.ShouldBe(ttl, TimeSpan.FromSeconds(1));
         }
 
         [Fact]
         public void TimeToLiveShouldBeTenSecs()
         {
-            this.policy.TimeToLive.Should().Be(TimeSpan.FromSeconds(10));
+            this.policy.TimeToLive.ShouldBe(TimeSpan.FromSeconds(10));
         }
 
         [Fact]
@@ -49,8 +49,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.Key.Should().Be(1);
-            item.Value.Should().Be(2);
+            item.Key.ShouldBe(1);
+            item.Value.ShouldBe(2);
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.TickCount.Should().BeCloseTo(Duration.SinceEpoch().raw, DurationTests.epsilon);
+            item.TickCount.ShouldBe(Duration.SinceEpoch().raw);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Touch(item);
 
-            item.WasAccessed.Should().BeTrue();
+            item.WasAccessed.ShouldBeTrue();
         }
 
         [RetryFact]
@@ -82,7 +82,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Update(item);
 
-            item.TickCount.Should().BeGreaterThan(tc);
+            item.TickCount.ShouldBeGreaterThan(tc);
         }
 
         [Fact]
@@ -91,7 +91,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(11).raw;
 
-            this.policy.ShouldDiscard(item).Should().BeTrue();
+            this.policy.ShouldDiscard(item).ShouldBeTrue();
         }
 
         [Fact]
@@ -100,13 +100,13 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.TickCount = Duration.SinceEpoch().raw - Duration.FromSeconds(9).raw;
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item).ShouldBeFalse();
         }
 
         [Fact]
         public void CanDiscardIsTrue()
         {
-            this.policy.CanDiscard().Should().BeTrue();
+            this.policy.CanDiscard().ShouldBeTrue();
         }
 
         [Theory]
@@ -118,7 +118,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -130,7 +130,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -142,7 +142,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item).ShouldBe(expectedDestination);
         }
 
         private LongTickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)

--- a/BitFaster.Caching.UnitTests/Lru/TlruTicksPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lru/TlruTicksPolicyTests.cs
@@ -1,13 +1,9 @@
-﻿using FluentAssertions;
-using FluentAssertions.Extensions;
-using BitFaster.Caching.Lru;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
+using BitFaster.Caching.Lru;
 using BitFaster.Caching.UnitTests.Retry;
+using Shouldly;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {
@@ -18,7 +14,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         [Fact]
         public void TimeToLiveShouldBeTenSecs()
         {
-            this.policy.TimeToLive.Should().Be(TimeSpan.FromSeconds(10));
+            this.policy.TimeToLive.ShouldBe(TimeSpan.FromSeconds(10));
         }
 
         [Fact]
@@ -26,8 +22,8 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.Key.Should().Be(1);
-            item.Value.Should().Be(2);
+            item.Key.ShouldBe(1);
+            item.Value.ShouldBe(2);
         }
 
         [Fact]
@@ -35,7 +31,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = this.policy.CreateItem(1, 2);
 
-            item.TickCount.Should().BeCloseTo(Environment.TickCount, 20);
+            item.TickCount.ShouldBe(Environment.TickCount);
         }
 
         [Fact]
@@ -46,7 +42,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Touch(item);
 
-            item.WasAccessed.Should().BeTrue();
+            item.WasAccessed.ShouldBeTrue();
         }
 
         [RetryFact]
@@ -59,7 +55,7 @@ namespace BitFaster.Caching.UnitTests.Lru
 
             this.policy.Update(item);
 
-            item.TickCount.Should().BeGreaterThan(tc);
+            item.TickCount.ShouldBeGreaterThan(tc);
         }
 
         [Fact]
@@ -68,7 +64,7 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.TickCount = Environment.TickCount - (int)TimeSpan.FromSeconds(11).ToEnvTicks();
 
-            this.policy.ShouldDiscard(item).Should().BeTrue();
+            this.policy.ShouldDiscard(item).ShouldBeTrue();
         }
 
         [Fact]
@@ -77,13 +73,13 @@ namespace BitFaster.Caching.UnitTests.Lru
             var item = this.policy.CreateItem(1, 2);
             item.TickCount = Environment.TickCount - (int)TimeSpan.FromSeconds(9).ToEnvTicks();
 
-            this.policy.ShouldDiscard(item).Should().BeFalse();
+            this.policy.ShouldDiscard(item).ShouldBeFalse();
         }
 
         [Fact]
         public void CanDiscardIsTrue()
         {
-            this.policy.CanDiscard().Should().BeTrue();
+            this.policy.CanDiscard().ShouldBeTrue();
         }
 
         [Theory]
@@ -95,7 +91,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteHot(item).Should().Be(expectedDestination);
+            this.policy.RouteHot(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -107,7 +103,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteWarm(item).Should().Be(expectedDestination);
+            this.policy.RouteWarm(item).ShouldBe(expectedDestination);
         }
 
         [Theory]
@@ -119,7 +115,7 @@ namespace BitFaster.Caching.UnitTests.Lru
         {
             var item = CreateItem(wasAccessed, isExpired);
 
-            this.policy.RouteCold(item).Should().Be(expectedDestination);
+            this.policy.RouteCold(item).ShouldBe(expectedDestination);
         }
 
         private TickCountLruItem<int, int> CreateItem(bool wasAccessed, bool isExpired)

--- a/BitFaster.Caching.UnitTests/Lru/ValueFactory.cs
+++ b/BitFaster.Caching.UnitTests/Lru/ValueFactory.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace BitFaster.Caching.UnitTests.Lru
 {

--- a/BitFaster.Caching.UnitTests/ReferenceCountTests.cs
+++ b/BitFaster.Caching.UnitTests/ReferenceCountTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -11,7 +11,7 @@ namespace BitFaster.Caching.UnitTests
             var a = new ReferenceCount<object>(new object());
             var b = a.IncrementCopy().DecrementCopy();
 
-            a.Should().Be(b);
+            a.ShouldBe(b);
         }
 
         [Fact]
@@ -20,7 +20,7 @@ namespace BitFaster.Caching.UnitTests
             var a = new ReferenceCount<object>(new object());
             var b = a.IncrementCopy().DecrementCopy();
 
-            a.Should().NotBeSameAs(b);
+            a.ShouldNotBeSameAs(b);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace BitFaster.Caching.UnitTests
             var a = new ReferenceCount<object>(new object());
             var b = new ReferenceCount<object>(new object());
 
-            a.Should().NotBe(b);
+            a.ShouldNotBe(b);
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace BitFaster.Caching.UnitTests
             var a = new ReferenceCount<int>(0);
             var b = a.IncrementCopy();
 
-            a.Should().NotBe(b);
+            a.ShouldNotBe(b);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace BitFaster.Caching.UnitTests
             var a = new ReferenceCount<object>(new object());
             var b = a.IncrementCopy().DecrementCopy();
 
-            a.GetHashCode().Should().Be(b.GetHashCode());
+            a.GetHashCode().ShouldBe(b.GetHashCode());
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace BitFaster.Caching.UnitTests
             var a = new ReferenceCount<object>(new object());
             var b = new ReferenceCount<object>(new object());
 
-            a.GetHashCode().Should().NotBe(b.GetHashCode());
+            a.GetHashCode().ShouldNotBe(b.GetHashCode());
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Retry/DelayedMessageBus.cs
+++ b/BitFaster.Caching.UnitTests/Retry/DelayedMessageBus.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 

--- a/BitFaster.Caching.UnitTests/Retry/RetryFact.cs
+++ b/BitFaster.Caching.UnitTests/Retry/RetryFact.cs
@@ -1,5 +1,5 @@
-﻿using Xunit.Sdk;
-using Xunit;
+﻿using Xunit;
+using Xunit.Sdk;
 
 namespace BitFaster.Caching.UnitTests.Retry
 {

--- a/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Scheduler;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Scheduler
@@ -14,18 +14,18 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         [Fact]
         public void IsBackground()
         {
-            scheduler.IsBackground.Should().BeTrue();
+            scheduler.IsBackground.ShouldBeTrue();
         }
 
         [Fact]
         public async Task WhenWorkIsScheduledCountIsIncremented()
         {
-            scheduler.RunCount.Should().Be(0);
+            scheduler.RunCount.ShouldBe(0);
 
             scheduler.Run(() => { });
             await Task.Yield();
 
-            scheduler.RunCount.Should().Be(1);
+            scheduler.RunCount.ShouldBe(1);
         }
 
         [Fact]
@@ -37,19 +37,19 @@ namespace BitFaster.Caching.UnitTests.Scheduler
             scheduler.Run(() => { Volatile.Write(ref run, true); tcs.SetResult(true); });
             await tcs.Task;
 
-            Volatile.Read(ref run).Should().BeTrue();
+            Volatile.Read(ref run).ShouldBeTrue();
         }
 
         [Fact]
         public async Task WhenWorkDoesNotThrowLastExceptionIsEmpty()
         {
-            scheduler.RunCount.Should().Be(0);
+            scheduler.RunCount.ShouldBe(0);
 
 
             scheduler.Run(() => { });
             await Task.Yield();
 
-            scheduler.LastException.HasValue.Should().BeFalse();
+            scheduler.LastException.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -61,8 +61,8 @@ namespace BitFaster.Caching.UnitTests.Scheduler
             await tcs.Task;
             await scheduler.WaitForExceptionAsync();
 
-            scheduler.LastException.HasValue.Should().BeTrue();
-            scheduler.LastException.Value.Should().BeOfType<InvalidCastException>();
+            scheduler.LastException.HasValue.ShouldBeTrue();
+            scheduler.LastException.Value.ShouldBeOfType<InvalidCastException>();
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace BitFaster.Caching.UnitTests.Scheduler
 
             mre.Set();
 
-            scheduler.RunCount.Should().BeCloseTo(BackgroundThreadScheduler.MaxBacklog, 1);
+            scheduler.RunCount.ShouldBe(BackgroundThreadScheduler.MaxBacklog);
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Scheduler/ForegroundSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/ForegroundSchedulerTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Scheduler;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Scheduler
@@ -16,17 +12,17 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         [Fact]
         public void IsNotBackground()
         {
-            scheduler.IsBackground.Should().BeFalse();
+            scheduler.IsBackground.ShouldBeFalse();
         }
 
         [Fact]
         public void WhenWorkIsScheduledCountIsIncremented()
         {
-            scheduler.RunCount.Should().Be(0);
+            scheduler.RunCount.ShouldBe(0);
 
             scheduler.Run(() => { });
 
-            scheduler.RunCount.Should().Be(1);
+            scheduler.RunCount.ShouldBe(1);
         }
 
         [Fact]
@@ -36,17 +32,17 @@ namespace BitFaster.Caching.UnitTests.Scheduler
 
             scheduler.Run(() => { run = true; });
 
-            run.Should().BeTrue();
+            run.ShouldBeTrue();
         }
 
         [Fact]
         public void WhenWorkDoesNotThrowLastExceptionIsEmpty()
         {
-            scheduler.RunCount.Should().Be(0);
+            scheduler.RunCount.ShouldBe(0);
 
             scheduler.Run(() => { });
 
-            scheduler.LastException.HasValue.Should().BeFalse();
+            scheduler.LastException.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -54,7 +50,7 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         {
             Action work = () => { scheduler.Run(() => { throw new InvalidCastException(); }); };
 
-            work.Should().Throw<InvalidCastException>();
+            work.ShouldThrow<InvalidCastException>();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Scheduler/NullSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/NullSchedulerTests.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using BitFaster.Caching.Scheduler;
-using FluentAssertions;
+﻿using BitFaster.Caching.Scheduler;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Scheduler
@@ -16,17 +11,17 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         [Fact]
         public void IsNotBackground()
         {
-            scheduler.IsBackground.Should().BeFalse();
+            scheduler.IsBackground.ShouldBeFalse();
         }
 
         [Fact]
         public void WhenWorkIsScheduledCountIsIncremented()
         {
-            scheduler.RunCount.Should().Be(0);
+            scheduler.RunCount.ShouldBe(0);
 
             scheduler.Run(() => { });
 
-            scheduler.RunCount.Should().Be(1);
+            scheduler.RunCount.ShouldBe(1);
         }
 
         [Fact]
@@ -36,13 +31,13 @@ namespace BitFaster.Caching.UnitTests.Scheduler
 
             scheduler.Run(() => { run = true; });
 
-            run.Should().BeFalse();
+            run.ShouldBeFalse();
         }
 
         [Fact]
         public void LastExceptionIsEmpty()
         {
-            scheduler.LastException.HasValue.Should().BeFalse();
+            scheduler.LastException.HasValue.ShouldBeFalse();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Scheduler/SchedulerTestExtensions.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/SchedulerTestExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using BitFaster.Caching.Scheduler;
 

--- a/BitFaster.Caching.UnitTests/Scheduler/ThreadPoolSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/ThreadPoolSchedulerTests.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using BitFaster.Caching.Scheduler;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests.Scheduler
@@ -14,12 +14,12 @@ namespace BitFaster.Caching.UnitTests.Scheduler
         [Fact]
         public async Task WhenWorkIsScheduledCountIsIncremented()
         {
-            scheduler.RunCount.Should().Be(0);
+            scheduler.RunCount.ShouldBe(0);
 
             scheduler.Run(() => { });
             await Task.Yield();
 
-            scheduler.RunCount.Should().Be(1);
+            scheduler.RunCount.ShouldBe(1);
         }
 
         [Fact]
@@ -32,20 +32,20 @@ namespace BitFaster.Caching.UnitTests.Scheduler
 
             await tcs.Task;
 
-            Volatile.Read(ref run).Should().BeTrue();
+            Volatile.Read(ref run).ShouldBeTrue();
         }
 
         [Fact]
         public async Task WhenWorkDoesNotThrowLastExceptionIsEmpty()
         {
             var tcs = new TaskCompletionSource<bool>();
-            scheduler.RunCount.Should().Be(0);
+            scheduler.RunCount.ShouldBe(0);
 
             scheduler.Run(() => { tcs.SetResult(true); });
 
             await tcs.Task;
 
-            scheduler.LastException.HasValue.Should().BeFalse();
+            scheduler.LastException.HasValue.ShouldBeFalse();
         }
 
         [Fact]
@@ -58,8 +58,8 @@ namespace BitFaster.Caching.UnitTests.Scheduler
             await tcs.Task;
             await scheduler.WaitForExceptionAsync();
 
-            scheduler.LastException.HasValue.Should().BeTrue();
-            scheduler.LastException.Value.Should().BeOfType<InvalidCastException>();
+            scheduler.LastException.HasValue.ShouldBeTrue();
+            scheduler.LastException.Value.ShouldBeOfType<InvalidCastException>();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedAsyncCacheTestBase.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -24,17 +24,17 @@ namespace BitFaster.Caching.UnitTests
         [Fact]
         public void WhenCreatedCapacityPropertyWrapsInnerCache()
         {
-            this.cache.Policy.Eviction.Value.Capacity.Should().Be(capacity);
+            this.cache.Policy.Eviction.Value.Capacity.ShouldBe(capacity);
         }
 
         [Fact]
         public void WhenItemIsAddedCountIsCorrect()
         {
-            this.cache.Count.Should().Be(0);
+            this.cache.Count.ShouldBe(0);
 
             this.cache.AddOrUpdate(1, new Disposable());
 
-            this.cache.Count.Should().Be(1);
+            this.cache.Count.ShouldBe(1);
         }
 
         [Fact]
@@ -43,8 +43,8 @@ namespace BitFaster.Caching.UnitTests
             this.cache.AddOrUpdate(1, new Disposable());
             this.cache.ScopedTryGet(1, out var lifetime);
 
-            this.cache.Metrics.Value.Misses.Should().Be(0);
-            this.cache.Metrics.Value.Hits.Should().Be(1);
+            this.cache.Metrics.Value.Misses.ShouldBe(0);
+            this.cache.Metrics.Value.Hits.ShouldBe(1);
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace BitFaster.Caching.UnitTests
             this.cache.AddOrUpdate(1, new Disposable());
             this.cache.TryRemove(1);
 
-            this.removedItems.First().Key.Should().Be(1);
+            this.removedItems.First().Key.ShouldBe(1);
         }
 
 // backcompat: remove conditional compile
@@ -68,7 +68,7 @@ namespace BitFaster.Caching.UnitTests
             this.cache.AddOrUpdate(1, new Disposable());
             this.cache.AddOrUpdate(1, new Disposable());
 
-            this.updatedItems.First().Key.Should().Be(1);
+            this.updatedItems.First().Key.ShouldBe(1);
         }
 #endif
 
@@ -78,8 +78,8 @@ namespace BitFaster.Caching.UnitTests
             var d = new Disposable();
             this.cache.AddOrUpdate(1, d);
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-            lifetime.Value.Should().Be(d);
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
+            lifetime.Value.ShouldBe(d);
         }
 
         // backcompat: remove conditional compile
@@ -92,8 +92,8 @@ namespace BitFaster.Caching.UnitTests
                 (k, a) => Task.FromResult(new Scoped<Disposable>(new Disposable(a))),
                 2);
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-            lifetime.Value.State.Should().Be(2);
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
+            lifetime.Value.State.ShouldBe(2);
         }
 #endif
         [Fact]
@@ -104,8 +104,8 @@ namespace BitFaster.Caching.UnitTests
             this.cache.AddOrUpdate(1, d1);
             this.cache.AddOrUpdate(1, d2);
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-            lifetime.Value.Should().Be(d2);
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
+            lifetime.Value.ShouldBe(d2);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace BitFaster.Caching.UnitTests
 
             // start a lifetime on 1
             this.cache.AddOrUpdate(1, d1);
-            this.cache.ScopedTryGet(1, out var lifetime1).Should().BeTrue();
+            this.cache.ScopedTryGet(1, out var lifetime1).ShouldBeTrue();
 
             using (lifetime1)
             {
@@ -124,13 +124,13 @@ namespace BitFaster.Caching.UnitTests
                 this.cache.AddOrUpdate(1, d2);
 
                 // cache reflects replacement
-                this.cache.ScopedTryGet(1, out var lifetime2).Should().BeTrue();
-                lifetime2.Value.Should().Be(d2);
+                this.cache.ScopedTryGet(1, out var lifetime2).ShouldBeTrue();
+                lifetime2.Value.ShouldBe(d2);
 
-                d1.IsDisposed.Should().BeFalse();
+                d1.IsDisposed.ShouldBeFalse();
             }
 
-            d1.IsDisposed.Should().BeTrue();
+            d1.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -141,22 +141,22 @@ namespace BitFaster.Caching.UnitTests
 
             this.cache.Clear();
 
-            d.IsDisposed.Should().BeTrue();
+            d.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
         public void WhenItemExistsTryGetReturnsLifetime()
         {
             this.cache.AddOrUpdate(1, new Disposable());
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
 
-            lifetime.Should().NotBeNull();
+            lifetime.ShouldNotBeNull();
         }
 
         [Fact]
         public void WhenItemDoesNotExistTryGetReturnsFalse()
         {
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeFalse();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
@@ -168,26 +168,26 @@ namespace BitFaster.Caching.UnitTests
 
             this.cache.Policy.Eviction.Value.Trim(1);
 
-            this.cache.ScopedTryGet(0, out var lifetime).Should().BeFalse();
+            this.cache.ScopedTryGet(0, out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryRemoveReturnsFalse()
         {
-            this.cache.TryRemove(1).Should().BeFalse();
+            this.cache.TryRemove(1).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyExistsTryRemoveReturnsTrue()
         {
             this.cache.AddOrUpdate(1, new Disposable());
-            this.cache.TryRemove(1).Should().BeTrue();
+            this.cache.TryRemove(1).ShouldBeTrue();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
         {
-            this.cache.TryUpdate(1, new Disposable()).Should().BeFalse();
+            this.cache.TryUpdate(1, new Disposable()).ShouldBeFalse();
         }
 
         [Fact]
@@ -195,16 +195,16 @@ namespace BitFaster.Caching.UnitTests
         {
             this.cache.AddOrUpdate(1, new Disposable());
 
-            this.cache.TryUpdate(1, new Disposable()).Should().BeTrue();
+            this.cache.TryUpdate(1, new Disposable()).ShouldBeTrue();
         }
 
         [Fact]
         public void WhenItemsAddedKeysContainsTheKeys()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, new Disposable());
             cache.AddOrUpdate(2, new Disposable());
-            cache.Keys.Should().BeEquivalentTo(new[] { 1, 2 });
+            cache.Keys.ShouldBe(new[] { 1, 2 });
         }
 
         [Fact]
@@ -213,12 +213,12 @@ namespace BitFaster.Caching.UnitTests
             var d1 = new Disposable();
             var d2 = new Disposable();
 
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, d1);
             cache.AddOrUpdate(2, d2);
             cache
                 .Select(kvp => new KeyValuePair<int, Disposable>(kvp.Key, kvp.Value.CreateLifetime().Value))
-                .Should().BeEquivalentTo(new[] { new KeyValuePair<int, Disposable>(1, d1), new KeyValuePair<int, Disposable>(2, d2) });
+                .ShouldBe(new[] { new KeyValuePair<int, Disposable>(1, d1), new KeyValuePair<int, Disposable>(2, d2) });
         }
 
         [Fact]
@@ -227,7 +227,7 @@ namespace BitFaster.Caching.UnitTests
             var d1 = new Disposable();
             var d2 = new Disposable();
 
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, d1);
             cache.AddOrUpdate(2, d2);
 
@@ -241,7 +241,7 @@ namespace BitFaster.Caching.UnitTests
                 list.Add(new KeyValuePair<int, Disposable>(kvp.Key, kvp.Value.CreateLifetime().Value));
             }
 
-            list.Should().BeEquivalentTo(new[] { new KeyValuePair<int, Disposable>(1, d1), new KeyValuePair<int, Disposable>(2, d2) });
+            list.ShouldBe(new[] { new KeyValuePair<int, Disposable>(1, d1), new KeyValuePair<int, Disposable>(2, d2) });
         }
 
         [Fact]
@@ -253,7 +253,7 @@ namespace BitFaster.Caching.UnitTests
             }
             catch { }
 
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -266,7 +266,7 @@ namespace BitFaster.Caching.UnitTests
             catch { }
 
             // IEnumerable.Count() instead of Count property
-            cache.Count().Should().Be(0);
+            cache.Count().ShouldBe(0);
         }
 
         [Fact]
@@ -278,7 +278,7 @@ namespace BitFaster.Caching.UnitTests
             }
             catch { }
 
-            cache.Keys.Count().Should().Be(0);
+            cache.Keys.Count().ShouldBe(0);
         }
 
         protected void OnItemRemoved(object sender, ItemRemovedEventArgs<int, Scoped<Disposable>> e)

--- a/BitFaster.Caching.UnitTests/ScopedAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedAsyncCacheTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -18,7 +18,7 @@ namespace BitFaster.Caching.UnitTests
         {
             Action constructor = () => { var x = new ScopedAsyncCache<int, Disposable>(null); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace BitFaster.Caching.UnitTests
 
             scope.Dispose();
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeFalse();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace BitFaster.Caching.UnitTests
         {
             await this.cache.ScopedGetOrAddAsync(1, k => Task.FromResult(new Scoped<Disposable>(new Disposable())));
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace BitFaster.Caching.UnitTests
 
             Func<Task> getOrAdd = async () => { await this.cache.ScopedGetOrAddAsync(1, k => Task.FromResult(scope)); };
 
-            await getOrAdd.Should().ThrowAsync<InvalidOperationException>();
+            var ex = await getOrAdd.ShouldThrowAsync<InvalidOperationException>();;
         }
 
 // backcompat: remove conditional compile
@@ -62,7 +62,7 @@ namespace BitFaster.Caching.UnitTests
 
             Func<Task> getOrAdd = async () => { await this.cache.ScopedGetOrAddAsync(1, (k, a) => Task.FromResult(scope), 2); };
 
-            await getOrAdd.Should().ThrowAsync<InvalidOperationException>();
+            var ex = await getOrAdd.ShouldThrowAsync<InvalidOperationException>();;
         }
 #endif
     }

--- a/BitFaster.Caching.UnitTests/ScopedCacheSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheSoakTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -21,7 +21,7 @@ namespace BitFaster.Caching.UnitTests
                     {
                         using (var l = this.cache.ScopedGetOrAdd(j, k => new Scoped<Disposable>(new Disposable(k))))
                         {
-                            l.Value.IsDisposed.Should().BeFalse($"ref count {l.ReferenceCount}");
+                            l.Value.IsDisposed.ShouldBeFalse($"ref count {l.ReferenceCount}");
                         }
                     }
                 });

--- a/BitFaster.Caching.UnitTests/ScopedCacheTestBase.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTestBase.cs
@@ -1,8 +1,7 @@
-﻿
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -23,17 +22,17 @@ namespace BitFaster.Caching.UnitTests
         [Fact]
         public void WhenCreatedCapacityPropertyWrapsInnerCache()
         {
-            this.cache.Policy.Eviction.Value.Capacity.Should().Be(capacity);
+            this.cache.Policy.Eviction.Value.Capacity.ShouldBe(capacity);
         }
 
         [Fact]
         public void WhenItemIsAddedCountIsCorrect()
         {
-            this.cache.Count.Should().Be(0);
+            this.cache.Count.ShouldBe(0);
 
             this.cache.AddOrUpdate(1, new Disposable());
 
-            this.cache.Count.Should().Be(1);
+            this.cache.Count.ShouldBe(1);
         }
 
         [Fact]
@@ -42,8 +41,8 @@ namespace BitFaster.Caching.UnitTests
             this.cache.AddOrUpdate(1, new Disposable());
             this.cache.ScopedTryGet(1, out var lifetime);
 
-            this.cache.Metrics.Value.Misses.Should().Be(0);
-            this.cache.Metrics.Value.Hits.Should().Be(1);
+            this.cache.Metrics.Value.Misses.ShouldBe(0);
+            this.cache.Metrics.Value.Hits.ShouldBe(1);
         }
 
         [Fact]
@@ -54,7 +53,7 @@ namespace BitFaster.Caching.UnitTests
             this.cache.AddOrUpdate(1, new Disposable());
             this.cache.TryRemove(1);
 
-            this.removedItems.First().Key.Should().Be(1);
+            this.removedItems.First().Key.ShouldBe(1);
         }
 
 // backcompat: remove conditional compile
@@ -67,7 +66,7 @@ namespace BitFaster.Caching.UnitTests
             this.cache.AddOrUpdate(1, new Disposable());
             this.cache.AddOrUpdate(1, new Disposable());
 
-            this.updatedItems.First().Key.Should().Be(1);
+            this.updatedItems.First().Key.ShouldBe(1);
         }
 #endif
 
@@ -77,8 +76,8 @@ namespace BitFaster.Caching.UnitTests
             var d = new Disposable();
             this.cache.AddOrUpdate(1, d);
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-            lifetime.Value.Should().Be(d);
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
+            lifetime.Value.ShouldBe(d);
         }
 
 // backcompat: remove conditional compile
@@ -91,8 +90,8 @@ namespace BitFaster.Caching.UnitTests
                 (k, a) => new Scoped<Disposable>(new Disposable(a)),
                 2);
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-            lifetime.Value.State.Should().Be(2);
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
+            lifetime.Value.State.ShouldBe(2);
         }
 #endif
 
@@ -104,8 +103,8 @@ namespace BitFaster.Caching.UnitTests
             this.cache.AddOrUpdate(1, d1);
             this.cache.AddOrUpdate(1, d2);
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
-            lifetime.Value.Should().Be(d2);
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
+            lifetime.Value.ShouldBe(d2);
         }
 
         [Fact]
@@ -116,7 +115,7 @@ namespace BitFaster.Caching.UnitTests
 
             // start a lifetime on 1
             this.cache.AddOrUpdate(1, d1);
-            this.cache.ScopedTryGet(1, out var lifetime1).Should().BeTrue();
+            this.cache.ScopedTryGet(1, out var lifetime1).ShouldBeTrue();
 
             using (lifetime1)
             {
@@ -124,13 +123,13 @@ namespace BitFaster.Caching.UnitTests
                 this.cache.AddOrUpdate(1, d2);
 
                 // cache reflects replacement
-                this.cache.ScopedTryGet(1, out var lifetime2).Should().BeTrue();
-                lifetime2.Value.Should().Be(d2);
+                this.cache.ScopedTryGet(1, out var lifetime2).ShouldBeTrue();
+                lifetime2.Value.ShouldBe(d2);
 
-                d1.IsDisposed.Should().BeFalse();
+                d1.IsDisposed.ShouldBeFalse();
             }
 
-            d1.IsDisposed.Should().BeTrue();
+            d1.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -141,22 +140,22 @@ namespace BitFaster.Caching.UnitTests
 
             this.cache.Clear();
 
-            d.IsDisposed.Should().BeTrue();
+            d.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
         public void WhenItemExistsTryGetReturnsLifetime()
         {
             this.cache.AddOrUpdate(1, new Disposable());
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
 
-            lifetime.Should().NotBeNull();
+            lifetime.ShouldNotBeNull();
         }
 
         [Fact]
         public void WhenItemDoesNotExistTryGetReturnsFalse()
         {
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeFalse();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
@@ -168,26 +167,26 @@ namespace BitFaster.Caching.UnitTests
 
             this.cache.Policy.Eviction.Value.Trim(1);
 
-            this.cache.ScopedTryGet(0, out var lifetime).Should().BeFalse();
+            this.cache.ScopedTryGet(0, out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryRemoveReturnsFalse()
         {
-            this.cache.TryRemove(1).Should().BeFalse();
+            this.cache.TryRemove(1).ShouldBeFalse();
         }
 
         [Fact]
         public void WhenKeyExistsTryRemoveReturnsTrue()
         {
             this.cache.AddOrUpdate(1, new Disposable());
-            this.cache.TryRemove(1).Should().BeTrue();
+            this.cache.TryRemove(1).ShouldBeTrue();
         }
 
         [Fact]
         public void WhenKeyDoesNotExistTryUpdateReturnsFalse()
         {
-            this.cache.TryUpdate(1, new Disposable()).Should().BeFalse();
+            this.cache.TryUpdate(1, new Disposable()).ShouldBeFalse();
         }
 
         [Fact]
@@ -195,16 +194,16 @@ namespace BitFaster.Caching.UnitTests
         {
             this.cache.AddOrUpdate(1, new Disposable());
 
-            this.cache.TryUpdate(1, new Disposable()).Should().BeTrue();
+            this.cache.TryUpdate(1, new Disposable()).ShouldBeTrue();
         }
 
         [Fact]
         public void WhenItemsAddedKeysContainsTheKeys()
         {
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, new Disposable());
             cache.AddOrUpdate(2, new Disposable());
-            cache.Keys.Should().BeEquivalentTo(new[] { 1, 2 });
+            cache.Keys.ShouldBe(new[] { 1, 2 });
         }
 
         [Fact]
@@ -213,12 +212,12 @@ namespace BitFaster.Caching.UnitTests
             var d1 = new Disposable();
             var d2 = new Disposable();
 
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, d1);
             cache.AddOrUpdate(2, d2);
             cache
                 .Select(kvp => new KeyValuePair<int, Disposable>(kvp.Key, kvp.Value.CreateLifetime().Value))
-                .Should().BeEquivalentTo(new[] { new KeyValuePair<int, Disposable>(1, d1), new KeyValuePair<int, Disposable>(2, d2) });
+                .ShouldBe(new[] { new KeyValuePair<int, Disposable>(1, d1), new KeyValuePair<int, Disposable>(2, d2) });
         }
 
         [Fact]
@@ -227,7 +226,7 @@ namespace BitFaster.Caching.UnitTests
             var d1 = new Disposable();
             var d2 = new Disposable();
 
-            cache.Count.Should().Be(0);
+            cache.Count.ShouldBe(0);
             cache.AddOrUpdate(1, d1);
             cache.AddOrUpdate(2, d2);
 
@@ -241,7 +240,7 @@ namespace BitFaster.Caching.UnitTests
                 list.Add(new KeyValuePair<int, Disposable>(kvp.Key, kvp.Value.CreateLifetime().Value));
             }
 
-            list.Should().BeEquivalentTo(new[] { new KeyValuePair<int, Disposable>(1, d1), new KeyValuePair<int, Disposable>(2, d2) });
+            list.ShouldBe(new[] { new KeyValuePair<int, Disposable>(1, d1), new KeyValuePair<int, Disposable>(2, d2) });
         }
 
         protected void OnItemRemoved(object sender, ItemRemovedEventArgs<int, Scoped<Disposable>> e)

--- a/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedCacheTests.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -21,7 +17,7 @@ namespace BitFaster.Caching.UnitTests
         {
             Action constructor = () => { var x = new ScopedCache<int, Disposable>(null); };
 
-            constructor.Should().Throw<ArgumentNullException>();
+            constructor.ShouldThrow<ArgumentNullException>();
         }
 
         [Fact]
@@ -33,7 +29,7 @@ namespace BitFaster.Caching.UnitTests
 
             scope.Dispose();
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeFalse();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeFalse();
         }
 
         [Fact]
@@ -41,7 +37,7 @@ namespace BitFaster.Caching.UnitTests
         {
             this.cache.ScopedGetOrAdd(1, k => new Scoped<Disposable>(new Disposable()));
 
-            this.cache.ScopedTryGet(1, out var lifetime).Should().BeTrue();
+            this.cache.ScopedTryGet(1, out var lifetime).ShouldBeTrue();
         }
 
         [Fact]
@@ -52,7 +48,7 @@ namespace BitFaster.Caching.UnitTests
             
             Action getOrAdd = () => { this.cache.ScopedGetOrAdd(1, k => scope); };
 
-            getOrAdd.Should().Throw<InvalidOperationException>();
+            getOrAdd.ShouldThrow<InvalidOperationException>();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/ScopedSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedSoakTests.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -19,15 +19,15 @@ namespace BitFaster.Caching.UnitTests
                     {
                         using (var l = scope.CreateLifetime())
                         {
-                            l.Value.IsDisposed.Should().BeFalse();
+                            l.Value.IsDisposed.ShouldBeFalse();
                         }
                     }
                 });
 
-                scope.IsDisposed.Should().BeFalse();
+                scope.IsDisposed.ShouldBeFalse();
                 scope.Dispose();
-                scope.TryCreateLifetime(out _).Should().BeFalse();
-                scope.IsDisposed.Should().BeTrue();
+                scope.TryCreateLifetime(out _).ShouldBeFalse();
+                scope.IsDisposed.ShouldBeTrue();
             }
         }
     }

--- a/BitFaster.Caching.UnitTests/ScopedTests.cs
+++ b/BitFaster.Caching.UnitTests/ScopedTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+﻿using Shouldly;
 using BitFaster.Caching.Lru;
 using System;
 using System.Collections.Generic;
@@ -15,7 +15,7 @@ namespace BitFaster.Caching.UnitTests
             var scope = new Scoped<Disposable>(disposable);
 
             scope.Dispose();
-            disposable.IsDisposed.Should().BeTrue();
+            disposable.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -27,10 +27,10 @@ namespace BitFaster.Caching.UnitTests
 
             scope.Dispose();
             scope.Dispose(); // validate double dispose is still single ref count
-            disposable.IsDisposed.Should().BeFalse();
+            disposable.IsDisposed.ShouldBeFalse();
 
             lifetime.Dispose();
-            disposable.IsDisposed.Should().BeTrue();
+            disposable.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -43,10 +43,10 @@ namespace BitFaster.Caching.UnitTests
             lifetime.Dispose();
             lifetime.Dispose(); // validate double dispose is still single ref count
 
-            disposable.IsDisposed.Should().BeFalse();
+            disposable.IsDisposed.ShouldBeFalse();
 
             scope.Dispose();
-            disposable.IsDisposed.Should().BeTrue();
+            disposable.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace BitFaster.Caching.UnitTests
             var scope = new Scoped<Disposable>(disposable);
             scope.Dispose();
 
-            scope.Invoking(s => s.CreateLifetime()).Should().Throw<ObjectDisposedException>();
+            Should.Throw<ObjectDisposedException>(() => scope.CreateLifetime());
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace BitFaster.Caching.UnitTests
             var scope = new Scoped<Disposable>(disposable);
             scope.Dispose();
 
-            scope.TryCreateLifetime(out var l).Should().BeFalse();
+            scope.TryCreateLifetime(out var l).ShouldBeFalse();
         }
 
         [Fact]
@@ -77,14 +77,14 @@ namespace BitFaster.Caching.UnitTests
 
             using (var lifetime = lru.GetOrAdd(1, valueFactory.Create).CreateLifetime())
             {
-                lifetime.Value.IsDisposed.Should().BeFalse();
+                lifetime.Value.IsDisposed.ShouldBeFalse();
             }
 
-            valueFactory.Disposable.IsDisposed.Should().BeFalse();
+            valueFactory.Disposable.IsDisposed.ShouldBeFalse();
 
             lru.TryRemove(1);
 
-            valueFactory.Disposable.IsDisposed.Should().BeTrue();
+            valueFactory.Disposable.IsDisposed.ShouldBeTrue();
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/SingletonCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/SingletonCacheTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -16,7 +16,7 @@ namespace BitFaster.Caching.UnitTests
 
             var lifetime1 = cache.Acquire("foo");
             var lifetime2 = cache.Acquire("FOO");
-            lifetime1.Value.Should().BeSameAs(lifetime2.Value);
+            lifetime1.Value.ShouldBeSameAs(lifetime2.Value);
             lifetime1.Dispose();
             lifetime2.Dispose();
         }
@@ -28,7 +28,7 @@ namespace BitFaster.Caching.UnitTests
 
             var lifetime1 = cache.Acquire("Foo");
             var lifetime2 = cache.Acquire("Foo");
-            lifetime1.Value.Should().BeSameAs(lifetime2.Value);
+            lifetime1.Value.ShouldBeSameAs(lifetime2.Value);
             lifetime1.Dispose();
             lifetime2.Dispose();
         }
@@ -42,19 +42,19 @@ namespace BitFaster.Caching.UnitTests
             {
                 using (var lifetime2 = cache.Acquire("Foo"))
                 {
-                    lifetime1.ReferenceCount.Should().Be(1);
-                    lifetime2.ReferenceCount.Should().Be(2);
+                    lifetime1.ReferenceCount.ShouldBe(1);
+                    lifetime2.ReferenceCount.ShouldBe(2);
                 }
 
                 using (var lifetime3 = cache.Acquire("Foo"))
                 {
-                    lifetime3.ReferenceCount.Should().Be(2);
+                    lifetime3.ReferenceCount.ShouldBe(2);
                 }
             }
 
             using (var lifetime4 = cache.Acquire("Foo"))
             {
-                lifetime4.ReferenceCount.Should().Be(1);
+                lifetime4.ReferenceCount.ShouldBe(1);
             }
         }
 
@@ -69,7 +69,7 @@ namespace BitFaster.Caching.UnitTests
             var lifetime2 = cache.Acquire("Foo");
             lifetime2.Dispose();
 
-            lifetime1.Value.Should().NotBeSameAs(lifetime2.Value);
+            lifetime1.Value.ShouldNotBeSameAs(lifetime2.Value);
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace BitFaster.Caching.UnitTests
 
             await Task.WhenAll(task1, task2);
 
-            lifetime1.Value.Should().BeSameAs(lifetime2.Value);
+            lifetime1.Value.ShouldBeSameAs(lifetime2.Value);
         }
 
         [Fact]
@@ -130,7 +130,7 @@ namespace BitFaster.Caching.UnitTests
                             lock (lifetime.Value)
                             {
                                 int result = Interlocked.Increment(ref count);
-                                result.Should().Be(1);
+                                result.ShouldBe(1);
                                 Interlocked.Decrement(ref count);
                             }
                         }
@@ -151,10 +151,10 @@ namespace BitFaster.Caching.UnitTests
             using (var lifetime = cache.Acquire("Foo"))
             {
                 value = lifetime.Value;
-                value.IsDisposed.Should().BeFalse();
+                value.IsDisposed.ShouldBeFalse();
             }
 
-            value.IsDisposed.Should().BeTrue();
+            value.IsDisposed.ShouldBeTrue();
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Threaded.cs
+++ b/BitFaster.Caching.UnitTests/Threaded.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/BitFaster.Caching.UnitTests/Timed.cs
+++ b/BitFaster.Caching.UnitTests/Timed.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading;
-using FluentAssertions;
+using Shouldly;
 
 namespace BitFaster.Caching.UnitTests
 {
@@ -70,7 +70,7 @@ namespace BitFaster.Caching.UnitTests
                 }
 
                 Thread.Sleep(200);
-                attempts++.Should().BeLessThan(128, "Unable to run test within verification margin");
+                attempts++.ShouldBeLessThan(128, "Unable to run test within verification margin");
             }
         }
     }

--- a/BitFaster.Caching.UnitTests/TypePropsTests.cs
+++ b/BitFaster.Caching.UnitTests/TypePropsTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Reflection;
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace BitFaster.Caching.UnitTests
@@ -20,7 +20,7 @@ namespace BitFaster.Caching.UnitTests
         { 
             var isWriteAtomic = method.MakeGenericMethod(argType);
 
-            isWriteAtomic.Invoke(null, null).Should().BeOfType<bool>().Which.Should().Be(expected);
+            isWriteAtomic.Invoke(null, null).ShouldBeOfType<bool>().ShouldBe(expected);
         }
 
         private static bool IsWriteAtomic<T>()


### PR DESCRIPTION
As stated in #661, FluentAssertions v8 changed their [license](https://github.com/fluentassertions/fluentassertions/blob/main/LICENSE) from open source (Apache 2.0) to paid costing [$130 per seat](https://xceed.com/products/unit-testing/fluent-assertions) for commercial use.

This pull request migrates the tests in BitFaster.Caching to [Shouldly](https://github.com/shouldly/shouldly), a similar library under the BSD-3-clause license.

Alternatively, you can continue using FluentAssertions without updates, but you must pin it at `[7.0.0]` or `[7.1.0]` to prevent accidental updates.

There was a huge amount to change here so I used this PowerShell script to help me out: [galadril/Shouldly.FromFluentAssertions](https://github.com/galadril/Shouldly.FromFluentAssertions)