### PR TITLE
define conc level by CPU count

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Lfu;
+using BitFaster.Caching.Lru;
 using BitFaster.Caching.Scheduler;
 using BitFaster.Caching.UnitTests.Lru;
 using FluentAssertions;
@@ -66,9 +67,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
 #if NET8_0_OR_GREATER
         // -1 is default conc level on .NET 8+. This can cause invalid striped buffer size without explicit handling.
         [Fact]
-        public void WhenConcurrencyIsNegativeOneCacheIsCreated()
+        public void WhenConcurrencyIsNegativeOneReadBufferIsCorrectSize()
         {
             var x = new ConcurrentLfu<int, string>(-1, 20, new ForegroundScheduler(), EqualityComparer<int>.Default);
+            x.Core.readBuffer.Capacity.Should().Be(BitOps.CeilingPowerOfTwo(Defaults.ConcurrencyLevel) * 128);
         }
 #endif
 

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuTests.cs
@@ -56,12 +56,21 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
-        public void WhenConcurrencyIsLessThan1CtorThrows()
+        public void WhenConcurrencyIsZeroCtorThrows()
         {
             Action constructor = () => { var x = new ConcurrentLfu<int, string>(0, 20, new ForegroundScheduler(), EqualityComparer<int>.Default); };
 
             constructor.Should().Throw<ArgumentOutOfRangeException>();
         }
+
+#if NET8_0_OR_GREATER
+        // -1 is default conc level on .NET 8+. This can cause invalid striped buffer size without explicit handling.
+        [Fact]
+        public void WhenConcurrencyIsNegativeOneCacheIsCreated()
+        {
+            var x = new ConcurrentLfu<int, string>(-1, 20, new ForegroundScheduler(), EqualityComparer<int>.Default);
+        }
+#endif
 
         [Fact]
         public void DefaultSchedulerIsThreadPool()

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 using BitFaster.Caching.Buffers;
 using BitFaster.Caching.Counters;
 using BitFaster.Caching.Scheduler;
+using BitFaster.Caching.Lru;
+
 
 #if DEBUG
 using System.Text;
@@ -95,6 +97,14 @@ namespace BitFaster.Caching.Lfu
 
             int dictionaryCapacity = ConcurrentDictionarySize.Estimate(capacity);
             this.dictionary = new(concurrencyLevel, dictionaryCapacity, comparer);
+
+            // On .NET 8+, -1 can be used for default conc level. concurrencyLevel is guarded by the dictionary ctor that will not throw in this case.
+#if NET8_0_OR_GREATER
+            if (concurrencyLevel == -1)
+            { 
+                concurrencyLevel = Defaults.ConcurrencyLevel;
+            }
+#endif
 
             // cap concurrency at proc count * 2
             int readStripes = Math.Min(BitOps.CeilingPowerOfTwo(concurrencyLevel), BitOps.CeilingPowerOfTwo(Environment.ProcessorCount * 2));

--- a/BitFaster.Caching/Lru/Defaults.cs
+++ b/BitFaster.Caching/Lru/Defaults.cs
@@ -4,11 +4,6 @@ namespace BitFaster.Caching.Lru
 {
     internal static class Defaults
     {
-#if NET8_0_OR_GREATER
-        // Note that on .net8+, -1 indicates the default concurrency level
-        public static int ConcurrencyLevel => -1;
-#else
         public static int ConcurrencyLevel => Environment.ProcessorCount;
-#endif
     }
 }


### PR DESCRIPTION
Revert the change made in https://github.com/bitfaster/BitFaster.Caching/pull/692.

Since LFU striped buffer configuration is determined by concurrency level, -1 is not correct when the host machine has many CPU cores.

Instead accept -1 as the default, and internally detect this and convert it to processor count for striped buffer.