### PR TITLE
fix build re-run

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       checks: write
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         include:
           # Windows
@@ -135,7 +135,6 @@ jobs:
     name: Coveralls Finished
     needs: build
     runs-on: ubuntu-latest
-    if: ${{ success() }} # Only run if all build jobs succeed
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
If any job in the build matrix fails due to an instability, it is not possible to re-run the individual job or the entire matrix.

![image](https://github.com/user-attachments/assets/9a79e2c1-e3b8-482a-b464-a17a84d80e5c)

Instead of `continue-on-error = true`, use  `fail-fast = false`:
https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast


