### PR TITLE
Implement ConcurrentLfu events

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -387,15 +387,16 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
         private static void RunIntegrityCheck<K, V>(ConcurrentLfu<K, V> cache, ITestOutputHelper output)
         {
-            new ConcurrentLfuIntegrityChecker<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>>(cache.Core).Validate(output);
+            new ConcurrentLfuIntegrityChecker<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V, EventPolicy<K, V>>, EventPolicy<K, V>>(cache.Core).Validate(output);
         }
     }
 
-    internal class ConcurrentLfuIntegrityChecker<K, V, N, P>
+    internal class ConcurrentLfuIntegrityChecker<K, V, N, P, E>
         where N : LfuNode<K, V>
-        where P : struct, INodePolicy<K, V, N>
+        where P : struct, INodePolicy<K, V, N, E>
+        where E : struct, IEventPolicy<K, V>
     {
-        private readonly ConcurrentLfuCore<K, V, N, P> cache;
+        private readonly ConcurrentLfuCore<K, V, N, P, E> cache;
 
         private readonly LfuNodeList<K, V> windowLru;
         private readonly LfuNodeList<K, V> probationLru;
@@ -404,14 +405,14 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private readonly StripedMpscBuffer<N> readBuffer;
         private readonly MpscBoundedBuffer<N> writeBuffer;
 
-        private static FieldInfo windowLruField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("windowLru", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static FieldInfo probationLruField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("probationLru", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static FieldInfo protectedLruField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("protectedLru", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo windowLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("windowLru", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo probationLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("probationLru", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo protectedLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("protectedLru", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        private static FieldInfo readBufferField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("readBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
-        private static FieldInfo writeBufferField = typeof(ConcurrentLfuCore<K, V, N, P>).GetField("writeBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo readBufferField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("readBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo writeBufferField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("writeBuffer", BindingFlags.NonPublic | BindingFlags.Instance);
 
-        public ConcurrentLfuIntegrityChecker(ConcurrentLfuCore<K, V, N, P> cache)
+        public ConcurrentLfuIntegrityChecker(ConcurrentLfuCore<K, V, N, P, E> cache)
         {
             this.cache = cache;
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
@@ -418,7 +419,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
         private static void RunIntegrityCheck<K, V>(ConcurrentLfu<K, V> cache, ITestOutputHelper output)
         {
-            new ConcurrentLfuIntegrityChecker<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>>(cache.Core).Validate(output);
+            new ConcurrentLfuIntegrityChecker<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V, EventPolicy<K, V>>, EventPolicy<K, V>>(cache.Core).Validate(output);
         }
     }
 
@@ -428,6 +429,13 @@ namespace BitFaster.Caching.UnitTests.Lfu
         where E : struct, IEventPolicy<K, V>
     {
         private readonly ConcurrentLfuCore<K, V, N, P, E> cache;
+        private readonly ConcurrentDictionary<K, N> dictionary;
+
+#if NET9_0_OR_GREATER
+        private readonly Lock maintenanceLock;
+#else
+        private readonly object maintenanceLock;
+#endif
 
         private readonly LfuNodeList<K, V> windowLru;
         private readonly LfuNodeList<K, V> probationLru;
@@ -436,10 +444,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private readonly StripedMpscBuffer<N> readBuffer;
         private readonly MpscBoundedBuffer<N> writeBuffer;
 
-	private static FieldInfo dictionaryField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("dictionary", BindingFlags.NonPublic | BindingFlags.Instance);
+	    private static FieldInfo dictionaryField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("dictionary", BindingFlags.NonPublic | BindingFlags.Instance);
         private static FieldInfo lockField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("maintenanceLock", BindingFlags.NonPublic | BindingFlags.Instance);
 
-	private static FieldInfo windowLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("windowLru", BindingFlags.NonPublic | BindingFlags.Instance);
+	    private static FieldInfo windowLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("windowLru", BindingFlags.NonPublic | BindingFlags.Instance);
         private static FieldInfo probationLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("probationLru", BindingFlags.NonPublic | BindingFlags.Instance);
         private static FieldInfo protectedLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("protectedLru", BindingFlags.NonPublic | BindingFlags.Instance);
 
@@ -451,7 +459,12 @@ namespace BitFaster.Caching.UnitTests.Lfu
             this.cache = cache;
 
             this.dictionary = (ConcurrentDictionary<K, N>)dictionaryField.GetValue(cache);
-            this.maintenanceLock = lockField.GetValue(cache);
+
+#if NET9_0_OR_GREATER
+            this.maintenanceLock = (Lock)lockField.GetValue(cache);
+#else
+         this.maintenanceLock = lockField.GetValue(cache);
+#endif
 
             // get lrus via reflection
             this.windowLru = (LfuNodeList<K, V>)windowLruField.GetValue(cache);

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -444,10 +444,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private readonly StripedMpscBuffer<N> readBuffer;
         private readonly MpscBoundedBuffer<N> writeBuffer;
 
-	    private static FieldInfo dictionaryField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("dictionary", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo dictionaryField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("dictionary", BindingFlags.NonPublic | BindingFlags.Instance);
         private static FieldInfo lockField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("maintenanceLock", BindingFlags.NonPublic | BindingFlags.Instance);
 
-	    private static FieldInfo windowLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("windowLru", BindingFlags.NonPublic | BindingFlags.Instance);
+        private static FieldInfo windowLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("windowLru", BindingFlags.NonPublic | BindingFlags.Instance);
         private static FieldInfo probationLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("probationLru", BindingFlags.NonPublic | BindingFlags.Instance);
         private static FieldInfo protectedLruField = typeof(ConcurrentLfuCore<K, V, N, P, E>).GetField("protectedLru", BindingFlags.NonPublic | BindingFlags.Instance);
 
@@ -463,7 +463,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
 #if NET9_0_OR_GREATER
             this.maintenanceLock = (Lock)lockField.GetValue(cache);
 #else
-         this.maintenanceLock = lockField.GetValue(cache);
+            this.maintenanceLock = lockField.GetValue(cache);
 #endif
 
             // get lrus via reflection

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -579,18 +579,32 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
             cache.DoMaintenance();
 
-            // buffers should be empty after maintenance
-            this.readBuffer.Count.Should().Be(0);
-            this.writeBuffer.Count.Should().Be(0);
+            if (cache.Scheduler.LastException.HasValue)
+            {
+                output.WriteLine($"Last scheduler exception {cache.Scheduler.LastException.Value}");
+                cache.Scheduler.LastException.Should().BeNull("scheduler should not have thrown");
+            }
 
-            // all the items in the LRUs must exist in the dictionary.
-            // no items should be marked as removed after maintenance has run
-            VerifyLruInDictionary(this.windowLru, output);
-            VerifyLruInDictionary(this.probationLru, output);
-            VerifyLruInDictionary(this.protectedLru, output);
+            lock (this.maintenanceLock)
+            {
+#if DEBUG
+                output.WriteLine("LRUs under lock:");
+                output.WriteLine(cache.FormatLfuString());
+#endif
 
-            // all the items in the dictionary must exist in the node list
-            VerifyDictionaryInLrus();
+                // buffers should be empty after maintenance
+                this.readBuffer.Count.Should().Be(0);
+                this.writeBuffer.Count.Should().Be(0);
+
+                // all the items in the LRUs must exist in the dictionary.
+                // no items should be marked as removed after maintenance has run
+                VerifyLruInDictionary(this.windowLru, output);
+                VerifyLruInDictionary(this.probationLru, output);
+                VerifyLruInDictionary(this.protectedLru, output);
+
+                // all the items in the dictionary must exist in the node list
+                VerifyDictionaryInLrus();
+            }
 
             // cache must be within capacity
             cache.Count.Should().BeLessThanOrEqualTo(cache.Capacity, "capacity out of valid range");

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -272,6 +272,106 @@ namespace BitFaster.Caching.UnitTests.Lfu
             await RunIntegrityCheckAsync(lfu, iteration);
         }
 
+#if NET9_0_OR_GREATER
+        [Theory]
+        [Repeat(soakIterations)]
+        public async Task WhenConcurrentAlternateLookupGetCacheEndsInConsistentState(int iteration)
+        {
+            var lfu = CreateStringWithBackgroundScheduler();
+            var alternate = lfu.GetAlternateLookup<ReadOnlySpan<char>>();
+
+            await Threaded.Run(threads, () =>
+            {
+                for (int i = 0; i < loopIterations; i++)
+                {
+                    string key = (i + 1).ToString();
+                    alternate.GetOrAdd(key.AsSpan(), static keySpan => keySpan.ToString());
+                }
+            });
+
+            await RunIntegrityCheckAsync(lfu, iteration);
+        }
+
+        [Theory]
+        [Repeat(soakIterations)]
+        public async Task WhenConcurrentAlternateLookupGetWithArgCacheEndsInConsistentState(int iteration)
+        {
+            var lfu = CreateStringWithBackgroundScheduler();
+            var alternate = lfu.GetAlternateLookup<ReadOnlySpan<char>>();
+
+            await Threaded.Run(threads, () =>
+            {
+                for (int i = 0; i < loopIterations; i++)
+                {
+                    string key = (i + 1).ToString();
+                    alternate.GetOrAdd(key.AsSpan(), static (keySpan, prefix) => prefix + keySpan.ToString(), "prefix-");
+                }
+            });
+
+            await RunIntegrityCheckAsync(lfu, iteration);
+        }
+
+        [Theory]
+        [Repeat(soakIterations)]
+        public async Task WhenConcurrentAlternateLookupGetAndRemoveCacheEndsInConsistentState(int iteration)
+        {
+            var lfu = CreateStringWithBackgroundScheduler();
+            var alternate = lfu.GetAlternateLookup<ReadOnlySpan<char>>();
+
+            await Threaded.Run(threads, () =>
+            {
+                for (int i = 0; i < loopIterations; i++)
+                {
+                    string key = (i + 1).ToString();
+                    alternate.TryRemove(key.AsSpan(), out _, out _);
+                    alternate.AddOrUpdate(key.AsSpan(), key);
+                }
+            });
+
+            await RunIntegrityCheckAsync(lfu, iteration);
+        }
+
+        [Theory]
+        [Repeat(soakIterations)]
+        public async Task WhenConcurrentAsyncAlternateLookupGetOrAddAsyncCacheEndsInConsistentState(int iteration)
+        {
+            var lfu = CreateStringWithBackgroundScheduler();
+            var alternate = lfu.GetAsyncAlternateLookup<ReadOnlySpan<char>>();
+
+            await Threaded.RunAsync(threads, async () =>
+            {
+                var key = new char[8];
+                for (int i = 0; i < loopIterations; i++)
+                {
+                    (i + 1).TryFormat(key, out int written);
+                    await alternate.GetOrAddAsync(key.AsSpan().Slice(0, written), static keySpan => Task.FromResult(keySpan.ToString()));
+                }
+            });
+
+            await RunIntegrityCheckAsync(lfu, iteration);
+        }
+
+        [Theory]
+        [Repeat(soakIterations)]
+        public async Task WhenConcurrentAsyncAlternateLookupGetOrAddAsyncWithArgCacheEndsInConsistentState(int iteration)
+        {
+            var lfu = CreateStringWithBackgroundScheduler();
+            var alternate = lfu.GetAsyncAlternateLookup<ReadOnlySpan<char>>();
+
+            await Threaded.RunAsync(threads, async () =>
+            {
+                var key = new char[8];
+                for (int i = 0; i < loopIterations; i++)
+                {
+                    (i + 1).TryFormat(key, out int written);
+                    await alternate.GetOrAddAsync(key.AsSpan().Slice(0, written), static (keySpan, prefix) => Task.FromResult(prefix + keySpan.ToString()), "prefix-");
+                }
+            });
+
+            await RunIntegrityCheckAsync(lfu, iteration);
+        }
+#endif
+
         [Fact]
         public async Task ThreadedVerifyMisses()
         {

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -514,9 +514,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
-        public void EventsAreDisabled()
+        public void EventsAreEnabled()
         {
-            cache.Events.HasValue.Should().BeFalse();
+            cache.Events.HasValue.Should().BeTrue();
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -21,6 +21,19 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private ConcurrentLfu<int, int> cache = new ConcurrentLfu<int, int>(1, 20, new BackgroundThreadScheduler(), EqualityComparer<int>.Default);
         private ValueFactory valueFactory = new ValueFactory();
 
+        private List<ItemRemovedEventArgs<int, int>> removedItems = new List<ItemRemovedEventArgs<int, int>>();
+        private List<ItemUpdatedEventArgs<int, int>> updatedItems = new List<ItemUpdatedEventArgs<int, int>>();
+
+        private void OnLfuItemRemoved(object sender, ItemRemovedEventArgs<int, int> e)
+        {
+            removedItems.Add(e);
+        }
+
+        private void OnLfuItemUpdated(object sender, ItemUpdatedEventArgs<int, int> e)
+        {
+            updatedItems.Add(e);
+        }
+
         public ConcurrentLfuTests(ITestOutputHelper output)
         {
             this.output = output;
@@ -804,8 +817,157 @@ namespace BitFaster.Caching.UnitTests.Lfu
         {
 #if DEBUG
             this.output.WriteLine(cache.FormatLfuString());
-#endif        
+#endif
         }
+
+        [Fact]
+        public void WhenItemIsRemovedRemovedEventIsFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentLfu<int, int>(20);
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+
+            lfuEvents.GetOrAdd(1, i => i + 2);
+
+            lfuEvents.TryRemove(1).Should().BeTrue();
+
+            // Maintenance is needed for events to be processed
+            lfuEvents.DoMaintenance();
+
+            removedItems.Count.Should().Be(1);
+            removedItems[0].Key.Should().Be(1);
+            removedItems[0].Value.Should().Be(3);
+            removedItems[0].Reason.Should().Be(ItemRemovedReason.Removed);
+        }
+
+        [Fact]
+        public void WhenItemRemovedEventIsUnregisteredEventIsNotFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentLfu<int, int>(20);
+
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+            lfuEvents.Events.Value.ItemRemoved -= OnLfuItemRemoved;
+
+            lfuEvents.GetOrAdd(1, i => i + 1);
+            lfuEvents.TryRemove(1);
+            lfuEvents.DoMaintenance();
+
+            removedItems.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void WhenValueEvictedItemRemovedEventIsFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentLfu<int, int>(6);
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+
+            // Fill cache to capacity
+            for (int i = 0; i < 6; i++)
+            {
+                lfuEvents.GetOrAdd(i, i => i);
+            }
+
+            // This should trigger eviction
+            lfuEvents.GetOrAdd(100, i => i);
+            lfuEvents.DoMaintenance();
+
+            // At least one item should be evicted
+            removedItems.Count.Should().BeGreaterThan(0);
+            removedItems.Any(r => r.Reason == ItemRemovedReason.Evicted).Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenItemsAreTrimmedAnEventIsFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentLfu<int, int>(20);
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+
+            for (int i = 0; i < 6; i++)
+            {
+                lfuEvents.GetOrAdd(i, i => i);
+            }
+
+            lfuEvents.Trim(2);
+
+            removedItems.Count.Should().Be(2);
+            removedItems.All(r => r.Reason == ItemRemovedReason.Trimmed).Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenItemsAreClearedAnEventIsFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentLfu<int, int>(20);
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+
+            for (int i = 0; i < 6; i++)
+            {
+                lfuEvents.GetOrAdd(i, i => i);
+            }
+
+            lfuEvents.Clear();
+
+            removedItems.Count.Should().Be(6);
+            removedItems.All(r => r.Reason == ItemRemovedReason.Cleared).Should().BeTrue();
+        }
+
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public void WhenItemExistsAddOrUpdateFiresUpdateEvent()
+        {
+            updatedItems.Clear();
+            var lfuEvents = new ConcurrentLfu<int, int>(20);
+            lfuEvents.Events.Value.ItemUpdated += OnLfuItemUpdated;
+
+            lfuEvents.AddOrUpdate(1, 2);
+            lfuEvents.AddOrUpdate(2, 3);
+
+            lfuEvents.AddOrUpdate(1, 3);
+
+            this.updatedItems.Count.Should().Be(1);
+            this.updatedItems[0].Key.Should().Be(1);
+            this.updatedItems[0].OldValue.Should().Be(2);
+            this.updatedItems[0].NewValue.Should().Be(3);
+        }
+
+        [Fact]
+        public void WhenItemExistsTryUpdateFiresUpdateEvent()
+        {
+            updatedItems.Clear();
+            var lfuEvents = new ConcurrentLfu<int, int>(20);
+            lfuEvents.Events.Value.ItemUpdated += OnLfuItemUpdated;
+
+            lfuEvents.AddOrUpdate(1, 2);
+            lfuEvents.AddOrUpdate(2, 3);
+
+            lfuEvents.TryUpdate(1, 3);
+
+            this.updatedItems.Count.Should().Be(1);
+            this.updatedItems[0].Key.Should().Be(1);
+            this.updatedItems[0].OldValue.Should().Be(2);
+            this.updatedItems[0].NewValue.Should().Be(3);
+        }
+
+        [Fact]
+        public void WhenItemUpdatedEventIsUnregisteredEventIsNotFired()
+        {
+            updatedItems.Clear();
+            var lfuEvents = new ConcurrentLfu<int, int>(20);
+
+            lfuEvents.Events.Value.ItemUpdated += OnLfuItemUpdated;
+            lfuEvents.Events.Value.ItemUpdated -= OnLfuItemUpdated;
+
+            lfuEvents.AddOrUpdate(1, 2);
+            lfuEvents.AddOrUpdate(1, 2);
+            lfuEvents.AddOrUpdate(1, 2);
+
+            updatedItems.Count.Should().Be(0);
+        }
+#endif
 
         public class ValueFactory
         {

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -885,8 +885,8 @@ namespace BitFaster.Caching.UnitTests.Lfu
             lfuEvents.DoMaintenance();
 
             // At least one item should be evicted
-            removedItems.Count.Should().BeGreaterThan(0);
-            removedItems.Any(r => r.Reason == ItemRemovedReason.Evicted).Should().BeTrue();
+            removedItems.Count.Should().Be(1);
+            removedItems.All(r => r.Reason == ItemRemovedReason.Evicted).Should().BeTrue();
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
@@ -75,10 +75,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
-        public void EventsHasValueIsFalse()
+        public void EventsAreEnabled()
         {
             var x = new ConcurrentTLfu<int, int>(3, new TestExpiryCalculator<int, int>());
-            x.Events.HasValue.Should().BeFalse();
+            x.Events.HasValue.Should().BeTrue();
         }
 
         [Fact]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentTLfuTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using BitFaster.Caching.Lfu;
@@ -20,6 +22,19 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
         // on MacOS time measurement seems to be less stable, give longer pause
         private int ttlWaitMlutiplier = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 8 : 2;
+
+        private List<ItemRemovedEventArgs<int, int>> removedItems = new List<ItemRemovedEventArgs<int, int>>();
+        private List<ItemUpdatedEventArgs<int, int>> updatedItems = new List<ItemUpdatedEventArgs<int, int>>();
+
+        private void OnLfuItemRemoved(object sender, ItemRemovedEventArgs<int, int> e)
+        {
+            removedItems.Add(e);
+        }
+
+        private void OnLfuItemUpdated(object sender, ItemUpdatedEventArgs<int, int> e)
+        {
+            updatedItems.Add(e);
+        }
 
         public ConcurrentTLfuTests()
         {
@@ -212,5 +227,154 @@ namespace BitFaster.Caching.UnitTests.Lfu
                 }
             );
         }
+
+        [Fact]
+        public void WhenItemIsRemovedRemovedEventIsFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentTLfu<int, int>(20, new TestExpiryCalculator<int, int>());
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+
+            lfuEvents.GetOrAdd(1, i => i + 2);
+
+            lfuEvents.TryRemove(1).Should().BeTrue();
+
+            // Maintenance is needed for events to be processed
+            lfuEvents.DoMaintenance();
+
+            removedItems.Count.Should().Be(1);
+            removedItems[0].Key.Should().Be(1);
+            removedItems[0].Value.Should().Be(3);
+            removedItems[0].Reason.Should().Be(ItemRemovedReason.Removed);
+        }
+
+        [Fact]
+        public void WhenItemRemovedEventIsUnregisteredEventIsNotFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentTLfu<int, int>(20, new TestExpiryCalculator<int, int>());
+
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+            lfuEvents.Events.Value.ItemRemoved -= OnLfuItemRemoved;
+
+            lfuEvents.GetOrAdd(1, i => i + 1);
+            lfuEvents.TryRemove(1);
+            lfuEvents.DoMaintenance();
+
+            removedItems.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void WhenValueEvictedItemRemovedEventIsFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentTLfu<int, int>(6, new TestExpiryCalculator<int, int>());
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+
+            // Fill cache to capacity
+            for (int i = 0; i < 6; i++)
+            {
+                lfuEvents.GetOrAdd(i, i => i);
+            }
+
+            // This should trigger eviction
+            lfuEvents.GetOrAdd(100, i => i);
+            lfuEvents.DoMaintenance();
+
+            // At least one item should be evicted
+            removedItems.Count.Should().BeGreaterThan(0);
+            removedItems.Any(r => r.Reason == ItemRemovedReason.Evicted).Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenItemsAreTrimmedAnEventIsFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentTLfu<int, int>(20, new TestExpiryCalculator<int, int>());
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+
+            for (int i = 0; i < 6; i++)
+            {
+                lfuEvents.GetOrAdd(i, i => i);
+            }
+
+            lfuEvents.Trim(2);
+
+            removedItems.Count.Should().Be(2);
+            removedItems.All(r => r.Reason == ItemRemovedReason.Trimmed).Should().BeTrue();
+        }
+
+        [Fact]
+        public void WhenItemsAreClearedAnEventIsFired()
+        {
+            removedItems.Clear();
+            var lfuEvents = new ConcurrentTLfu<int, int>(20, new TestExpiryCalculator<int, int>());
+            lfuEvents.Events.Value.ItemRemoved += OnLfuItemRemoved;
+
+            for (int i = 0; i < 6; i++)
+            {
+                lfuEvents.GetOrAdd(i, i => i);
+            }
+
+            lfuEvents.Clear();
+
+            removedItems.Count.Should().Be(6);
+            removedItems.All(r => r.Reason == ItemRemovedReason.Cleared).Should().BeTrue();
+        }
+
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public void WhenItemExistsAddOrUpdateFiresUpdateEvent()
+        {
+            updatedItems.Clear();
+            var lfuEvents = new ConcurrentTLfu<int, int>(20, new TestExpiryCalculator<int, int>());
+            lfuEvents.Events.Value.ItemUpdated += OnLfuItemUpdated;
+
+            lfuEvents.AddOrUpdate(1, 2);
+            lfuEvents.AddOrUpdate(2, 3);
+
+            lfuEvents.AddOrUpdate(1, 3);
+
+            updatedItems.Count.Should().Be(1);
+            updatedItems[0].Key.Should().Be(1);
+            updatedItems[0].OldValue.Should().Be(2);
+            updatedItems[0].NewValue.Should().Be(3);
+        }
+
+        [Fact]
+        public void WhenItemExistsTryUpdateFiresUpdateEvent()
+        {
+            updatedItems.Clear();
+            var lfuEvents = new ConcurrentTLfu<int, int>(20, new TestExpiryCalculator<int, int>());
+            lfuEvents.Events.Value.ItemUpdated += OnLfuItemUpdated;
+
+            lfuEvents.AddOrUpdate(1, 2);
+            lfuEvents.AddOrUpdate(2, 3);
+
+            lfuEvents.TryUpdate(1, 3);
+
+            updatedItems.Count.Should().Be(1);
+            updatedItems[0].Key.Should().Be(1);
+            updatedItems[0].OldValue.Should().Be(2);
+            updatedItems[0].NewValue.Should().Be(3);
+        }
+
+        [Fact]
+        public void WhenItemUpdatedEventIsUnregisteredEventIsNotFired()
+        {
+            updatedItems.Clear();
+            var lfuEvents = new ConcurrentTLfu<int, int>(20, new TestExpiryCalculator<int, int>());
+
+            lfuEvents.Events.Value.ItemUpdated += OnLfuItemUpdated;
+            lfuEvents.Events.Value.ItemUpdated -= OnLfuItemUpdated;
+
+            lfuEvents.AddOrUpdate(1, 2);
+            lfuEvents.AddOrUpdate(1, 2);
+            lfuEvents.AddOrUpdate(1, 2);
+
+            updatedItems.Count.Should().Be(0);
+        }
+#endif
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/EventPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/EventPolicyTests.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections.Generic;
+using BitFaster.Caching.Lfu;
+using FluentAssertions;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests.Lfu
+{
+    public class EventPolicyTests
+    {
+        private EventPolicy<int, int> eventPolicy = default;
+
+        public EventPolicyTests()
+        {
+            eventPolicy.SetEventSource(this);
+        }
+
+        [Fact]
+        public void OnItemRemovedInvokesEvent()
+        {
+            List<ItemRemovedEventArgs<int, int>> eventList = new();
+
+            eventPolicy.ItemRemoved += (source, args) => eventList.Add(args);
+
+            eventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+
+            eventList.Should().HaveCount(1);
+            eventList[0].Key.Should().Be(1);
+            eventList[0].Value.Should().Be(2);
+            eventList[0].Reason.Should().Be(ItemRemovedReason.Evicted);
+        }
+
+        [Fact]
+        public void OnItemUpdatedInvokesEvent()
+        {
+            List<ItemUpdatedEventArgs<int, int>> eventList = new();
+
+            eventPolicy.ItemUpdated += (source, args) => eventList.Add(args);
+
+            eventPolicy.OnItemUpdated(1, 2, 3);
+
+            eventList.Should().HaveCount(1);
+            eventList[0].Key.Should().Be(1);
+            eventList[0].OldValue.Should().Be(2);
+            eventList[0].NewValue.Should().Be(3);
+        }
+
+        [Fact]
+        public void EventSourceIsSetItemRemovedEventUsesSource()
+        {
+            List<object> eventSourceList = new();
+
+            eventPolicy.SetEventSource(this);
+
+            eventPolicy.ItemRemoved += (source, args) => eventSourceList.Add(source);
+
+            eventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+
+            eventSourceList.Should().HaveCount(1);
+            eventSourceList[0].Should().Be(this);
+        }
+
+        [Fact]
+        public void EventSourceIsSetItemUpdatedEventUsesSource()
+        {
+            List<object> eventSourceList = new();
+
+            eventPolicy.SetEventSource(this);
+
+            eventPolicy.ItemUpdated += (source, args) => eventSourceList.Add(source);
+
+            eventPolicy.OnItemUpdated(1, 2, 3);
+
+            eventSourceList.Should().HaveCount(1);
+            eventSourceList[0].Should().Be(this);
+        }
+
+        [Fact]
+        public void MultipleItemRemovedSubscribersAllInvoked()
+        {
+            int invocationCount = 0;
+
+            eventPolicy.ItemRemoved += (source, args) => invocationCount++;
+            eventPolicy.ItemRemoved += (source, args) => invocationCount++;
+            eventPolicy.ItemRemoved += (source, args) => invocationCount++;
+
+            eventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+
+            invocationCount.Should().Be(3);
+        }
+
+        [Fact]
+        public void MultipleItemUpdatedSubscribersAllInvoked()
+        {
+            int invocationCount = 0;
+
+            eventPolicy.ItemUpdated += (source, args) => invocationCount++;
+            eventPolicy.ItemUpdated += (source, args) => invocationCount++;
+            eventPolicy.ItemUpdated += (source, args) => invocationCount++;
+
+            eventPolicy.OnItemUpdated(1, 2, 3);
+
+            invocationCount.Should().Be(3);
+        }
+
+        [Fact]
+        public void ItemRemovedEventCanBeUnsubscribed()
+        {
+            int invocationCount = 0;
+
+            EventHandler<ItemRemovedEventArgs<int, int>> handler = (source, args) => invocationCount++;
+
+            eventPolicy.ItemRemoved += handler;
+            eventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+
+            invocationCount.Should().Be(1);
+
+            eventPolicy.ItemRemoved -= handler;
+            eventPolicy.OnItemRemoved(3, 4, ItemRemovedReason.Evicted);
+
+            invocationCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void ItemUpdatedEventCanBeUnsubscribed()
+        {
+            int invocationCount = 0;
+
+            EventHandler<ItemUpdatedEventArgs<int, int>> handler = (source, args) => invocationCount++;
+
+            eventPolicy.ItemUpdated += handler;
+            eventPolicy.OnItemUpdated(1, 2, 3);
+
+            invocationCount.Should().Be(1);
+
+            eventPolicy.ItemUpdated -= handler;
+            eventPolicy.OnItemUpdated(4, 5, 6);
+
+            invocationCount.Should().Be(1);
+        }
+
+        [Fact]
+        public void OnItemRemovedWithoutSubscribersDoesNotThrow()
+        {
+            Action act = () => eventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void OnItemUpdatedWithoutSubscribersDoesNotThrow()
+        {
+            Action act = () => eventPolicy.OnItemUpdated(1, 2, 3);
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void MultipleOnItemRemovedCallsInvokeMultipleEvents()
+        {
+            List<ItemRemovedEventArgs<int, int>> eventList = new();
+
+            eventPolicy.ItemRemoved += (source, args) => eventList.Add(args);
+
+            eventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+            eventPolicy.OnItemRemoved(3, 4, ItemRemovedReason.Removed);
+            eventPolicy.OnItemRemoved(5, 6, ItemRemovedReason.Evicted);
+
+            eventList.Should().HaveCount(3);
+            eventList[0].Key.Should().Be(1);
+            eventList[1].Key.Should().Be(3);
+            eventList[2].Key.Should().Be(5);
+        }
+
+        [Fact]
+        public void MultipleOnItemUpdatedCallsInvokeMultipleEvents()
+        {
+            List<ItemUpdatedEventArgs<int, int>> eventList = new();
+
+            eventPolicy.ItemUpdated += (source, args) => eventList.Add(args);
+
+            eventPolicy.OnItemUpdated(1, 2, 3);
+            eventPolicy.OnItemUpdated(4, 5, 6);
+            eventPolicy.OnItemUpdated(7, 8, 9);
+
+            eventList.Should().HaveCount(3);
+            eventList[0].Key.Should().Be(1);
+            eventList[1].Key.Should().Be(4);
+            eventList[2].Key.Should().Be(7);
+        }
+
+        [Fact]
+        public void ItemRemovedAndItemUpdatedEventsAreIndependent()
+        {
+            List<ItemRemovedEventArgs<int, int>> removedEventList = new();
+            List<ItemUpdatedEventArgs<int, int>> updatedEventList = new();
+
+            eventPolicy.ItemRemoved += (source, args) => removedEventList.Add(args);
+            eventPolicy.ItemUpdated += (source, args) => updatedEventList.Add(args);
+
+            eventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+            eventPolicy.OnItemUpdated(3, 4, 5);
+
+            removedEventList.Should().HaveCount(1);
+            updatedEventList.Should().HaveCount(1);
+        }
+    }
+}

--- a/BitFaster.Caching.UnitTests/Lfu/NoEventPolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/NoEventPolicyTests.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using BitFaster.Caching.Lfu;
+using FluentAssertions;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests.Lfu
+{
+    public class NoEventPolicyTests
+    {
+        private NoEventPolicy<int, int> noEventPolicy = default;
+
+        [Fact]
+        public void OnItemRemovedDoesNothing()
+        {
+            Action act = () => noEventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void OnItemUpdatedDoesNothing()
+        {
+            Action act = () => noEventPolicy.OnItemUpdated(1, 2, 3);
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void SetEventSourceDoesNothing()
+        {
+            Action act = () => noEventPolicy.SetEventSource(this);
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void ItemRemovedEventCanBeSubscribedWithoutEffect()
+        {
+            List<ItemRemovedEventArgs<int, int>> eventList = new();
+
+            noEventPolicy.ItemRemoved += (source, args) => eventList.Add(args);
+
+            noEventPolicy.OnItemRemoved(1, 2, ItemRemovedReason.Evicted);
+
+            eventList.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItemUpdatedEventCanBeSubscribedWithoutEffect()
+        {
+            List<ItemUpdatedEventArgs<int, int>> eventList = new();
+
+            noEventPolicy.ItemUpdated += (source, args) => eventList.Add(args);
+
+            noEventPolicy.OnItemUpdated(1, 2, 3);
+
+            eventList.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void ItemRemovedEventCanBeUnsubscribedWithoutEffect()
+        {
+            EventHandler<ItemRemovedEventArgs<int, int>> handler = (source, args) => { };
+
+            Action subscribe = () => noEventPolicy.ItemRemoved += handler;
+            Action unsubscribe = () => noEventPolicy.ItemRemoved -= handler;
+
+            subscribe.Should().NotThrow();
+            unsubscribe.Should().NotThrow();
+        }
+
+        [Fact]
+        public void ItemUpdatedEventCanBeUnsubscribedWithoutEffect()
+        {
+            EventHandler<ItemUpdatedEventArgs<int, int>> handler = (source, args) => { };
+
+            Action subscribe = () => noEventPolicy.ItemUpdated += handler;
+            Action unsubscribe = () => noEventPolicy.ItemUpdated -= handler;
+
+            subscribe.Should().NotThrow();
+            unsubscribe.Should().NotThrow();
+        }
+    }
+}

--- a/BitFaster.Caching.UnitTests/Lfu/TimerWheelTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/TimerWheelTests.cs
@@ -20,7 +20,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
         private readonly TimerWheel<int, IDisposable> timerWheel;
         private readonly WheelEnumerator<int, IDisposable> wheelEnumerator;
         private readonly LfuNodeList<int, IDisposable> lfuNodeList;
-        private readonly ExpireAfterPolicy<int, IDisposable,NoEventPolicy<int, IDisposable>> policy;
+        private readonly ExpireAfterPolicy<int, IDisposable, NoEventPolicy<int, IDisposable>> policy;
         private ConcurrentLfuCore<int, IDisposable, TimeOrderNode<int, IDisposable>, ExpireAfterPolicy<int, IDisposable, NoEventPolicy<int, IDisposable>>, NoEventPolicy<int, IDisposable>> cache;
 
         public TimerWheelTests(ITestOutputHelper testOutputHelper)

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -220,11 +220,8 @@ namespace BitFaster.Caching.Lfu
 
         // To get JIT optimizations, policies must be structs.
         // If the structs are returned directly via properties, they will be copied. Since
-        // eventPolicy is a mutable struct, copy is bad. One workaround is to store the
-        // state within the struct in an object. Since the struct points to the same object
-        // it becomes immutable. However, this object is then somewhere else on the
-        // heap, which slows down the policies with hit counter logic in benchmarks. Likely
-        // this approach keeps the structs data members in the same CPU cache line as the LFU.
+        // eventPolicy is a mutable struct, copy is bad since changes are lost.
+        // Hence it is returned by ref and mutated via Proxy.
         private class Proxy : ICacheEvents<K, V>
         {
             private readonly ConcurrentLfu<K, V> lfu;

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -36,7 +36,7 @@ namespace BitFaster.Caching.Lfu
         where K : notnull
     {
         // Note: for performance reasons this is a mutable struct, it cannot be readonly.
-        private ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>> core;
+        private ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V, EventPolicy<K, V>>, EventPolicy<K, V>> core;
 
         /// <summary>
         /// The default buffer size.
@@ -49,7 +49,9 @@ namespace BitFaster.Caching.Lfu
         /// <param name="capacity">The capacity.</param>
         public ConcurrentLfu(int capacity)
         {
-            this.core = new(Defaults.ConcurrencyLevel, capacity, new ThreadPoolScheduler(), EqualityComparer<K>.Default, () => this.DrainBuffers(), default);
+            EventPolicy<K, V> eventPolicy = default;
+            eventPolicy.SetEventSource(this);
+            this.core = new(Defaults.ConcurrencyLevel, capacity, new ThreadPoolScheduler(), EqualityComparer<K>.Default, () => this.DrainBuffers(), default, eventPolicy);
         }
 
         /// <summary>
@@ -61,10 +63,12 @@ namespace BitFaster.Caching.Lfu
         /// <param name="comparer">The equality comparer.</param>
         public ConcurrentLfu(int concurrencyLevel, int capacity, IScheduler scheduler, IEqualityComparer<K> comparer)
         {
-            this.core = new(concurrencyLevel, capacity, scheduler, comparer, () => this.DrainBuffers(), default);
+            EventPolicy<K, V> eventPolicy = default;
+            eventPolicy.SetEventSource(this);
+            this.core = new(concurrencyLevel, capacity, scheduler, comparer, () => this.DrainBuffers(), default, eventPolicy);
         }
 
-        internal ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V>> Core => core;
+        internal ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, AccessOrderPolicy<K, V, EventPolicy<K, V>>, EventPolicy<K, V>> Core => core;
 
         // structs cannot declare self referencing lambda functions, therefore pass this in from the ctor
         private void DrainBuffers()
@@ -79,7 +83,7 @@ namespace BitFaster.Caching.Lfu
         public Optional<ICacheMetrics> Metrics => core.Metrics;
 
         ///<inheritdoc/>
-        public Optional<ICacheEvents<K, V>> Events => Optional<ICacheEvents<K, V>>.None();
+        public Optional<ICacheEvents<K, V>> Events => new(core.eventPolicy);
 
         ///<inheritdoc/>
         public CachePolicy Policy => core.Policy;

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -83,7 +83,9 @@ namespace BitFaster.Caching.Lfu
         public Optional<ICacheMetrics> Metrics => core.Metrics;
 
         ///<inheritdoc/>
-        public Optional<ICacheEvents<K, V>> Events => new(core.eventPolicy);
+        public Optional<ICacheEvents<K, V>> Events => new(new Proxy(this));
+
+        internal ref EventPolicy<K, V> EventPolicyRef => ref this.core.eventPolicy;
 
         ///<inheritdoc/>
         public CachePolicy Policy => core.Policy;
@@ -120,6 +122,7 @@ namespace BitFaster.Caching.Lfu
         public void Clear()
         {
             core.Clear();
+            DoMaintenance();
         }
 
         ///<inheritdoc/>
@@ -150,6 +153,7 @@ namespace BitFaster.Caching.Lfu
         public void Trim(int itemCount)
         {
             core.Trim(itemCount);
+            DoMaintenance();
         }
 
         ///<inheritdoc/>
@@ -213,6 +217,54 @@ namespace BitFaster.Caching.Lfu
             return core.FormatLfuString();
         }
 #endif
+
+        // To get JIT optimizations, policies must be structs.
+        // If the structs are returned directly via properties, they will be copied. Since
+        // eventPolicy is a mutable struct, copy is bad. One workaround is to store the
+        // state within the struct in an object. Since the struct points to the same object
+        // it becomes immutable. However, this object is then somewhere else on the
+        // heap, which slows down the policies with hit counter logic in benchmarks. Likely
+        // this approach keeps the structs data members in the same CPU cache line as the LFU.
+        private class Proxy : ICacheEvents<K, V>
+        {
+            private readonly ConcurrentLfu<K, V> lfu;
+
+            public Proxy(ConcurrentLfu<K, V> lfu)
+            {
+                this.lfu = lfu;
+            }
+
+            public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
+            {
+                add
+                {
+                    ref var policy = ref this.lfu.EventPolicyRef;
+                    policy.ItemRemoved += value;
+                }
+                remove
+                {
+                    ref var policy = ref this.lfu.EventPolicyRef;
+                    policy.ItemRemoved -= value;
+                }
+            }
+
+            // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+            public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
+            {
+                add
+                {
+                    ref var policy = ref this.lfu.EventPolicyRef;
+                    policy.ItemUpdated += value;
+                }
+                remove
+                {
+                    ref var policy = ref this.lfu.EventPolicyRef;
+                    policy.ItemUpdated -= value;
+                }
+            }
+#endif
+        }
 
         [ExcludeFromCodeCoverage]
         internal class LfuDebugView<N>

--- a/BitFaster.Caching/Lfu/ConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfu.cs
@@ -128,7 +128,6 @@ namespace BitFaster.Caching.Lfu
         public void Clear()
         {
             core.Clear();
-            DoMaintenance();
         }
 
         ///<inheritdoc/>
@@ -162,7 +161,6 @@ namespace BitFaster.Caching.Lfu
         public void Trim(int itemCount)
         {
             core.Trim(itemCount);
-            DoMaintenance();
         }
 
         ///<inheritdoc/>
@@ -274,11 +272,13 @@ namespace BitFaster.Caching.Lfu
 
             public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
             {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 add
                 {
                     ref var policy = ref this.lfu.EventPolicyRef;
                     policy.ItemRemoved += value;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 remove
                 {
                     ref var policy = ref this.lfu.EventPolicyRef;
@@ -290,11 +290,13 @@ namespace BitFaster.Caching.Lfu
 #if NETCOREAPP3_0_OR_GREATER
             public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
             {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 add
                 {
                     ref var policy = ref this.lfu.EventPolicyRef;
                     policy.ItemUpdated += value;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 remove
                 {
                     ref var policy = ref this.lfu.EventPolicyRef;

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -648,7 +648,7 @@ namespace BitFaster.Caching.Lfu
 
         private static class RemoveEventInliner
         {
-            private static readonly bool IsEnabled = typeof(E) == typeof(EventPolicy<K,V>);
+            private static readonly bool IsEnabled = typeof(E) == typeof(EventPolicy<K, V>);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static void OnRemovedEvent(ConcurrentLfuCore<K, V, N, P, E> cache, N node)

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -194,7 +194,7 @@ namespace BitFaster.Caching.Lfu
 #endif
             {
                 Evict(candidate, reason);
-            }         
+            }
         }
 
         private bool TryAdd(K key, V value)

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -429,7 +429,7 @@ namespace BitFaster.Caching.Lfu
 
                     // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
-                    EventInliner.OnUpdatedEvent(this, node.Key, oldValue, value);
+                    EventPolicyDispatch.OnUpdatedEvent(this, node.Key, oldValue, value);
 #endif
                     return true;
                 }
@@ -690,7 +690,7 @@ namespace BitFaster.Caching.Lfu
                 {
                     // if a write is in the buffer and is then removed in the buffer, it will enter OnWrite twice.
                     // we mark as deleted to avoid double counting/disposing it
-                    EventInliner.OnRemovedEvent(this, node, ItemRemovedReason.Removed);
+                    EventPolicyDispatch.OnRemovedEvent(this, node, ItemRemovedReason.Removed);
                     this.metrics.evictedCount++;
                     Disposer<V>.Dispose(node.Value);
                     node.WasDeleted = true;
@@ -896,7 +896,7 @@ namespace BitFaster.Caching.Lfu
             ((ICollection<KeyValuePair<K, N>>)this.dictionary).Remove(kvp);
 #endif
             evictee.list?.Remove(evictee);
-            EventInliner.OnRemovedEvent(this, evictee, reason);
+            EventPolicyDispatch.OnRemovedEvent(this, evictee, reason);
             Disposer<V>.Dispose(evictee.Value);
             this.metrics.evictedCount++;
 
@@ -1011,7 +1011,7 @@ namespace BitFaster.Caching.Lfu
         }
 
         // enable JIT to elide unused code.
-        private static class EventInliner
+        private static class EventPolicyDispatch
         {
             private static readonly bool IsEnabled = typeof(E) == typeof(EventPolicy<K, V>);
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -411,29 +411,29 @@ namespace BitFaster.Caching.Lfu
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool TryUpdateValue(N node, V value)
         {
-                lock (node)
+            lock (node)
+            {
+                if (!node.WasRemoved)
                 {
-                    if (!node.WasRemoved)
-                    {
-                        // backcompat: remove conditional compile
+                    // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
-                        V oldValue = node.Value;
+                    V oldValue = node.Value;
 #endif
-                        node.Value = value;
+                    node.Value = value;
 
-                        // It's ok for this to be lossy, since the node is already tracked
-                        // and we will just lose ordering/hit count, but not orphan the node.
-                        this.writeBuffer.TryAdd(node);
-                        TryScheduleDrain();
-                        this.policy.OnWrite(node);
+                    // It's ok for this to be lossy, since the node is already tracked
+                    // and we will just lose ordering/hit count, but not orphan the node.
+                    this.writeBuffer.TryAdd(node);
+                    TryScheduleDrain();
+                    this.policy.OnWrite(node);
 
-                        // backcompat: remove conditional compile
+                    // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
-                        this.eventPolicy.OnItemUpdated(key, oldValue, value);
+                    this.eventPolicy.OnItemUpdated(node.Key, oldValue, value);
 #endif
-                        return true;
-                    }
+                    return true;
                 }
+            }
 
             return false;
         }
@@ -1084,7 +1084,7 @@ namespace BitFaster.Caching.Lfu
         internal readonly struct AlternateLookup<TAlternateKey> : IAlternateLookup<TAlternateKey, K, V>, IAsyncAlternateLookup<TAlternateKey, K, V>
             where TAlternateKey : notnull, allows ref struct
         {
-            internal AlternateLookup(ConcurrentLfuCore<K, V, N, P> lfu)
+            internal AlternateLookup(ConcurrentLfuCore<K, V, N, P, E> lfu)
             {
                 Debug.Assert(lfu.dictionary.IsCompatibleKey<TAlternateKey, K, N>());
                 this.Lfu = lfu;
@@ -1092,7 +1092,7 @@ namespace BitFaster.Caching.Lfu
                 this.Comparer = lfu.dictionary.GetAlternateComparer<TAlternateKey, K, N>();
             }
 
-            internal ConcurrentLfuCore<K, V, N, P> Lfu { get; }
+            internal ConcurrentLfuCore<K, V, N, P, E> Lfu { get; }
 
             internal ConcurrentDictionary<K, N>.AlternateLookup<TAlternateKey> Alternate { get; }
 

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -429,7 +429,7 @@ namespace BitFaster.Caching.Lfu
 
                     // backcompat: remove conditional compile
 #if NETCOREAPP3_0_OR_GREATER
-                    this.eventPolicy.OnItemUpdated(node.Key, oldValue, value);
+                    EventInliner.OnUpdatedEvent(this, node.Key, oldValue, value);
 #endif
                     return true;
                 }
@@ -678,22 +678,6 @@ namespace BitFaster.Caching.Lfu
             policy.AfterRead(node);
         }
 
-        private static class RemoveEventInliner
-        {
-            private static readonly bool IsEnabled = typeof(E) == typeof(EventPolicy<K, V>);
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static void OnRemovedEvent(ConcurrentLfuCore<K, V, N, P, E> cache, N node)
-            {
-                if (IsEnabled)
-                {
-                    // WasRemoved flag is set via TryRemove, else item is evicted via policy
-                    ItemRemovedReason reason = node.WasRemoved ? ItemRemovedReason.Removed : ItemRemovedReason.Evicted;
-                    cache.eventPolicy.OnItemRemoved(node.Key, node.Value, reason);
-                }
-            }
-        }
-
         private void OnWrite(N node)
         {
             // Nodes can be removed while they are in the write buffer, in which case they should
@@ -706,7 +690,7 @@ namespace BitFaster.Caching.Lfu
                 {
                     // if a write is in the buffer and is then removed in the buffer, it will enter OnWrite twice.
                     // we mark as deleted to avoid double counting/disposing it
-                    RemoveEventInliner.OnRemovedEvent(this, node);
+                    EventInliner.OnRemovedEvent(this, node);
                     this.metrics.evictedCount++;
                     Disposer<V>.Dispose(node.Value);
                     node.WasDeleted = true;
@@ -912,7 +896,7 @@ namespace BitFaster.Caching.Lfu
             ((ICollection<KeyValuePair<K, N>>)this.dictionary).Remove(kvp);
 #endif
             evictee.list?.Remove(evictee);
-            this.eventPolicy.OnItemRemoved(evictee.Key, evictee.Value, reason);
+            EventInliner.OnRemovedEvent(this, evictee, reason);
             Disposer<V>.Dispose(evictee.Value);
             this.metrics.evictedCount++;
 
@@ -1024,6 +1008,41 @@ namespace BitFaster.Caching.Lfu
             public long Updated => updatedCount;
 
             public long Evicted => evictedCount;
+        }
+
+        private static class EventInliner
+        {
+            private static readonly bool IsEnabled = typeof(E) == typeof(EventPolicy<K, V>);
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void OnRemovedEvent(ConcurrentLfuCore<K, V, N, P, E> cache, N node)
+            {
+                if (IsEnabled)
+                {
+                    // WasRemoved flag is set via TryRemove, else item is evicted via policy
+                    ItemRemovedReason reason = node.WasRemoved ? ItemRemovedReason.Removed : ItemRemovedReason.Evicted;
+                    cache.eventPolicy.OnItemRemoved(node.Key, node.Value, reason);
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void OnRemovedEvent(ConcurrentLfuCore<K, V, N, P, E> cache, LfuNode<K, V> node, ItemRemovedReason reason)
+            {
+                if (IsEnabled)
+                {
+                    cache.eventPolicy.OnItemRemoved(node.Key, node.Value, reason);
+                }
+            }
+#if NETCOREAPP3_0_OR_GREATER
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void OnUpdatedEvent(ConcurrentLfuCore<K, V, N, P, E> cache, K key, V oldValue, V newValue)
+            {
+                if (IsEnabled)
+                {
+                    cache.eventPolicy.OnItemUpdated(key, oldValue, newValue);
+                }
+            }
+#endif
         }
 
 #if NET9_0_OR_GREATER

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -690,7 +690,7 @@ namespace BitFaster.Caching.Lfu
                 {
                     // if a write is in the buffer and is then removed in the buffer, it will enter OnWrite twice.
                     // we mark as deleted to avoid double counting/disposing it
-                    EventInliner.OnRemovedEvent(this, node);
+                    EventInliner.OnRemovedEvent(this, node, ItemRemovedReason.Evicted);
                     this.metrics.evictedCount++;
                     Disposer<V>.Dispose(node.Value);
                     node.WasDeleted = true;
@@ -1010,20 +1010,10 @@ namespace BitFaster.Caching.Lfu
             public long Evicted => evictedCount;
         }
 
+        // enable JIT to elide unused code.
         private static class EventInliner
         {
             private static readonly bool IsEnabled = typeof(E) == typeof(EventPolicy<K, V>);
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static void OnRemovedEvent(ConcurrentLfuCore<K, V, N, P, E> cache, N node)
-            {
-                if (IsEnabled)
-                {
-                    // WasRemoved flag is set via TryRemove, else item is evicted via policy
-                    ItemRemovedReason reason = node.WasRemoved ? ItemRemovedReason.Removed : ItemRemovedReason.Evicted;
-                    cache.eventPolicy.OnItemRemoved(node.Key, node.Value, reason);
-                }
-            }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static void OnRemovedEvent(ConcurrentLfuCore<K, V, N, P, E> cache, LfuNode<K, V> node, ItemRemovedReason reason)

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -690,7 +690,7 @@ namespace BitFaster.Caching.Lfu
                 {
                     // if a write is in the buffer and is then removed in the buffer, it will enter OnWrite twice.
                     // we mark as deleted to avoid double counting/disposing it
-                    EventInliner.OnRemovedEvent(this, node, ItemRemovedReason.Evicted);
+                    EventInliner.OnRemovedEvent(this, node, ItemRemovedReason.Removed);
                     this.metrics.evictedCount++;
                     Disposer<V>.Dispose(node.Value);
                     node.WasDeleted = true;

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -406,7 +406,7 @@ namespace BitFaster.Caching.Lfu
 
             return false;
         }
-        
+
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool TryUpdateValue(N node, V value)

--- a/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
@@ -201,11 +201,8 @@ namespace BitFaster.Caching.Lfu
 
         // To get JIT optimizations, policies must be structs.
         // If the structs are returned directly via properties, they will be copied. Since
-        // eventPolicy is a mutable struct, copy is bad. One workaround is to store the
-        // state within the struct in an object. Since the struct points to the same object
-        // it becomes immutable. However, this object is then somewhere else on the
-        // heap, which slows down the policies with hit counter logic in benchmarks. Likely
-        // this approach keeps the structs data members in the same CPU cache line as the LFU.
+        // eventPolicy is a mutable struct, copy is bad since changes are lost.
+        // Hence it is returned by ref and mutated via Proxy.
         private class Proxy : ICacheEvents<K, V>
         {
             private readonly ConcurrentTLfu<K, V> lfu;

--- a/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
@@ -13,16 +13,20 @@ namespace BitFaster.Caching.Lfu
         where K : notnull
     {
         // Note: for performance reasons this is a mutable struct, it cannot be readonly.
-        private ConcurrentLfuCore<K, V, TimeOrderNode<K, V>, ExpireAfterPolicy<K, V>> core;
+        private ConcurrentLfuCore<K, V, TimeOrderNode<K, V>, ExpireAfterPolicy<K, V, EventPolicy<K, V>>, EventPolicy<K, V>> core;
 
         public ConcurrentTLfu(int capacity, IExpiryCalculator<K, V> expiryCalculator)
         {
-            this.core = new(Defaults.ConcurrencyLevel, capacity, new ThreadPoolScheduler(), EqualityComparer<K>.Default, () => this.DrainBuffers(), new(expiryCalculator));
+            EventPolicy<K, V> eventPolicy = default;
+            eventPolicy.SetEventSource(this);
+            this.core = new(Defaults.ConcurrencyLevel, capacity, new ThreadPoolScheduler(), EqualityComparer<K>.Default, () => this.DrainBuffers(), new(expiryCalculator), eventPolicy);
         }
 
         public ConcurrentTLfu(int concurrencyLevel, int capacity, IScheduler scheduler, IEqualityComparer<K> comparer, IExpiryCalculator<K, V> expiryCalculator)
         {
-            this.core = new(concurrencyLevel, capacity, scheduler, comparer, () => this.DrainBuffers(), new(expiryCalculator));
+            EventPolicy<K, V> eventPolicy = default;
+            eventPolicy.SetEventSource(this);
+            this.core = new(concurrencyLevel, capacity, scheduler, comparer, () => this.DrainBuffers(), new(expiryCalculator), eventPolicy);
         }
 
         // structs cannot declare self referencing lambda functions, therefore pass this in from the ctor
@@ -38,7 +42,7 @@ namespace BitFaster.Caching.Lfu
         public Optional<ICacheMetrics> Metrics => core.Metrics;
 
         ///<inheritdoc/>
-        public Optional<ICacheEvents<K, V>> Events => Optional<ICacheEvents<K, V>>.None();
+        public Optional<ICacheEvents<K, V>> Events => new(core.eventPolicy);
 
         ///<inheritdoc/>
         public CachePolicy Policy => CreatePolicy();

--- a/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentTLfu.cs
@@ -79,7 +79,6 @@ namespace BitFaster.Caching.Lfu
         public void Clear()
         {
             core.Clear();
-            DoMaintenance();
         }
 
         ///<inheritdoc/>
@@ -113,7 +112,6 @@ namespace BitFaster.Caching.Lfu
         public void Trim(int itemCount)
         {
             core.Trim(itemCount);
-            DoMaintenance();
         }
 
         ///<inheritdoc/>
@@ -255,11 +253,13 @@ namespace BitFaster.Caching.Lfu
 
             public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
             {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 add
                 {
                     ref var policy = ref this.lfu.EventPolicyRef;
                     policy.ItemRemoved += value;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 remove
                 {
                     ref var policy = ref this.lfu.EventPolicyRef;
@@ -271,11 +271,13 @@ namespace BitFaster.Caching.Lfu
 #if NETCOREAPP3_0_OR_GREATER
             public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
             {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 add
                 {
                     ref var policy = ref this.lfu.EventPolicyRef;
                     policy.ItemUpdated += value;
                 }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
                 remove
                 {
                     ref var policy = ref this.lfu.EventPolicyRef;

--- a/BitFaster.Caching/Lfu/EventPolicy.cs
+++ b/BitFaster.Caching/Lfu/EventPolicy.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Diagnostics;
+using BitFaster.Caching.Counters;
+
+namespace BitFaster.Caching.Lfu
+{
+    /// <summary>
+    /// Represents an event policy with events.
+    /// </summary>
+    /// <typeparam name="K">The type of the Key</typeparam>
+    /// <typeparam name="V">The type of the value</typeparam>
+    [DebuggerDisplay("Upd = {Updated}, Evict = {Evicted}")]
+    public struct EventPolicy<K, V> : IEventPolicy<K, V>
+        where K : notnull
+    {
+        private Counter evictedCount;
+        private Counter updatedCount;
+        private object eventSource;
+
+        ///<inheritdoc/>
+        public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved;
+
+        ///<inheritdoc/>
+        public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated;
+
+        ///<inheritdoc/>
+        public long Evicted => this.evictedCount.Count();
+
+        ///<inheritdoc/>
+        public long Updated => this.updatedCount.Count();
+
+        ///<inheritdoc/>
+        public void OnItemRemoved(K key, V value, ItemRemovedReason reason)
+        {
+            if (reason == ItemRemovedReason.Evicted)
+            {
+                this.evictedCount.Increment();
+            }
+
+            // passing 'this' as source boxes the struct, and is anyway the wrong object
+            this.ItemRemoved?.Invoke(this.eventSource, new ItemRemovedEventArgs<K, V>(key, value, reason));
+        }
+
+        ///<inheritdoc/>
+        public void OnItemUpdated(K key, V oldValue, V newValue)
+        {
+            this.updatedCount.Increment();
+
+            // passing 'this' as source boxes the struct, and is anyway the wrong object
+            this.ItemUpdated?.Invoke(this.eventSource, new ItemUpdatedEventArgs<K, V>(key, oldValue, newValue));
+        }
+
+        ///<inheritdoc/>
+        public void SetEventSource(object source)
+        {
+            this.evictedCount = new Counter();
+            this.updatedCount = new Counter();
+            this.eventSource = source;
+        }
+    }
+}

--- a/BitFaster.Caching/Lfu/EventPolicy.cs
+++ b/BitFaster.Caching/Lfu/EventPolicy.cs
@@ -10,7 +10,7 @@ namespace BitFaster.Caching.Lfu
     /// <typeparam name="K">The type of the Key</typeparam>
     /// <typeparam name="V">The type of the value</typeparam>
     [DebuggerDisplay("Upd = {Updated}, Evict = {Evicted}")]
-    public struct EventPolicy<K, V> : IEventPolicy<K, V>
+    internal struct EventPolicy<K, V> : IEventPolicy<K, V>
         where K : notnull
     {
         private object eventSource;

--- a/BitFaster.Caching/Lfu/EventPolicy.cs
+++ b/BitFaster.Caching/Lfu/EventPolicy.cs
@@ -13,8 +13,6 @@ namespace BitFaster.Caching.Lfu
     public struct EventPolicy<K, V> : IEventPolicy<K, V>
         where K : notnull
     {
-        private Counter evictedCount;
-        private Counter updatedCount;
         private object eventSource;
 
         ///<inheritdoc/>
@@ -24,19 +22,8 @@ namespace BitFaster.Caching.Lfu
         public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated;
 
         ///<inheritdoc/>
-        public long Evicted => this.evictedCount.Count();
-
-        ///<inheritdoc/>
-        public long Updated => this.updatedCount.Count();
-
-        ///<inheritdoc/>
         public void OnItemRemoved(K key, V value, ItemRemovedReason reason)
         {
-            if (reason == ItemRemovedReason.Evicted)
-            {
-                this.evictedCount.Increment();
-            }
-
             // passing 'this' as source boxes the struct, and is anyway the wrong object
             this.ItemRemoved?.Invoke(this.eventSource, new ItemRemovedEventArgs<K, V>(key, value, reason));
         }
@@ -44,8 +31,6 @@ namespace BitFaster.Caching.Lfu
         ///<inheritdoc/>
         public void OnItemUpdated(K key, V oldValue, V newValue)
         {
-            this.updatedCount.Increment();
-
             // passing 'this' as source boxes the struct, and is anyway the wrong object
             this.ItemUpdated?.Invoke(this.eventSource, new ItemUpdatedEventArgs<K, V>(key, oldValue, newValue));
         }
@@ -53,8 +38,6 @@ namespace BitFaster.Caching.Lfu
         ///<inheritdoc/>
         public void SetEventSource(object source)
         {
-            this.evictedCount = new Counter();
-            this.updatedCount = new Counter();
             this.eventSource = source;
         }
     }

--- a/BitFaster.Caching/Lfu/IEventPolicy.cs
+++ b/BitFaster.Caching/Lfu/IEventPolicy.cs
@@ -6,7 +6,7 @@ namespace BitFaster.Caching.Lfu
     /// </summary>
     /// <typeparam name="K">The type of the key.</typeparam>
     /// <typeparam name="V">The type of the value.</typeparam>
-    public interface IEventPolicy<K, V> : ICacheEvents<K, V>
+    internal interface IEventPolicy<K, V> : ICacheEvents<K, V>
         where K : notnull
     {
         /// <summary>

--- a/BitFaster.Caching/Lfu/IEventPolicy.cs
+++ b/BitFaster.Caching/Lfu/IEventPolicy.cs
@@ -1,0 +1,37 @@
+﻿
+namespace BitFaster.Caching.Lfu
+{
+    /// <summary>
+    /// Represents an event policy.
+    /// </summary>
+    /// <typeparam name="K">The type of the key.</typeparam>
+    /// <typeparam name="V">The type of the value.</typeparam>
+    public interface IEventPolicy<K, V> : ICacheEvents<K, V>
+        where K : notnull
+    {
+        /// <summary>
+        /// Register the removal of an item.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="reason">The reason for removal.</param>
+        void OnItemRemoved(K key, V value, ItemRemovedReason reason);
+
+        // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+        /// <summary>
+        /// Register the update of an item.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="oldValue">The old value.</param>
+        /// <param name="value">The new value.</param>
+        void OnItemUpdated(K key, V oldValue, V value) {}
+#endif
+
+        /// <summary>
+        /// Set the event source for any events that are fired.
+        /// </summary>
+        /// <param name="source">The event source.</param>
+        void SetEventSource(object source);
+    }
+}

--- a/BitFaster.Caching/Lfu/IEventPolicy.cs
+++ b/BitFaster.Caching/Lfu/IEventPolicy.cs
@@ -25,7 +25,7 @@ namespace BitFaster.Caching.Lfu
         /// <param name="key">The key.</param>
         /// <param name="oldValue">The old value.</param>
         /// <param name="value">The new value.</param>
-        void OnItemUpdated(K key, V oldValue, V value) {}
+        void OnItemUpdated(K key, V oldValue, V value);
 #endif
 
         /// <summary>

--- a/BitFaster.Caching/Lfu/NoEventPolicy.cs
+++ b/BitFaster.Caching/Lfu/NoEventPolicy.cs
@@ -9,7 +9,7 @@ namespace BitFaster.Caching.Lfu
     /// </summary>
     /// <typeparam name="K">The type of the key.</typeparam>
     /// <typeparam name="V">The type of the value.</typeparam>
-    public struct NoEventPolicy<K, V> : IEventPolicy<K, V>
+    internal struct NoEventPolicy<K, V> : IEventPolicy<K, V>
         where K : notnull
     {
         ///<inheritdoc/>

--- a/BitFaster.Caching/Lfu/NoEventPolicy.cs
+++ b/BitFaster.Caching/Lfu/NoEventPolicy.cs
@@ -13,12 +13,6 @@ namespace BitFaster.Caching.Lfu
         where K : notnull
     {
         ///<inheritdoc/>
-        public long Updated => 0;
-
-        ///<inheritdoc/>
-        public long Evicted => 0;
-
-        ///<inheritdoc/>
         public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
         {
             // no-op, nothing is registered

--- a/BitFaster.Caching/Lfu/NoEventPolicy.cs
+++ b/BitFaster.Caching/Lfu/NoEventPolicy.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace BitFaster.Caching.Lfu
+{
+    /// <summary>
+    /// Represents an event policy that does not have events (is disabled).
+    /// This enables use of the cache without events where maximum performance is required.
+    /// </summary>
+    /// <typeparam name="K">The type of the key.</typeparam>
+    /// <typeparam name="V">The type of the value.</typeparam>
+    public struct NoEventPolicy<K, V> : IEventPolicy<K, V>
+        where K : notnull
+    {
+        ///<inheritdoc/>
+        public long Updated => 0;
+
+        ///<inheritdoc/>
+        public long Evicted => 0;
+
+        ///<inheritdoc/>
+        public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
+        {
+            // no-op, nothing is registered
+            add { }
+            remove { }
+        }
+
+        ///<inheritdoc/>
+        public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
+        {
+            // no-op, nothing is registered
+            add { }
+            remove { }
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnItemRemoved(K key, V value, ItemRemovedReason reason)
+        {
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnItemUpdated(K key, V oldValue, V value)
+        {
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetEventSource(object source)
+        {
+        }
+    }
+}

--- a/BitFaster.Caching/Lfu/NodePolicy.cs
+++ b/BitFaster.Caching/Lfu/NodePolicy.cs
@@ -142,7 +142,7 @@ namespace BitFaster.Caching.Lfu
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, TimeOrderNode<K, V>, P, E> cache) where P : struct, INodePolicy<K, V, TimeOrderNode<K, V>, E>
         {
-            wheel.Advance(ref cache, Duration.SinceEpoch());
+            wheel.Advance<TimeOrderNode<K, V>, P, TimeOrderNode<K, V>, E>(ref cache, Duration.SinceEpoch());
         }
     }
 }

--- a/BitFaster.Caching/Lfu/TimerWheel.cs
+++ b/BitFaster.Caching/Lfu/TimerWheel.cs
@@ -135,7 +135,7 @@ namespace BitFaster.Caching.Lfu
                     {
                         if ((node.GetTimestamp() - time) < 0)
                         {
-                            cache.Evict(node);
+                            cache.Evict(node, ItemRemovedReason.Evicted);
                         }
                         else
                         {

--- a/BitFaster.Caching/Lfu/TimerWheel.cs
+++ b/BitFaster.Caching/Lfu/TimerWheel.cs
@@ -61,9 +61,10 @@ namespace BitFaster.Caching.Lfu
         /// </summary>
         /// <param name="cache"></param>
         /// <param name="currentTime"></param>
-        public void Advance<N, P>(ref ConcurrentLfuCore<K, V, N, P> cache, Duration currentTime)
+        public void Advance<N, P, E>(ref ConcurrentLfuCore<K, V, N, P, E> cache, Duration currentTime)
             where N : LfuNode<K, V>
-            where P : struct, INodePolicy<K, V, N>
+            where P : struct, INodePolicy<K, V, N, E>
+            where E : struct, IEventPolicy<K, V>
         {
             long previousTime = time;
             time = currentTime.raw;
@@ -101,9 +102,10 @@ namespace BitFaster.Caching.Lfu
         }
 
         // Expires entries or reschedules into the proper bucket if still active.
-        private void Expire<N, P>(ref ConcurrentLfuCore<K, V, N, P> cache, int index, long previousTicks, long delta)
+        private void Expire<N, P, E>(ref ConcurrentLfuCore<K, V, N, P, E> cache, int index, long previousTicks, long delta)
             where N : LfuNode<K, V>
-            where P : struct, INodePolicy<K, V, N>
+            where P : struct, INodePolicy<K, V, N, E>
+            where E : struct, IEventPolicy<K, V>
         {
             TimeOrderNode<K, V>[] timerWheel = wheels[index];
             int mask = timerWheel.Length - 1;

--- a/BitFaster.Caching/Lfu/TimerWheel.cs
+++ b/BitFaster.Caching/Lfu/TimerWheel.cs
@@ -52,7 +52,7 @@ namespace BitFaster.Caching.Lfu
 
                 for (int j = 0; j < wheels[i].Length; j++)
                 {
-                    wheels[i][j] = TimeOrderNode< K, V>.CreateSentinel();
+                    wheels[i][j] = TimeOrderNode<K, V>.CreateSentinel();
                 }
             }
         }
@@ -86,12 +86,12 @@ namespace BitFaster.Caching.Lfu
                     long previousTicks = (long)(((ulong)previousTime) >> TimerWheel.Shift[i]);
                     long currentTicks = (long)(((ulong)currentTime.raw) >> TimerWheel.Shift[i]);
                     long delta = (currentTicks - previousTicks);
-                    
+
                     if (delta <= 0L)
                     {
                         break;
                     }
-                    
+
                     Expire<N, P, T, E>(ref cache, i, previousTicks, delta);
                 }
             }
@@ -284,7 +284,7 @@ namespace BitFaster.Caching.Lfu
             TimeOrderNode<K, V> sentinel = timerWheel[probe];
             TimeOrderNode<K, V> next = sentinel.GetNextInTimeOrder();
 
-            return (next == sentinel) ? long.MaxValue: (TimerWheel.Spans[index] - (time & spanMask));
+            return (next == sentinel) ? long.MaxValue : (TimerWheel.Spans[index] - (time & spanMask));
         }
     }
 }

--- a/Tools/bench.bat
+++ b/Tools/bench.bat
@@ -23,4 +23,4 @@ shift
 goto parse_args
 
 :run
-dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net9.0 -- --runtimes %RUNTIMES% %EXTRA_ARGS%
+dotnet run -c Release --project BitFaster.Caching.Benchmarks --framework net10.0 -- --runtimes %RUNTIMES% %EXTRA_ARGS%


### PR DESCRIPTION
This PR implements events for `ConcurrentLfu` as a switchable policy. When disabled all event code is fully elided at runtime by the JIT compiler.

Events are considered perf critical in `ConcurrentLfu` because the ItemRemoved logic is invoked as part of the maintenance cycle, this introduces overhead even when there are no events registered. The Maintenance method latency determines cache throughput at the limit, so any overhead here is not desired. Later, these events could be captured in a list and processed asynchronously via the scheduler.

In this implementation, calling `TryRemove` defers event processing to the maintenance cycle (thus `TryRemove` and policy based eviction behave the same), whereas `TryUpdate` executes the event handler immediately when `TryUpdate` is called. 

Based on this earlier PR: https://github.com/bitfaster/BitFaster.Caching/pull/727