### PR TITLE
Use Timeout.InfiniteTimeSpan

### DIFF
--- a/BitFaster.Caching/Lru/Defaults.cs
+++ b/BitFaster.Caching/Lru/Defaults.cs
@@ -6,11 +6,6 @@ namespace BitFaster.Caching.Lru
 {
     internal static class Defaults
     {
-        public static int ConcurrencyLevel
-        {
-            get { return Environment.ProcessorCount; }
-        }
-
-        public static readonly TimeSpan Infinite = new(0, 0, 0, 0, -1);
+        public static int ConcurrencyLevel => Environment.ProcessorCount;
     }
 }

--- a/BitFaster.Caching/Lru/LruPolicy.cs
+++ b/BitFaster.Caching/Lru/LruPolicy.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace BitFaster.Caching.Lru
 {
@@ -10,7 +11,7 @@ namespace BitFaster.Caching.Lru
         where K : notnull
     {
         ///<inheritdoc/>
-        public TimeSpan TimeToLive => Defaults.Infinite;
+        public TimeSpan TimeToLive => Timeout.InfiniteTimeSpan;
 
         ///<inheritdoc/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This is just a readability thing. Use `Timeout.InfiniteTimeSpan` not `new TimeSpan(0, 0, 0, 0, -1)`.