### PR TITLE
BackgroundScheduler stability

### DIFF
--- a/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
@@ -88,7 +88,30 @@ namespace BitFaster.Caching.UnitTests.Scheduler
 
         [Theory]
         [Repeat(10)]
-        public async Task WhenDisposedRunsToCompletion(int iteration)
+        public async Task WhenDisposedRunsToCompletion(int _)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            scheduler.Run(() => { tcs.SetResult(true); });
+            await tcs.Task;
+
+            this.scheduler.Dispose();
+
+            var completion = scheduler.Completion;
+
+            if (await Task.WhenAny(completion, Task.Delay(TimeSpan.FromSeconds(60))) != completion)
+            {
+                if (this.scheduler.LastException.HasValue)
+                {
+                    output.WriteLine(this.scheduler.LastException.ToString());
+                }
+
+                throw new Exception("Failed to stop");
+            }
+        }
+
+        [Theory]
+        [Repeat(10)]
+        public async Task WhenDisposedImmediatelyRunsToCompletion(int _)
         {
             this.scheduler.Dispose();
 
@@ -100,6 +123,7 @@ namespace BitFaster.Caching.UnitTests.Scheduler
                 { 
                     output.WriteLine(this.scheduler.LastException.ToString()); 
                 }
+
                 throw new Exception("Failed to stop");
             }
         }

--- a/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
@@ -93,6 +93,20 @@ namespace BitFaster.Caching.UnitTests.Scheduler
             }
         }
 
+        [Fact]
+        public async Task WhenDoubleDisposedRunsToCompletion()
+        {
+            this.scheduler.Dispose();
+            this.scheduler.Dispose();
+
+            var completion = scheduler.Completion;
+
+            if (await Task.WhenAny(completion, Task.Delay(TimeSpan.FromSeconds(60))) != completion)
+            {
+                throw new Exception("Failed to stop");
+            }
+        }
+
         public void Dispose()
         {
             this?.scheduler.Dispose();

--- a/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
+++ b/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs
@@ -4,12 +4,18 @@ using System.Threading.Tasks;
 using BitFaster.Caching.Scheduler;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace BitFaster.Caching.UnitTests.Scheduler
 {
     public class BackgroundSchedulerTests : IDisposable
     {
         private BackgroundThreadScheduler scheduler = new BackgroundThreadScheduler();
+        private readonly ITestOutputHelper output;
+        public BackgroundSchedulerTests(ITestOutputHelper testOutputHelper)
+        {
+            this.output = testOutputHelper;
+        }
 
         [Fact]
         public void IsBackground()
@@ -80,8 +86,9 @@ namespace BitFaster.Caching.UnitTests.Scheduler
             scheduler.RunCount.Should().BeCloseTo(BackgroundThreadScheduler.MaxBacklog, 1);
         }
 
-        [Fact]
-        public async Task WhenDisposedRunsToCompletion()
+        [Theory]
+        [Repeat(10)]
+        public async Task WhenDisposedRunsToCompletion(int iteration)
         {
             this.scheduler.Dispose();
 
@@ -89,6 +96,10 @@ namespace BitFaster.Caching.UnitTests.Scheduler
 
             if (await Task.WhenAny(completion, Task.Delay(TimeSpan.FromSeconds(60))) != completion)
             {
+                if (this.scheduler.LastException.HasValue)
+                { 
+                    output.WriteLine(this.scheduler.LastException.ToString()); 
+                }
                 throw new Exception("Failed to stop");
             }
         }

--- a/BitFaster.Caching/Scheduler/BackgroundThreadScheduler.cs
+++ b/BitFaster.Caching/Scheduler/BackgroundThreadScheduler.cs
@@ -64,7 +64,7 @@ namespace BitFaster.Caching.Scheduler
         {
             var spinner = new SpinWait();
 
-            while (true)
+            while (!cts.IsCancellationRequested)
             {
                 try
                 {
@@ -106,6 +106,11 @@ namespace BitFaster.Caching.Scheduler
         /// </summary>
         public void Dispose()
         {
+            if (cts.IsCancellationRequested)
+            { 
+                return; 
+            }
+
             // prevent hang when cancel runs on the same thread
             this.cts.CancelAfter(TimeSpan.Zero);
         }

--- a/BitFaster.Caching/Scheduler/BackgroundThreadScheduler.cs
+++ b/BitFaster.Caching/Scheduler/BackgroundThreadScheduler.cs
@@ -27,7 +27,7 @@ namespace BitFaster.Caching.Scheduler
         private readonly MpmcBoundedBuffer<Action> work = new(MaxBacklog);
 
         private Optional<Exception> lastException = Optional<Exception>.None();
-        readonly TaskCompletionSource<bool> completion = new();
+        private readonly Task completion;
 
         /// <summary>
         /// Initializes a new instance of the BackgroundThreadScheduler class.
@@ -35,11 +35,11 @@ namespace BitFaster.Caching.Scheduler
         public BackgroundThreadScheduler()
         {
             // dedicated thread
-            _ = Task.Factory.StartNew(async () => await Background().ConfigureAwait(false), cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            this.completion = Task.Factory.StartNew(async () => await Background().ConfigureAwait(false), cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
 
         ///<inheritdoc/>
-        public Task Completion => completion.Task;
+        public Task Completion => completion;
 
         ///<inheritdoc/>
         public bool IsBackground => true;
@@ -62,14 +62,13 @@ namespace BitFaster.Caching.Scheduler
 
         private async Task Background()
         {
-            var spinner = new SpinWait();
-
-            while (!cts.IsCancellationRequested)
+            while (true)
             {
                 try
                 {
                     await semaphore.WaitAsync(cts.Token).ConfigureAwait(false);
 
+                    var spinner = new SpinWait();
                     BufferStatus s;
                     do
                     {
@@ -79,12 +78,17 @@ namespace BitFaster.Caching.Scheduler
                         {
                             action!();
                         }
+                        else if (s == BufferStatus.Empty)
+                        {
+                            break;
+                        }
                         else
                         {
                             spinner.SpinOnce();
                         }
                     }
                     while (s == BufferStatus.Contended);
+
                 }
                 catch (OperationCanceledException)
                 {
@@ -94,11 +98,7 @@ namespace BitFaster.Caching.Scheduler
                 {
                     this.lastException = new Optional<Exception>(ex);
                 }
-
-                spinner.SpinOnce();
             }
-
-            completion.SetResult(true);
         }
 
         /// <summary>
@@ -106,11 +106,6 @@ namespace BitFaster.Caching.Scheduler
         /// </summary>
         public void Dispose()
         {
-            if (cts.IsCancellationRequested)
-            { 
-                return; 
-            }
-
             // prevent hang when cancel runs on the same thread
             this.cts.CancelAfter(TimeSpan.Zero);
         }

--- a/BitFaster.Caching/Scheduler/BackgroundThreadScheduler.cs
+++ b/BitFaster.Caching/Scheduler/BackgroundThreadScheduler.cs
@@ -78,10 +78,6 @@ namespace BitFaster.Caching.Scheduler
                         {
                             action!();
                         }
-                        else if (s == BufferStatus.Empty)
-                        {
-                            break;
-                        }
                         else
                         {
                             spinner.SpinOnce();


### PR DESCRIPTION
On ubuntu-latest test fails, from the log:

failure: System.Exception : Failed to stop
at [BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs](https://github.com/bitfaster/BitFaster.Caching/blob/783e72a52f53cd81d24006bcbfe55ae3028d39b6/BitFaster.Caching.UnitTests/Scheduler/BackgroundSchedulerTests.cs#L84-L93)

It appears that the test can fail when the scheduler is immediately disposed and cancellation source is cancelled before `Task.Factory.StartNew` is called. In this situation, completion is never set leading to a hang.