### PR TITLE
Inline GetAlternateLookup

### DIFF
--- a/BitFaster.Caching.Benchmarks/AltBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/AltBenchmark.cs
@@ -12,8 +12,11 @@ using BitFaster.Caching.Scheduler;
 
 namespace BitFaster.Caching.Benchmarks
 {
+    // The get alternate lookup family of methods return an interface, while under the hood they return a struct.
+    // This benchmark verifies whether the JIT can devirtualize the return type to avoid boxing the struct.
+    // It is not currently possible to avoid allocs for TryGet.
     [MemoryDiagnoser]
-    [HideColumns("Job", "Median", "RatioSD")]
+    [HideColumns("Job", "Median", "RatioSD", "Error", "StdDev")]
     public class AltBenchmark
     {
         private static readonly ConcurrentLru<string, int> concurrentLru = new ConcurrentLru<string, int>(8, 9, EqualityComparer<string>.Default);
@@ -28,9 +31,8 @@ namespace BitFaster.Caching.Benchmarks
         }
 
 #if NET9_0_OR_GREATER
-
         [Benchmark]
-        public int LruGetAlternateInline()
+        public int LruGetAlternate()
         {
             var alt = concurrentLru.GetAlternateLookup<ReadOnlySpan<char>>();
             alt.TryGet("1", out int value);
@@ -38,10 +40,26 @@ namespace BitFaster.Caching.Benchmarks
         }
 
         [Benchmark]
-        public int LfuGetAlternateInline()
+        public int LruTryGetAlternate()
+        {
+            concurrentLru.TryGetAlternateLookup<ReadOnlySpan<char>>(out var alt);
+            alt.TryGet("1", out int value);
+            return value;
+        }
+
+        [Benchmark]
+        public int LfuGetAlternate()
         {
             var alt = concurrentLfu.GetAlternateLookup<ReadOnlySpan<char>>();
             alt.TryGet("2", out int value);
+            return value;
+        }
+
+        [Benchmark]
+        public int LfuTryGetAlternate()
+        {
+            concurrentLfu.TryGetAlternateLookup<ReadOnlySpan<char>>(out var alt);
+            alt.TryGet("1", out int value);
             return value;
         }
 #endif

--- a/BitFaster.Caching.Benchmarks/AltBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/AltBenchmark.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Lru;
+using BitFaster.Caching.Scheduler;
 
 namespace BitFaster.Caching.Benchmarks
 {
@@ -15,28 +17,31 @@ namespace BitFaster.Caching.Benchmarks
     public class AltBenchmark
     {
         private static readonly ConcurrentLru<string, int> concurrentLru = new ConcurrentLru<string, int>(8, 9, EqualityComparer<string>.Default);
+        private static readonly ConcurrentLfu<string, int> concurrentLfu = new ConcurrentLfu<string, int>(8, 9, new ThreadPoolScheduler(), EqualityComparer<string>.Default);
+
 
         [GlobalSetup]
         public void GlobalSetup()
         {
             concurrentLru.AddOrUpdate("1", 1);
+            concurrentLfu.AddOrUpdate("2", 2);
         }
 
 #if NET9_0_OR_GREATER
 
-        [Benchmark(Baseline = true)]
-        public int GetAlternateInline()
+        [Benchmark]
+        public int LruGetAlternateInline()
         {
             var alt = concurrentLru.GetAlternateLookup<ReadOnlySpan<char>>();
             alt.TryGet("1", out int value);
             return value;
         }
 
-        [Benchmark()]
-        public int GetAlternateNoInline()
+        [Benchmark]
+        public int LfuGetAlternateInline()
         {
-            var alt = concurrentLru.GetAlternateLookup2<ReadOnlySpan<char>>();
-            alt.TryGet("1", out int value);
+            var alt = concurrentLfu.GetAlternateLookup<ReadOnlySpan<char>>();
+            alt.TryGet("2", out int value);
             return value;
         }
 #endif

--- a/BitFaster.Caching.Benchmarks/AltBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/AltBenchmark.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BitFaster.Caching.Lru;
+
+namespace BitFaster.Caching.Benchmarks
+{
+    [MemoryDiagnoser]
+    [HideColumns("Job", "Median", "RatioSD")]
+    public class AltBenchmark
+    {
+        private static readonly ConcurrentLru<string, int> concurrentLru = new ConcurrentLru<string, int>(8, 9, EqualityComparer<string>.Default);
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            concurrentLru.AddOrUpdate("1", 1);
+        }
+
+#if NET9_0_OR_GREATER
+
+        [Benchmark(Baseline = true)]
+        public int GetAlternateInline()
+        {
+            var alt = concurrentLru.GetAlternateLookup<ReadOnlySpan<char>>();
+            alt.TryGet("1", out int value);
+            return value;
+        }
+
+        [Benchmark()]
+        public int GetAlternateNoInline()
+        {
+            var alt = concurrentLru.GetAlternateLookup2<ReadOnlySpan<char>>();
+            alt.TryGet("1", out int value);
+            return value;
+        }
+#endif
+    }
+}

--- a/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
+++ b/BitFaster.Caching.Benchmarks/BitFaster.Caching.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
-    <TargetFrameworks>net48;net6.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net48;net6.0;net8.0;</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <!-- https://stackoverflow.com/a/59916801/131345 -->
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Lru;
@@ -206,6 +207,7 @@ namespace BitFaster.Caching.Lfu
 
 #if NET9_0_OR_GREATER
         ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAlternateLookup<TAlternateKey, K, V> GetAlternateLookup<TAlternateKey>()
             where TAlternateKey : notnull, allows ref struct
         {
@@ -220,6 +222,7 @@ namespace BitFaster.Caching.Lfu
         }
 
         ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAsyncAlternateLookup<TAlternateKey, K, V> GetAsyncAlternateLookup<TAlternateKey>()
             where TAlternateKey : notnull, allows ref struct
         {

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -980,6 +980,7 @@ namespace BitFaster.Caching.Lfu
 
 #if NET9_0_OR_GREATER
         ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAlternateLookup<TAlternateKey, K, V> GetAlternateLookup<TAlternateKey>()
             where TAlternateKey : notnull, allows ref struct
         {
@@ -1006,6 +1007,7 @@ namespace BitFaster.Caching.Lfu
         }
 
         ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAsyncAlternateLookup<TAlternateKey, K, V> GetAsyncAlternateLookup<TAlternateKey>()
             where TAlternateKey : notnull, allows ref struct
         {

--- a/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using BitFaster.Caching.Lru;
 using BitFaster.Caching.Scheduler;
@@ -146,6 +147,7 @@ namespace BitFaster.Caching.Lfu
 
 #if NET9_0_OR_GREATER
         ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAlternateLookup<TAlternateKey, K, V> GetAlternateLookup<TAlternateKey>()
             where TAlternateKey : notnull, allows ref struct
         {
@@ -160,6 +162,7 @@ namespace BitFaster.Caching.Lfu
         }
 
         ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAsyncAlternateLookup<TAlternateKey, K, V> GetAsyncAlternateLookup<TAlternateKey>()
             where TAlternateKey : notnull, allows ref struct
         {

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -907,7 +907,19 @@ namespace BitFaster.Caching.Lru
 
 #if NET9_0_OR_GREATER
         ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAlternateLookup<TAlternateKey, K, V> GetAlternateLookup<TAlternateKey>()
+            where TAlternateKey : notnull, allows ref struct
+        {
+            if (!this.dictionary.IsCompatibleKey<TAlternateKey, K, I>())
+            {
+                Throw.IncompatibleComparer();
+            }
+
+            return new AlternateLookup<TAlternateKey>(this);
+        }
+
+        public IAlternateLookup<TAlternateKey, K, V> GetAlternateLookup2<TAlternateKey>()
             where TAlternateKey : notnull, allows ref struct
         {
             if (!this.dictionary.IsCompatibleKey<TAlternateKey, K, I>())

--- a/BitFaster.Caching/Lru/ConcurrentLruCore.cs
+++ b/BitFaster.Caching/Lru/ConcurrentLruCore.cs
@@ -919,17 +919,6 @@ namespace BitFaster.Caching.Lru
             return new AlternateLookup<TAlternateKey>(this);
         }
 
-        public IAlternateLookup<TAlternateKey, K, V> GetAlternateLookup2<TAlternateKey>()
-            where TAlternateKey : notnull, allows ref struct
-        {
-            if (!this.dictionary.IsCompatibleKey<TAlternateKey, K, I>())
-            {
-                Throw.IncompatibleComparer();
-            }
-
-            return new AlternateLookup<TAlternateKey>(this);
-        }
-
         ///<inheritdoc/>
         public bool TryGetAlternateLookup<TAlternateKey>([MaybeNullWhen(false)] out IAlternateLookup<TAlternateKey, K, V> lookup)
             where TAlternateKey : notnull, allows ref struct
@@ -945,6 +934,7 @@ namespace BitFaster.Caching.Lru
         }
 
         ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public IAsyncAlternateLookup<TAlternateKey, K, V> GetAsyncAlternateLookup<TAlternateKey>()
             where TAlternateKey : notnull, allows ref struct
         {

--- a/Tools/bench.bat
+++ b/Tools/bench.bat
@@ -1,0 +1,26 @@
+@echo off
+setlocal
+
+if "%~1"=="" (
+    echo Usage: bench.bat ^<runtimes^> [additional args]
+    echo.
+    echo   runtimes    Comma-separated list of runtimes ^(e.g. net90,net60^)
+    echo.
+    echo Example:
+    echo   bench.bat net90,net60
+    echo   bench.bat net90 --filter *Lru*
+    exit /b 1
+)
+
+set RUNTIMES=%~1
+shift
+
+set EXTRA_ARGS=
+:parse_args
+if "%~1"=="" goto run
+set EXTRA_ARGS=%EXTRA_ARGS% %1
+shift
+goto parse_args
+
+:run
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 -- --runtimes %RUNTIMES% %EXTRA_ARGS%


### PR DESCRIPTION
Inlining GetAlternateLookup eliminates the heap allocation for the AlternateLookup struct on .NET 10:

| Method               | Runtime   | Mean     | Ratio | Gen0   | Allocated |
|--------------------- |---------- |---------:|------:|-------:|----------:|
| GetAlternateInline   | .NET 10.0 | 42.73 ns |  0.77 |      - |         - |
| GetAlternateNoInline | .NET 10.0 | 52.94 ns |  0.96 | 0.0092 |      40 B |
| GetAlternateInline   | .NET 9.0  | 55.35 ns |  1.00 | 0.0092 |      40 B |
| GetAlternateNoInline | .NET 9.0  | 56.13 ns |  1.01 | 0.0092 |      40 B |

From https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/runtime

> ### Inlining improvements
> Various inlining improvements have been made in .NET 10.
>
> The JIT can now inline methods that become eligible for devirtualization due to previous inlining. This improvement allows the JIT to uncover more optimization opportunities, such as further inlining and devirtualization.
>
> ...
>
> #### Return types
> During inlining, the JIT now updates the type of temporary variables that hold return values. If all return sites in a callee yield the same type, this precise type information is used to devirtualize subsequent calls. This enhancement complements the improvements in late devirtualization and array enumeration de-abstraction.
