### PR TITLE
Fix concurrency bug in ScopedAtomicFactory

### DIFF
--- a/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedCacheSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Atomic/AtomicFactoryScopedCacheSoakTests.cs
@@ -1,0 +1,45 @@
+﻿﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BitFaster.Caching.Atomic;
+using BitFaster.Caching.Lru;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests.Atomic
+{
+    [Collection("Soak")]
+    public class AtomicFactoryScopedCacheSoakTests
+    {
+        private const int capacity = 6;
+        private const int threadCount = 4;
+        private const int soakIterations = 10;
+        private const int loopIterations = 100_000;
+
+        [Theory]
+        [Repeat(soakIterations)]
+        public async Task ScopedGetOrAddAlternateLifetimeIsAlwaysAlive(int _)
+        {
+            var cache = new AtomicFactoryScopedCache<int, Disposable>(new ConcurrentLru<int, ScopedAtomicFactory<int, Disposable>>(1, capacity, EqualityComparer<int>.Default));
+
+            var run = Threaded.Run(threadCount, _ =>
+            {
+                var key = new char[8];
+
+                for (int i = 0; i < loopIterations; i++)
+                {
+                    using (var lifetime = cache.ScopedGetOrAdd(i, k => { return new Scoped<Disposable>(new Disposable(k)); }))
+                    {
+                        lifetime.Value.IsDisposed.Should().BeFalse($"ref count {lifetime.ReferenceCount}");
+                    }
+                }
+            });
+
+            await run;
+        }
+    }
+}

--- a/BitFaster.Caching/Atomic/ScopedAsyncAtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/ScopedAsyncAtomicFactory.cs
@@ -132,7 +132,7 @@ namespace BitFaster.Caching.Atomic
         /// </summary>
         public void Dispose()
         {
-            var init = initializer;
+            var init = Volatile.Read(ref initializer);
 
             if (init != null && init.TryGetScope(out var disposeScope))
             {

--- a/BitFaster.Caching/Atomic/ScopedAtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/ScopedAtomicFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace BitFaster.Caching.Atomic
@@ -134,7 +135,7 @@ namespace BitFaster.Caching.Atomic
 
         private void InitializeScope<TFactory>(K key, TFactory valueFactory) where TFactory : struct, IValueFactory<K, Scoped<V>>
         {
-            var init = initializer;
+            var init = Volatile.Read(ref initializer);
 
             if (init != null)
             {

--- a/BitFaster.Caching/Atomic/ScopedAtomicFactory.cs
+++ b/BitFaster.Caching/Atomic/ScopedAtomicFactory.cs
@@ -150,7 +150,7 @@ namespace BitFaster.Caching.Atomic
         /// </summary>
         public void Dispose()
         {
-            var init = initializer;
+            var init = Volatile.Read(ref initializer);
 
             if (init != null)
             {


### PR DESCRIPTION
This should be a volatile read, see equivalent code for ScopedAsyncAtomicFactory:
https://github.com/bitfaster/BitFaster.Caching/blob/689f26346c74a718c191652f93bde4d3e73b7cb3/BitFaster.Caching/Atomic/ScopedAsyncAtomicFactory.cs#L120

Issue was exposed via new soak tests in https://github.com/bitfaster/BitFaster.Caching/pull/771. This shows there is also a test gap.

Without the volatile read, the JIT will optimize away the copy. Fixed the same issue in the dispose code path.