### PR TITLE
Add skills to compare assembly code

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "Bash(dotnet build:*)",
       "Bash(ls:*)",
       "Bash(find:*)",
-      "Bash(dotnet format:*)"
+      "Bash(dotnet format:*)",
+      "Bash(dotnet run:*)"
     ]
   }
 }

--- a/.claude/skills/bench-fast/skill.md
+++ b/.claude/skills/bench-fast/skill.md
@@ -5,29 +5,29 @@ Run a benchmark quickly with minimal iterations to generate assembly code via Di
 ## Usage
 
 ```
-/bench-fast <BenchmarkName> [<Framework>]
+/bench-fast <BenchmarkName> [<Runtimes>]
 ```
 
 ## Arguments
 
-- `$ARGUMENTS` - The name of the benchmark class to run (e.g., `LruJustGetOrAdd`, `LfuJustGetOrAdd`, `SketchIncrement`), optionally followed by a target framework (e.g., `net9.0`, `net8.0`, `net6.0`)
+- `$ARGUMENTS` - The name of the benchmark class to run (e.g., `LruJustGetOrAdd`, `LfuJustGetOrAdd`, `SketchIncrement`), optionally followed by a list of one or more runtimes (e.g., `net48`, `net9.0` or `net48 net9.0`)
 
 ## Instructions
 
-Run the specified benchmark from BitFaster.Caching.Benchmarks with minimal iterations using BenchmarkDotNet's dry job mode.
+Run the specified benchmark from BitFaster.Caching.Benchmarks with minimal iterations using BenchmarkDotNet's command line.
 
-Parse the arguments: the first argument is the benchmark name, and the optional second argument is the target framework.
+Parse the arguments: the first argument is the benchmark name, and the optional second argument is the list of runtimes.
 
-If a framework is specified, execute:
+If a runtime arg is specified, execute:
 
 ```bash
-dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework <Framework> --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 -- --runtimes <Runtimes> --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
 ```
 
-If no framework is specified, default to `net9.0`:
+If no runtime is specified, simply omit that command line arg:
 
 ```bash
-dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 -- --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
 ```
 
 The `--warmupCount 3 --iterationCount 5` options reduce warmup and iteration counts for faster execution while still executing the code enough times to JIT optimized code.

--- a/.claude/skills/bench-fast/skill.md
+++ b/.claude/skills/bench-fast/skill.md
@@ -1,0 +1,33 @@
+# bench-fast
+
+Run a benchmark quickly with minimal iterations to generate assembly code via DisassemblyDiagnoser.
+
+## Usage
+
+```
+/bench-fast <BenchmarkName> [<Framework>]
+```
+
+## Arguments
+
+- `$ARGUMENTS` - The name of the benchmark class to run (e.g., `LruJustGetOrAdd`, `LfuJustGetOrAdd`, `SketchIncrement`), optionally followed by a target framework (e.g., `net9.0`, `net8.0`, `net6.0`)
+
+## Instructions
+
+Run the specified benchmark from BitFaster.Caching.Benchmarks with minimal iterations using BenchmarkDotNet's dry job mode.
+
+Parse the arguments: the first argument is the benchmark name, and the optional second argument is the target framework.
+
+If a framework is specified, execute:
+
+```bash
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework <Framework> -- --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+```
+
+If no framework is specified, default to `net9.0`:
+
+```bash
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 -- --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+```
+
+The `--warmupCount 3 --iterationCount 5` options reduce warmup and iteration counts for faster execution while still executing the code enough times to JIT optimized code.

--- a/.claude/skills/bench-fast/skill.md
+++ b/.claude/skills/bench-fast/skill.md
@@ -1,6 +1,7 @@
-# bench-fast
-
-Run a benchmark quickly with minimal iterations to generate assembly code via DisassemblyDiagnoser.
+---
+name: bench-fast
+description: Run a benchmark with minimal iterations to generate assembly code via BenchmarkDotNet's DisassemblyDiagnoser. Use to generate one big assembly code file per benchmark. 
+---
 
 ## Usage
 

--- a/.claude/skills/bench-fast/skill.md
+++ b/.claude/skills/bench-fast/skill.md
@@ -21,13 +21,13 @@ Parse the arguments: the first argument is the benchmark name, and the optional 
 If a framework is specified, execute:
 
 ```bash
-dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework <Framework> -- --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework <Framework> --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
 ```
 
 If no framework is specified, default to `net9.0`:
 
 ```bash
-dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 -- --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
 ```
 
 The `--warmupCount 3 --iterationCount 5` options reduce warmup and iteration counts for faster execution while still executing the code enough times to JIT optimized code.

--- a/.claude/skills/dump-asm/skill.md
+++ b/.claude/skills/dump-asm/skill.md
@@ -1,0 +1,89 @@
+# dump-asm
+
+Generate assembly code for a benchmark and organize output into a baseline directory named after the current git branch.
+
+## Usage
+
+```
+/dump-asm <BenchmarkName> [<Framework>]
+```
+
+## Arguments
+
+- `$ARGUMENTS` - The name of the benchmark class to run (e.g., `LruJustGetOrAdd`, `LfuJustGetOrAdd`, `SketchIncrement`), optionally followed by a target framework (e.g., `net9.0`, `net8.0`, `net6.0`)
+
+## Instructions
+
+This skill orchestrates benchmark assembly generation and organizes the output for comparison.
+
+Parse the arguments: the first argument is the benchmark name, and the optional second argument is the target framework.
+
+### Step 1: Clean artifacts
+
+Delete the BenchmarkDotNet.Artifacts directory to ensure a clean run:
+
+```bash
+rm -rf BenchmarkDotNet.Artifacts
+```
+
+### Step 2: Run benchmark
+
+Run the bench-fast skill with the provided benchmark name and optional framework to generate assembly code.
+
+If a framework is specified, execute:
+
+```bash
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework <Framework> --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+```
+
+If no framework is specified, default to `net9.0`:
+
+```bash
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+```
+
+### Step 3: Split assembly files
+
+Run the split-asm skill to generate individual assembly code files:
+
+```bash
+dotnet run --project C:/repo/splitasm/splitasm -- BenchmarkDotNet.Artifacts/results
+```
+
+### Step 4: Organize into baseline directory
+
+Get the current git branch name and convert it to a valid directory name by replacing forward slashes with dashes:
+
+```bash
+git rev-parse --abbrev-ref HEAD | tr '/' '-'
+```
+
+For example, `users/alexpeck/foo` becomes `users-alexpeck-foo`.
+
+Create the baseline directory structure preserving the benchmark name and runtime hierarchy. For each benchmark and runtime combination found in `BenchmarkDotNet.Artifacts/results/`:
+
+1. Extract the short benchmark name from the full benchmark path (e.g., `BitFaster.Caching.Benchmarks.LruJustGetOrAdd` → `LruJustGetOrAdd`)
+2. Create the directory `baseline/<sanitized-branch-name>/<benchmarkname>/<runtime>/`
+3. Copy all files from the corresponding `BenchmarkDotNet.Artifacts/results/<full-benchmark-name>/<runtime>/` directory
+
+The final structure should be:
+```
+baseline/
+  <sanitized-branch-name>/
+    <benchmarkname>/
+      <runtime>/
+        <MethodName>-asm.md
+        <MethodName>-summary.md
+        ...
+```
+
+For example:
+```
+baseline/
+  users-alexpeck-skills/
+    LruJustGetOrAdd/
+      .NET 6.0.36 (6.0.3624.51421), X64 RyuJIT AVX2/
+        FastConcurrentLru-asm.md
+        FastConcurrentLru-summary.md
+        ...
+```

--- a/.claude/skills/dump-asm/skill.md
+++ b/.claude/skills/dump-asm/skill.md
@@ -45,24 +45,27 @@ Invoke the `/split-asm` skill to generate individual assembly code files:
 
 ### Step 4: Organize into baseline directory
 
-Get the current git branch name and convert it to a valid directory name by replacing forward slashes with dashes:
+Get the current git branch name and convert it to a valid directory name by replacing forward slashes with dashes, then append the short commit hash:
 
 ```bash
 git rev-parse --abbrev-ref HEAD | tr '/' '-'
+git rev-parse --short HEAD
 ```
 
-For example, `users/alexpeck/foo` becomes `users-alexpeck-foo`.
+Combine these to form the directory name: `<sanitized-branch-name>-<commit-hash>`.
+
+For example, branch `users/alexpeck/foo` at commit `abc1234` becomes `users-alexpeck-foo-abc1234`.
 
 Create the baseline directory structure preserving the benchmark name and runtime hierarchy. For each benchmark and runtime combination found in `BenchmarkDotNet.Artifacts/results/`:
 
 1. Extract the short benchmark name from the full benchmark path (e.g., `BitFaster.Caching.Benchmarks.LruJustGetOrAdd` → `LruJustGetOrAdd`)
-2. Create the directory `baseline/<sanitized-branch-name>/<benchmarkname>/<runtime>/`
+2. Create the directory `baseline/<sanitized-branch-name>-<commit-hash>/<benchmarkname>/<runtime>/`
 3. Copy all files from the corresponding `BenchmarkDotNet.Artifacts/results/<full-benchmark-name>/<runtime>/` directory
 
 The final structure should be:
 ```
 baseline/
-  <sanitized-branch-name>/
+  <sanitized-branch-name>-<commit-hash>/
     <benchmarkname>/
       <runtime>/
         <MethodName>-asm.md
@@ -73,7 +76,7 @@ baseline/
 For example:
 ```
 baseline/
-  users-alexpeck-skills/
+  users-alexpeck-skills-16c32c5/
     LruJustGetOrAdd/
       .NET 6.0.36 (6.0.3624.51421), X64 RyuJIT AVX2/
         FastConcurrentLru-asm.md

--- a/.claude/skills/dump-asm/skill.md
+++ b/.claude/skills/dump-asm/skill.md
@@ -1,22 +1,23 @@
-# dump-asm
-
-Generate assembly code for a benchmark and organize output into a baseline directory named after the current git branch.
+---
+name: dump-asm
+description: Generate assembly for code exercised by a benchmark and organize output into a baseline directory named after the current git branch. Use to generate assembly code that can be diff'd between branches.
+---
 
 ## Usage
 
 ```
-/dump-asm <BenchmarkName> [<Framework>]
+/dump-asm <BenchmarkName> [<Runtimes>]
 ```
 
 ## Arguments
 
-- `$ARGUMENTS` - The name of the benchmark class to run (e.g., `LruJustGetOrAdd`, `LfuJustGetOrAdd`, `SketchIncrement`), optionally followed by a target framework (e.g., `net9.0`, `net8.0`, `net6.0`)
+- `$ARGUMENTS` - The name of the benchmark class to run (e.g., `LruJustGetOrAdd`, `LfuJustGetOrAdd`, `SketchIncrement`), optionally followed by a list of one or more runtimes (e.g., `net48`, `net9.0` or `net48 net9.0`)
 
 ## Instructions
 
 This skill orchestrates benchmark assembly generation and organizes the output for comparison.
 
-Parse the arguments: the first argument is the benchmark name, and the optional second argument is the target framework.
+Parse the arguments: the first argument is the benchmark name, and the optional second argument is the list of runtimes.
 
 ### Step 1: Clean artifacts
 
@@ -28,26 +29,18 @@ rm -rf BenchmarkDotNet.Artifacts
 
 ### Step 2: Run benchmark
 
-Run the bench-fast skill with the provided benchmark name and optional framework to generate assembly code.
+Invoke the `/bench-fast` skill with the provided benchmark name and optional runtime to generate assembly code:
 
-If a framework is specified, execute:
-
-```bash
-dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework <Framework> --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
 ```
-
-If no framework is specified, default to `net9.0`:
-
-```bash
-dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 --filter "<BenchmarkName>" -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5
+/bench-fast <BenchmarkName> [<Runtimes>]
 ```
 
 ### Step 3: Split assembly files
 
-Run the split-asm skill to generate individual assembly code files:
+Invoke the `/split-asm` skill to generate individual assembly code files:
 
-```bash
-dotnet run --project C:/repo/splitasm/splitasm -- BenchmarkDotNet.Artifacts/results
+```
+/split-asm
 ```
 
 ### Step 4: Organize into baseline directory

--- a/.claude/skills/split-asm/skill.md
+++ b/.claude/skills/split-asm/skill.md
@@ -1,0 +1,45 @@
+# split-asm
+
+Split BenchmarkDotNet assembly markdown files into individual files per benchmark method using splitasm.
+
+## Usage
+
+```
+/split-asm [<ResultsPath>]
+```
+
+## Arguments
+
+- `$ARGUMENTS` - Optional path to the BenchmarkDotNet results directory. Defaults to `BenchmarkDotNet.Artifacts/results` in the current repository.
+
+## Instructions
+
+Run splitasm to break down BenchmarkDotNet assembly markdown files into a single file per benchmark method. This enables using file diffs to compare how code changes affect disassembler output.
+
+Parse the arguments: the optional first argument is the path to the results directory.
+
+If a path is specified, execute:
+
+```bash
+dotnet run --project C:/repo/splitasm/splitasm -- <ResultsPath>
+```
+
+If no path is specified, default to the standard BenchmarkDotNet output location:
+
+```bash
+dotnet run --project C:/repo/splitasm/splitasm -- BenchmarkDotNet.Artifacts/results
+```
+
+The tool produces:
+1. Individual assembly files - one markdown file per benchmarked method containing its assembly code
+2. A summary file listing disassembled code size in bytes for each benchmarked method
+
+Output is organized hierarchically by target benchmark, then by target framework.
+
+## Prerequisites
+
+The splitasm repository should be cloned to C:/repo/splitasm. If not available, clone from https://github.com/bitfaster/splitasm:
+
+```bash
+cd C:/repo && git clone https://github.com/bitfaster/splitasm.git
+```

--- a/.claude/skills/split-asm/skill.md
+++ b/.claude/skills/split-asm/skill.md
@@ -1,6 +1,7 @@
-# split-asm
-
-Split BenchmarkDotNet assembly markdown files into individual files per benchmark method using splitasm.
+---
+name: split-asm
+description: Split BenchmarkDotNet assembly markdown files into individual files per benchmark method using splitasm. Use to break one big assembly code file per benchmark into one file per benchmark method. 
+---
 
 ## Usage
 

--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0;net8.0;net9.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!-- https://stackoverflow.com/a/59916801/131345 -->
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 

--- a/BitFaster.Caching.Benchmarks/DataStructureBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DataStructureBenchmarks.cs
@@ -7,10 +7,6 @@ using BenchmarkDotNet.Jobs;
 
 namespace BitFaster.Caching.Benchmarks
 {
-#if Windows
-    [SimpleJob(RuntimeMoniker.Net48)]
-#endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     public class DataStructureBenchmarks
     {

--- a/BitFaster.Caching.Benchmarks/DisposerBench.cs
+++ b/BitFaster.Caching.Benchmarks/DisposerBench.cs
@@ -9,9 +9,7 @@ namespace BitFaster.Caching.Benchmarks
     // https://github.com/dotnet/runtime/issues/4920
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DisposerBench

--- a/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/DrainBenchmarks.cs
@@ -8,9 +8,7 @@ namespace BitFaster.Caching.Benchmarks
 {
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class DrainBenchmarks
     {

--- a/BitFaster.Caching.Benchmarks/Lfu/LfuJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lfu/LfuJustGetOrAdd.cs
@@ -10,10 +10,6 @@ using BitFaster.Caching.Scheduler;
 
 namespace BitFaster.Caching.Benchmarks
 {
-#if Windows
-    [SimpleJob(RuntimeMoniker.Net48)]
-#endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     //[DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
     [MemoryDiagnoser(displayGenColumns: false)]
     // [HardwareCounters(HardwareCounter.LlcMisses, HardwareCounter.CacheMisses)] // Requires Admin https://adamsitnik.com/Hardware-Counters-Diagnoser/

--- a/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruAsyncGet.cs
@@ -9,10 +9,6 @@ namespace BitFaster.Caching.Benchmarks.Lru
     /// <summary>
     /// Verify 0 allocs for GetOrAddAsync cache hits.
     /// </summary>
-#if Windows
-    [SimpleJob(RuntimeMoniker.Net48)]
-#endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     // [DisassemblyDiagnoser(printSource: true, maxDepth: 5)] // Unstable
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]

--- a/BitFaster.Caching.Benchmarks/Lru/LruCycleBench.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruCycleBench.cs
@@ -24,9 +24,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     //|         ClassicLru | 16.35 us | 0.091 us | 0.076 us |  0.72 |      4 KB | 3.2959 |     14 KB |
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruCycleBench

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAdd.cs
@@ -32,9 +32,7 @@ namespace BitFaster.Caching.Benchmarks
     //| ExtensionsMemoryCacheGet |  93.188 ns | 0.2321 ns | 0.2171 ns | 11.85 |    0.07 |      78 B | 0.0055 |      24 B |
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     // [HardwareCounters(HardwareCounter.LlcMisses, HardwareCounter.CacheMisses)] // Requires Admin https://adamsitnik.com/Hardware-Counters-Diagnoser/
     // [ThreadingDiagnoser] // Requires .NET Core

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAddGuid.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustGetOrAddGuid.cs
@@ -16,9 +16,7 @@ namespace BitFaster.Caching.Benchmarks
 
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     // [HardwareCounters(HardwareCounter.LlcMisses, HardwareCounter.CacheMisses)] // Requires Admin https://adamsitnik.com/Hardware-Counters-Diagnoser/
     // [ThreadingDiagnoser] // Requires .NET Core

--- a/BitFaster.Caching.Benchmarks/Lru/LruJustTryGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruJustTryGet.cs
@@ -21,9 +21,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     //|   FastConcurrentTLru | 25.350 ns | 0.3301 ns | 0.3088 ns |  5.66 |    0.08 |     546 B |         - |
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruJustTryGet

--- a/BitFaster.Caching.Benchmarks/Lru/LruMultiGet.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruMultiGet.cs
@@ -26,9 +26,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     //|          MemoryCache | 117.075 ns | 1.7664 ns | 1.5658 ns | 13.96 |    0.18 |      94 B | 0.0073 |      32 B |
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruMultiGet

--- a/BitFaster.Caching.Benchmarks/Lru/LruZipDistribution.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/LruZipDistribution.cs
@@ -23,9 +23,7 @@ namespace BitFaster.Caching.Benchmarks.Lru
     //|     ConcurrentTLru | 169.7 ns | 0.86 ns | 0.80 ns |  1.52 |    0.02 | 0.0098 |   5,982 B |      43 B |
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class LruZipDistribution

--- a/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/Lru/TLruTimeBenchmark.cs
@@ -9,10 +9,6 @@ namespace BitFaster.Caching.Benchmarks.Lru
     /// <summary>
     /// Compare different implementations of the TLRU policy. In particular, which clock impl is fastest?
     /// </summary>
-#if Windows
-    [SimpleJob(RuntimeMoniker.Net48)]
-#endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class TLruTimeBenchmark
     {

--- a/BitFaster.Caching.Benchmarks/Program.cs
+++ b/BitFaster.Caching.Benchmarks/Program.cs
@@ -1,4 +1,9 @@
-﻿using BenchmarkDotNet.Running;
+﻿using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
 
 namespace BitFaster.Caching.Benchmarks
 {
@@ -6,7 +11,35 @@ namespace BitFaster.Caching.Benchmarks
     {
         static void Main(string[] args)
         {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, GetGlobalConfig(args));
+        }
+
+        // This gives a default where we run both net48 and net9.0 unless overridden on the command line.
+        static IConfig GetGlobalConfig(string[] args)
+        {
+            //if args contains either --runtimes or --r, return default config  
+            foreach (var a in args)
+            {
+                if (a == "--runtimes" || a == "--r")
+                {
+                    return DefaultConfig.Instance;
+                }
+            }
+
+            // else default to both net48 and net9.0
+            return DefaultConfig.Instance
+#if Windows
+                .AddJob(
+                    Job.Default
+                        .WithRuntime(ClrRuntime.Net48)
+                        .WithId("net48"))
+#endif
+                .AddJob(
+                    Job.Default
+                        .WithRuntime(CoreRuntime.Core90)
+                        .WithId("net9.0")
+                        .AsDefault());
+
         }
     }
 }

--- a/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/TimeBenchmarks.cs
@@ -8,10 +8,7 @@ namespace BitFaster.Caching.Benchmarks
 {
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
-    [SimpleJob(RuntimeMoniker.Net90)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class TimeBenchmarks
     {

--- a/BitFaster.Caching.Benchmarks/ValueFactoryBenchmarks.cs
+++ b/BitFaster.Caching.Benchmarks/ValueFactoryBenchmarks.cs
@@ -7,9 +7,7 @@ namespace BitFaster.Caching.Benchmarks
 {
 #if Windows
     [DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
-    [SimpleJob(RuntimeMoniker.Net48)]
 #endif
-    [SimpleJob(RuntimeMoniker.Net60)]
     [MemoryDiagnoser(displayGenColumns: false)]
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
     public class ValueFactoryBenchmarks


### PR DESCRIPTION
Add a dump-asm skill to make it easy to generate baselines for branches and compare the assembly code. This PR adds 3 skills to enable this:

- fast-bench: runs specified benchmark to generate asm files
- split-asm: generate an asm.md file per benchmark method
- dump-asm: generate asm.md files for benchmarks, and store them as baseline data in a directory based on the branch name

The benchmark jobs have been refactored to enable:
- Running via shift+F5 and benchmark switcher, which runs .net48 and .net9.0
- Running at command line with no runtime specified, runs .net48 and .net9.0
- Running at command line with runtime specified, uses specified runtime (tested .net48, .net9.0, and .net48+.net9)

Example command line:

`dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 -- --runtimes net48 net9.0 --filter *LruJustGetOrAdd* -j short --warmupCount 3 --iterationCount 5 -d --disasmDepth 5`

Previously, it was not possible to run at the command line, and specify the runtime AND warmup/iteration count. Runtime would cause the whole bench suite to run, extending runtime from ~2 minutes to ~30 minutes.