### PR TITLE
Limit key count for soak test logging 

### DIFF
--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -1205,6 +1205,8 @@ namespace BitFaster.Caching.Lfu
 #endif
 
 #if DEBUG
+        private const int maxDebugLruDisplay = 99;
+
         /// <summary>
         /// Format the LFU as a string by converting all the keys to strings.
         /// </summary>
@@ -1214,11 +1216,11 @@ namespace BitFaster.Caching.Lfu
             var sb = new StringBuilder();
 
             sb.Append("W [");
-            sb.Append(string.Join(",", this.windowLru.Select(n => n.Key.ToString())));
+            sb.Append(string.Join(",", this.windowLru.Select(n => n.Key.ToString()).Take(maxDebugLruDisplay)));
             sb.Append("] Protected [");
-            sb.Append(string.Join(",", this.protectedLru.Select(n => n.Key.ToString())));
+            sb.Append(string.Join(",", this.protectedLru.Select(n => n.Key.ToString()).Take(maxDebugLruDisplay)));
             sb.Append("] Probation [");
-            sb.Append(string.Join(",", this.probationLru.Select(n => n.Key.ToString())));
+            sb.Append(string.Join(",", this.probationLru.Select(n => n.Key.ToString()).Take(maxDebugLruDisplay)));
             sb.Append(']');
 
             return sb.ToString();


### PR DESCRIPTION
We see soak test fail very rarely with out of memory. Prior to calling `FormatLfuString`, the keys in the dictionary are logged showing the cache contains about 10 items.

Out of memory may indicate a corrupt LRU node list or bug in the enumerator where the enumerator returns an endless list of the same nodes, this limit will enable printing the list without triggering OOM.