### PR TITLE
Add test case for concurrent callers throwing in AsyncAtomicFactory.GetValueAsync

### DIFF
--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryAsyncCacheTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryAsyncCacheTests.cs
@@ -92,7 +92,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         }
 
         // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenUpdatedEventHandlerIsRegisteredItIsFired()
         {
@@ -259,7 +259,7 @@ namespace BitFaster.Caching.UnitTests.Atomic
         }
 
        // backcompat: remove conditional compile
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         [Fact]
         public void WhenRemovedValueIsReturned()
         {

--- a/BitFaster.Caching.UnitTests/Atomic/ScopedAsyncAtomicFactoryTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/ScopedAsyncAtomicFactoryTests.cs
@@ -156,6 +156,49 @@ namespace BitFaster.Caching.UnitTests.Atomic
             winnerCount.Should().Be(1);
         }
 
+
+        [Fact]
+        public async Task WhenCallersRunConcurrentlyWithFailureSameExceptionIsPropagated()
+        {
+            var enter = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var resume = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var atomicFactory = new ScopedAsyncAtomicFactory<int, IntHolder>();
+
+            var first = atomicFactory.TryCreateLifetimeAsync(1, async k =>
+            {
+                enter.SetResult(true);
+                await resume.Task;
+
+                throw new ArithmeticException("1");
+            }).AsTask(); ;
+
+            var second = atomicFactory.TryCreateLifetimeAsync(1, async k =>
+            {
+                enter.SetResult(true);
+                await resume.Task;
+
+                throw new InvalidOperationException("2");
+            }).AsTask();
+
+            await enter.Task;
+            resume.SetResult(true);
+
+            // Both tasks will throw, but the first one to complete will propagate its exception
+            // Both exceptions should be the same. If they are not, there will be an aggregate exception.
+            try
+            {
+                await Task.WhenAll(first, second)
+                    .TimeoutAfter(TimeSpan.FromSeconds(5), "Tasks did not complete within the expected time. Exceptions are not propagated between callers correctly.");
+            }
+            catch (ArithmeticException)
+            {
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
         [Fact]
         public async Task WhenDisposedWhileInitResultIsDisposed()
         {


### PR DESCRIPTION
When called concurrently, AsyncAtomicFactory.GetValueAsync will enforce that one thread is calling the factory method. 

Let's say 
- There are two threads, A and B, that both call GetValueAsync. 
- Thread A starts first
- Thread B starts while thread A is running
- Thread A throws an exception
- Thread B should see the exception from Thread A

In other words, a second caller to GetValueAsync that overlaps the first should effectively queue on the same underlying task, and if the first throws, the second task should see that exception. This PR adds a test case to verify this.

By queuing on the same task like this, we mitigate [lock convoys](https://en.wikipedia.org/wiki/Lock_convoy) as discussed in https://github.com/bitfaster/BitFaster.Caching/pull/477.