### PR TITLE
Use System.Threading.Lock in ConcurrentLfu

### DIFF
--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!-- https://stackoverflow.com/a/59916801/131345 -->
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 

--- a/BitFaster.Caching/BitFaster.Caching.csproj
+++ b/BitFaster.Caching/BitFaster.Caching.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0;net9.0</TargetFrameworks>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>13.0</LangVersion>
     <Authors>Alex Peck</Authors>
     <Company />
     <Product>BitFaster.Caching</Product>
@@ -30,7 +30,7 @@
     <Nullable>enable</Nullable>
     <!--Package Validation-->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>2.5.3</PackageValidationBaselineVersion>    
+    <PackageValidationBaselineVersion>2.5.4</PackageValidationBaselineVersion>    
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">


### PR DESCRIPTION
Take the `ConcurrentLfu` lock optimization from https://github.com/bitfaster/BitFaster.Caching/pull/638.

Benchmark shows lock try enter is slightly faster:

| Method     | Mean     | Error    | StdDev   | Ratio | Allocated |
|----------- |---------:|---------:|---------:|------:|----------:|
| UseMonitor | 17.88 ns | 0.235 ns | 0.220 ns |  1.00 |         - |
| UseLock    | 14.79 ns | 0.315 ns | 0.309 ns |  0.83 |         - |