### PR TITLE
fix alternate lookup GetOrAdd for AtomicFactoryCache

### DIFF
--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheAlternateLookupTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryCacheAlternateLookupTests.cs
@@ -77,21 +77,19 @@ namespace BitFaster.Caching.UnitTests.Atomic
             var factoryCalls = 0;
             ReadOnlySpan<char> key = "42";
 
-            alternate.GetOrAdd(key, key =>
+            alternate.GetOrAdd(key, k =>
             {
                 factoryCalls++;
-                return $"value-{key}";
+                return $"value-{k}";
             }).Should().Be("value-42");
 
-            alternate.GetOrAdd(key, (_, prefix) =>
+            alternate.GetOrAdd(key, k =>
             {
                 factoryCalls++;
-                return prefix;
-            }, "unused").Should().Be("value-42");
+                return "1";
+            }).Should().Be("value-42");
 
             factoryCalls.Should().Be(1);
-            cache.TryGet("42", out var value).Should().BeTrue();
-            value.Should().Be("value-42");
         }
 
         [Fact]
@@ -114,8 +112,6 @@ namespace BitFaster.Caching.UnitTests.Atomic
             }, "unused").Should().Be("value-42");
 
             factoryCalls.Should().Be(1);
-            cache.TryGet("42", out var value).Should().BeTrue();
-            value.Should().Be("value-42");
         }
 
         [Fact]

--- a/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
+++ b/BitFaster.Caching/Atomic/AtomicFactoryCache.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace BitFaster.Caching.Atomic
 {
@@ -176,7 +177,8 @@ namespace BitFaster.Caching.Atomic
             where TAlternateKey : notnull, allows ref struct
         {
             var inner = cache.GetAlternateLookup<TAlternateKey>();
-            return new AlternateLookup<TAlternateKey>(inner);
+            var comparer = (IAlternateEqualityComparer<TAlternateKey, K>)cache.Comparer;
+            return new AlternateLookup<TAlternateKey>(inner, comparer);
         }
 
         ///<inheritdoc/>
@@ -185,7 +187,8 @@ namespace BitFaster.Caching.Atomic
         {
             if (cache.TryGetAlternateLookup<TAlternateKey>(out var inner))
             {
-                lookup = new AlternateLookup<TAlternateKey>(inner);
+                var comparer = (IAlternateEqualityComparer<TAlternateKey, K>)cache.Comparer;
+                lookup = new AlternateLookup<TAlternateKey>(inner, comparer);
                 return true;
             }
 
@@ -197,10 +200,12 @@ namespace BitFaster.Caching.Atomic
             where TAlternateKey : notnull, allows ref struct
         {
             private readonly IAlternateLookup<TAlternateKey, K, AtomicFactory<K, V>> inner;
+            private readonly IAlternateEqualityComparer<TAlternateKey, K> comparer;
 
-            internal AlternateLookup(IAlternateLookup<TAlternateKey, K, AtomicFactory<K, V>> inner)
+            internal AlternateLookup(IAlternateLookup<TAlternateKey, K, AtomicFactory<K, V>> inner, IAlternateEqualityComparer<TAlternateKey, K> comparer)
             {
                 this.inner = inner;
+                this.comparer = comparer;
             }
 
             public bool TryGet(TAlternateKey key, [MaybeNullWhen(false)] out V value)
@@ -239,18 +244,28 @@ namespace BitFaster.Caching.Atomic
 
             public V GetOrAdd(TAlternateKey key, Func<K, V> valueFactory)
             {
-                var atomicFactory = inner.GetOrAdd(key,
-                    static (k, factory) => new AtomicFactory<K, V>(factory(k)),
-                    valueFactory);
-                return atomicFactory.ValueIfCreated!;
+                var atomicFactory = inner.GetOrAdd(key, _ => new AtomicFactory<K, V>());
+
+                if (atomicFactory.IsValueCreated)
+                {
+                    return atomicFactory.ValueIfCreated!;
+                }
+
+                K actualKey = comparer.Create(key);
+                return atomicFactory.GetValue(actualKey, valueFactory);
             }
 
             public V GetOrAdd<TArg>(TAlternateKey key, Func<K, TArg, V> valueFactory, TArg factoryArgument)
             {
-                var atomicFactory = inner.GetOrAdd(key,
-                    static (k, args) => new AtomicFactory<K, V>(args.valueFactory(k, args.factoryArgument)),
-                    (valueFactory, factoryArgument));
-                return atomicFactory.ValueIfCreated!;
+                var atomicFactory = inner.GetOrAdd(key, _ => new AtomicFactory<K, V>());
+
+                if (atomicFactory.IsValueCreated)
+                {
+                    return atomicFactory.ValueIfCreated!;
+                }
+
+                K actualKey = comparer.Create(key);
+                return atomicFactory.GetValue(actualKey, valueFactory, factoryArgument);
             }
         }
 #endif


### PR DESCRIPTION
Comparer was not previously available, LLM generated code directly invoked the value factory delegate in the ctor - so this was not atomic, there could be concurrent invocations of value factory.