### PR TITLE
More LFU soak diagnostics

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -484,31 +484,38 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
         private async Task RunIntegrityCheckAsync(ConcurrentLfu<int, string> lfu, int iteration)
         {
-            this.output.WriteLine($"iteration {iteration} keys={string.Join(" ", lfu.Keys)}");
-#if DEBUG
-            this.output.WriteLine(lfu.FormatLfuString());
-#endif
+            Log(lfu, iteration, "before");
 
             if (lfu.Scheduler is BackgroundThreadScheduler scheduler)
             {
                 scheduler.Dispose();
                 await scheduler.Completion;
             }
+
+            Log(lfu, iteration, "after");
 
             RunIntegrityCheck(lfu, this.output);
         }
 
         private async Task RunIntegrityCheckAsync(ConcurrentLfu<string, string> lfu, int iteration)
         {
-            this.output.WriteLine($"iteration {iteration} keys={string.Join(" ", lfu.Keys)}");
-
+            Log(lfu, iteration, "before");
             if (lfu.Scheduler is BackgroundThreadScheduler scheduler)
             {
                 scheduler.Dispose();
                 await scheduler.Completion;
             }
+            Log(lfu, iteration, "after");
 
             RunIntegrityCheck(lfu, this.output);
+        }
+
+        private void Log<K>(ConcurrentLfu<K, string> lfu, int iteration, string stage)
+        {
+            this.output.WriteLine($"{stage} iteration {iteration} keys={string.Join(" ", lfu.Keys)}");
+#if DEBUG
+            this.output.WriteLine(lfu.FormatLfuString());
+#endif
         }
 
         private static void RunIntegrityCheck<K, V>(ConcurrentLfu<K, V> cache, ITestOutputHelper output)

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -531,6 +531,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private readonly ConcurrentLfuCore<K, V, N, P> cache;
 
         private readonly ConcurrentDictionary<K, N> dictionary;
+        private readonly object maintenanceLock;
 
         private readonly LfuNodeList<K, V> windowLru;
         private readonly LfuNodeList<K, V> probationLru;
@@ -540,6 +541,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private readonly MpscBoundedBuffer<N> writeBuffer;
 
         private static FieldInfo dictionaryField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("dictionary", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo lockField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("maintenanceLock", BindingFlags.NonPublic | BindingFlags.Instance);
 
         private static FieldInfo windowLruField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("windowLru", BindingFlags.NonPublic | BindingFlags.Instance);
         private static FieldInfo probationLruField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("probationLru", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -553,6 +555,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             this.cache = cache;
 
             this.dictionary = (ConcurrentDictionary<K, N>)dictionaryField.GetValue(cache);
+            this.maintenanceLock = lockField.GetValue(cache);
 
             // get lrus via reflection
             this.windowLru = (LfuNodeList<K, V>)windowLruField.GetValue(cache);
@@ -573,18 +576,26 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 cache.Scheduler.LastException.Should().BeNull("scheduler should not have thrown");
             }
 
-            // buffers should be empty after maintenance
-            this.readBuffer.Count.Should().Be(0);
-            this.writeBuffer.Count.Should().Be(0);
+            lock (this.maintenanceLock)
+            {
+#if DEBUG
+                output.WriteLine("LRUs under lock:");
+                output.WriteLine(cache.FormatLfuString());
+#endif
 
-            // all the items in the LRUs must exist in the dictionary.
-            // no items should be marked as removed after maintenance has run
-            VerifyLruInDictionary(this.windowLru, output);
-            VerifyLruInDictionary(this.probationLru, output);
-            VerifyLruInDictionary(this.protectedLru, output);
+                // buffers should be empty after maintenance
+                this.readBuffer.Count.Should().Be(0);
+                this.writeBuffer.Count.Should().Be(0);
 
-            // all the items in the dictionary must exist in the node list
-            VerifyDictionaryInLrus();
+                // all the items in the LRUs must exist in the dictionary.
+                // no items should be marked as removed after maintenance has run
+                VerifyLruInDictionary(this.windowLru, output);
+                VerifyLruInDictionary(this.probationLru, output);
+                VerifyLruInDictionary(this.protectedLru, output);
+
+                // all the items in the dictionary must exist in the node list
+                VerifyDictionaryInLrus();
+            }
 
             // cache must be within capacity
             cache.Count.Should().BeLessThanOrEqualTo(cache.Capacity, "capacity out of valid range");

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -632,12 +632,15 @@ namespace BitFaster.Caching.Lfu
             switch (node.Position)
             {
                 case Position.Window:
+                    Debug.Assert(node.list == this.windowLru);
                     this.windowLru.MoveToEnd(node);
                     break;
                 case Position.Probation:
+                    Debug.Assert(node.list == this.probationLru);
                     PromoteProbation(node);
                     break;
                 case Position.Protected:
+                    Debug.Assert(node.list == this.protectedLru);
                     this.protectedLru.MoveToEnd(node);
                     break;
             }
@@ -677,15 +680,18 @@ namespace BitFaster.Caching.Lfu
                     }
                     else
                     {
+                        Debug.Assert(node.list == this.windowLru);
                         this.windowLru.MoveToEnd(node);
                         this.metrics.updatedCount++;
                     }
                     break;
                 case Position.Probation:
+                    Debug.Assert(node.list == this.probationLru);
                     PromoteProbation(node);
                     this.metrics.updatedCount++;
                     break;
                 case Position.Protected:
+                    Debug.Assert(node.list == this.protectedLru);
                     this.protectedLru.MoveToEnd(node);
                     this.metrics.updatedCount++;
                     break;


### PR DESCRIPTION
Still not clear why this is failing, latest failure shows key exists in probation but logging is prior to maintenance run.

2026-04-15T00:23:59.1304247Z    Expected exists to be True because key **99968** in Probation removed: False deleted False must exist in LRU lists, but found False.

2026-04-15T00:23:59.4422211Z  iteration 1 keys=99966 **99968** 99969 99970 99972 99980 99981 99990 99996 99997 99998 99999 100000
2026-04-15T00:23:59.4422711Z  W [99996] Protected [] Probation [99966,**99968**,99969,99970,99972,99980,99981,99990]

