### PR TITLE
cleanup pragma for null constraint

### DIFF
--- a/BitFaster.Caching/IAlternateLookup.cs
+++ b/BitFaster.Caching/IAlternateLookup.cs
@@ -12,7 +12,6 @@ namespace BitFaster.Caching
     /// <typeparam name="TValue">The cache value type.</typeparam>
     public interface IAlternateLookup<TAlternateKey, TKey, TValue>
         where TAlternateKey : notnull, allows ref struct
-        where TKey : notnull
     {
         /// <summary>
         /// Attempts to get a value using an alternate key.

--- a/BitFaster.Caching/IAsyncAlternateLookup.cs
+++ b/BitFaster.Caching/IAsyncAlternateLookup.cs
@@ -13,7 +13,6 @@ namespace BitFaster.Caching
     /// <typeparam name="TValue">The cache value type.</typeparam>
     public interface IAsyncAlternateLookup<TAlternateKey, TKey, TValue>
         where TAlternateKey : notnull, allows ref struct
-        where TKey : notnull
     {
         /// <summary>
         /// Attempts to get a value using an alternate key.

--- a/BitFaster.Caching/IAsyncCache.cs
+++ b/BitFaster.Caching/IAsyncCache.cs
@@ -120,8 +120,6 @@ namespace BitFaster.Caching
         void Clear();
 
 #if NET9_0_OR_GREATER
-// backcompat: add not null constraint to IAsyncCache (where K : notnull)
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         /// <summary>
         /// Gets an async alternate lookup that can use an alternate key type with the configured comparer.
         /// </summary>
@@ -141,7 +139,6 @@ namespace BitFaster.Caching
         bool TryGetAsyncAlternateLookup<TAlternateKey>([MaybeNullWhen(false)] out IAsyncAlternateLookup<TAlternateKey, K, V> lookup)
             where TAlternateKey : notnull, allows ref struct
             => throw new NotSupportedException();
-#pragma warning restore CS8714
 #endif
     }
 }

--- a/BitFaster.Caching/ICache.cs
+++ b/BitFaster.Caching/ICache.cs
@@ -121,8 +121,6 @@ namespace BitFaster.Caching
         void Clear();
 
 #if NET9_0_OR_GREATER
-// backcompat: add not null constraint to ICache (where K : notnull)
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         /// <summary>
         /// Gets an alternate lookup that can use an alternate key type with the configured comparer.
         /// </summary>
@@ -142,7 +140,6 @@ namespace BitFaster.Caching
         bool TryGetAlternateLookup<TAlternateKey>([MaybeNullWhen(false)] out IAlternateLookup<TAlternateKey, K, V> lookup)
             where TAlternateKey : notnull, allows ref struct
             => throw new NotSupportedException();
-#pragma warning restore CS8714
 #endif
     }
 }

--- a/BitFaster.Caching/IScopedAlternateLookup.cs
+++ b/BitFaster.Caching/IScopedAlternateLookup.cs
@@ -12,7 +12,6 @@ namespace BitFaster.Caching
     /// <typeparam name="TValue">The cache value type.</typeparam>
     public interface IScopedAlternateLookup<TAlternateKey, TKey, TValue>
         where TAlternateKey : notnull, allows ref struct
-        where TKey : notnull
         where TValue : IDisposable
     {
         /// <summary>

--- a/BitFaster.Caching/IScopedAsyncAlternateLookup.cs
+++ b/BitFaster.Caching/IScopedAsyncAlternateLookup.cs
@@ -13,7 +13,6 @@ namespace BitFaster.Caching
     /// <typeparam name="TValue">The cache value type.</typeparam>
     public interface IScopedAsyncAlternateLookup<TAlternateKey, TKey, TValue>
         where TAlternateKey : notnull, allows ref struct
-        where TKey : notnull
         where TValue : IDisposable
     {
         /// <summary>

--- a/BitFaster.Caching/IScopedAsyncCache.cs
+++ b/BitFaster.Caching/IScopedAsyncCache.cs
@@ -47,8 +47,6 @@ namespace BitFaster.Caching
         /// </summary>
         IEqualityComparer<K> Comparer => throw new NotSupportedException();
 
-// backcompat: add not null constraint to IScopedAsyncCache (where K : notnull)
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         /// <summary>
         /// Gets an async alternate lookup that can use an alternate key type with the configured comparer.
         /// </summary>
@@ -68,7 +66,6 @@ namespace BitFaster.Caching
         bool TryGetAsyncAlternateLookup<TAlternateKey>([MaybeNullWhen(false)] out IScopedAsyncAlternateLookup<TAlternateKey, K, V> lookup)
             where TAlternateKey : notnull, allows ref struct
             => throw new NotSupportedException();
-#pragma warning restore CS8714
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/IScopedCache.cs
+++ b/BitFaster.Caching/IScopedCache.cs
@@ -46,8 +46,6 @@ namespace BitFaster.Caching
         /// </summary>
         IEqualityComparer<K> Comparer => throw new NotSupportedException();
 
-// backcompat: add not null constraint to IScopedCache (where K : notnull)
-#pragma warning disable CS8714 // The type cannot be used as type parameter in the generic type or method. Nullability of type argument doesn't match 'notnull' constraint.
         /// <summary>
         /// Gets an alternate lookup that can use an alternate key type with the configured comparer.
         /// </summary>
@@ -67,7 +65,6 @@ namespace BitFaster.Caching
         bool TryGetAlternateLookup<TAlternateKey>([MaybeNullWhen(false)] out IScopedAlternateLookup<TAlternateKey, K, V> lookup)
             where TAlternateKey : notnull, allows ref struct
             => throw new NotSupportedException();
-#pragma warning restore CS8714
 #endif
 
         /// <summary>


### PR DESCRIPTION
The type `TKey` for `ICache` etc. does not have a `notnull` constraint. Therefore if the alt lookups constrain the key to notnull, it generates build warnings.

This change makes the generic constraints for `TKey` match across interfaces. This can be added back cleanly in v3.0.

It is a breaking change to add the notnull constraint to `ICache`:
`error CP0021: Cannot add constraint 'notnull' on type parameter 'K' of 'BitFaster.Caching.ICache<K, V>'.`