### PR TITLE
Implement Lfu events: attempt 2

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/TimerWheelTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/TimerWheelTests.cs
@@ -21,7 +21,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private readonly WheelEnumerator<int, IDisposable> wheelEnumerator;
         private readonly LfuNodeList<int, IDisposable> lfuNodeList;
         private readonly ExpireAfterPolicy<int, IDisposable> policy;
-        private ConcurrentLfuCore<int, IDisposable, TimeOrderNode<int, IDisposable>, ExpireAfterPolicy<int, IDisposable>> cache;
+        private ConcurrentLfuCore<int, IDisposable, TimeOrderNode<int, IDisposable>, ExpireAfterPolicy<int, IDisposable>, NoTelemetryPolicy<int, IDisposable>> cache;
 
         public TimerWheelTests(ITestOutputHelper testOutputHelper)
         {
@@ -31,7 +31,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             wheelEnumerator = new(timerWheel, testOutputHelper);
             policy = new ExpireAfterPolicy<int, IDisposable>(new TestExpiryCalculator<int, IDisposable>());
             cache = new(
-                Defaults.ConcurrencyLevel, 3, new ThreadPoolScheduler(), EqualityComparer<int>.Default, () => { }, policy);
+                Defaults.ConcurrencyLevel, 3, new ThreadPoolScheduler(), EqualityComparer<int>.Default, () => { }, policy, default);
         }
 
         [Theory]

--- a/BitFaster.Caching/Lfu/NodePolicy.cs
+++ b/BitFaster.Caching/Lfu/NodePolicy.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using BitFaster.Caching.Lru;
 
 namespace BitFaster.Caching.Lfu
 {
@@ -15,7 +16,7 @@ namespace BitFaster.Caching.Lfu
         void AfterRead(N node);
         void AfterWrite(N node);
         void OnEvict(N node);
-        void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, N, P> cache) where P : struct, INodePolicy<K, V, N>;
+        void ExpireEntries<P, T>(ref ConcurrentLfuCore<K, V, N, P, T> cache) where P : struct, INodePolicy<K, V, N> where T : struct, ITelemetryPolicy<K, V>;
     }
 
     internal struct AccessOrderPolicy<K, V> : INodePolicy<K, V, AccessOrderNode<K, V>>
@@ -59,7 +60,7 @@ namespace BitFaster.Caching.Lfu
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, P> cache) where P : struct, INodePolicy<K, V, AccessOrderNode<K, V>>
+        public void ExpireEntries<P, T>(ref ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, P, T> cache) where P : struct, INodePolicy<K, V, AccessOrderNode<K, V>> where T : struct, ITelemetryPolicy<K, V>
         {
         }
     }
@@ -137,7 +138,7 @@ namespace BitFaster.Caching.Lfu
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, TimeOrderNode<K, V>, P> cache) where P : struct, INodePolicy<K, V, TimeOrderNode<K, V>>
+        public void ExpireEntries<P, T>(ref ConcurrentLfuCore<K, V, TimeOrderNode<K, V>, P, T> cache) where P : struct, INodePolicy<K, V, TimeOrderNode<K, V>> where T : struct, ITelemetryPolicy<K, V>
         {
             wheel.Advance(ref cache, Duration.SinceEpoch());
         }

--- a/BitFaster.Caching/Lfu/TimerWheel.cs
+++ b/BitFaster.Caching/Lfu/TimerWheel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using BitFaster.Caching.Lru;
 
 namespace BitFaster.Caching.Lfu
 {
@@ -61,9 +62,10 @@ namespace BitFaster.Caching.Lfu
         /// </summary>
         /// <param name="cache"></param>
         /// <param name="currentTime"></param>
-        public void Advance<N, P>(ref ConcurrentLfuCore<K, V, N, P> cache, Duration currentTime)
+        public void Advance<N, P, T>(ref ConcurrentLfuCore<K, V, N, P, T> cache, Duration currentTime)
             where N : LfuNode<K, V>
             where P : struct, INodePolicy<K, V, N>
+            where T : struct, ITelemetryPolicy<K, V>
         {
             long previousTime = time;
             time = currentTime.raw;
@@ -101,9 +103,10 @@ namespace BitFaster.Caching.Lfu
         }
 
         // Expires entries or reschedules into the proper bucket if still active.
-        private void Expire<N, P>(ref ConcurrentLfuCore<K, V, N, P> cache, int index, long previousTicks, long delta)
+        private void Expire<N, P, T>(ref ConcurrentLfuCore<K, V, N, P, T> cache, int index, long previousTicks, long delta)
             where N : LfuNode<K, V>
             where P : struct, INodePolicy<K, V, N>
+            where T : struct, ITelemetryPolicy<K, V>
         {
             TimeOrderNode<K, V>[] timerWheel = wheels[index];
             int mask = timerWheel.Length - 1;


### PR DESCRIPTION
Prompt:

_Implement the ItemRemoved and ItemUpdated events for ConcurrentLfu. Do not modify the LFU builder classes yet._

This breaks the existing hit count logic.