### PR TITLE
Add weight-based eviction to ConcurrentLfu

### DIFF
--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
@@ -577,25 +577,45 @@ namespace BitFaster.Caching.UnitTests.Lfu
         }
 
         [Fact]
-        public void WithWeigherAndEventsThrows()
+        public void WithWeigherAndEventsBuildsWeightedCacheWithEvents()
         {
-            var builder = new ConcurrentLfuBuilder<int, int>()
+            ICache<int, int> weighted = new ConcurrentLfuBuilder<int, int>()
+                .WithCapacity(100)
                 .WithWeigher(new IntValueWeigher())
-                .WithEvents();
+                .WithEvents()
+                .Build();
 
-            Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            weighted.Should().BeAssignableTo<WeightedConcurrentLfu<int, int, WeightedAccessOrderNode<int, int>, WeightedAccessOrderPolicy<int, int, EventPolicy<int, int>>>>();
+            weighted.Events.HasValue.Should().BeTrue();
         }
 
         [Fact]
-        public void WithWeigherAndExpireAfterWriteThrows()
+        public void WithWeigherAndExpireAfterWriteBuildsWeightedCacheWithExpiry()
         {
-            var builder = new ConcurrentLfuBuilder<int, int>()
+            ICache<int, int> weighted = new ConcurrentLfuBuilder<int, int>()
+                .WithCapacity(100)
                 .WithWeigher(new IntValueWeigher())
-                .WithExpireAfterWrite(TimeSpan.FromSeconds(1));
+                .WithExpireAfterWrite(TimeSpan.FromSeconds(1))
+                .Build();
 
-            Action act = () => builder.Build();
-            act.Should().Throw<InvalidOperationException>();
+            weighted.Should().BeAssignableTo<FastConcurrentLfu<int, int, WeightedTimeOrderNode<int, int>, WeightedExpireAfterPolicy<int, int, NoEventPolicy<int, int>>>>();
+            weighted.Policy.ExpireAfterWrite.HasValue.Should().BeTrue();
+            weighted.Policy.ExpireAfterWrite.Value.TimeToLive.Should().Be(TimeSpan.FromSeconds(1));
+        }
+
+        [Fact]
+        public void WithWeigherAndExpireAfterWriteAndEventsBuildsWeightedCache()
+        {
+            ICache<int, int> weighted = new ConcurrentLfuBuilder<int, int>()
+                .WithCapacity(100)
+                .WithWeigher(new IntValueWeigher())
+                .WithExpireAfterWrite(TimeSpan.FromSeconds(1))
+                .WithEvents()
+                .Build();
+
+            weighted.Should().BeAssignableTo<WeightedConcurrentLfu<int, int, WeightedTimeOrderNode<int, int>, WeightedExpireAfterPolicy<int, int, EventPolicy<int, int>>>>();
+            weighted.Policy.ExpireAfterWrite.HasValue.Should().BeTrue();
+            weighted.Events.HasValue.Should().BeTrue();
         }
 
         private sealed class IntValueWeigher : IWeigher<int, int>

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
@@ -618,9 +618,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
             weighted.Events.HasValue.Should().BeTrue();
         }
 
-        private sealed class IntValueWeigher : IWeigher<int, int>
+        private sealed class IntValueWeigher : IWeightCalculator<int, int>
         {
-            public int Weigh(int key, int value) => value;
+            public int GetWeight(int key, int value) => value;
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuBuilderTests.cs
@@ -560,5 +560,47 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
             lru.Should().BeAssignableTo<IScopedAsyncCache<int, Disposable>>();
         }
+
+        [Fact]
+        public void WithWeigherBuildsWeightedCache()
+        {
+            ICache<int, int> weighted = new ConcurrentLfuBuilder<int, int>()
+                .WithCapacity(100)
+                .WithWeigher(new IntValueWeigher())
+                .Build();
+
+            weighted.Should().BeAssignableTo<FastConcurrentLfu<int, int, WeightedAccessOrderNode<int, int>, WeightedAccessOrderPolicy<int, int, NoEventPolicy<int, int>>>>();
+
+            weighted.GetOrAdd(1, k => 5);
+            weighted.TryGet(1, out var value).Should().BeTrue();
+            value.Should().Be(5);
+        }
+
+        [Fact]
+        public void WithWeigherAndEventsThrows()
+        {
+            var builder = new ConcurrentLfuBuilder<int, int>()
+                .WithWeigher(new IntValueWeigher())
+                .WithEvents();
+
+            Action act = () => builder.Build();
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void WithWeigherAndExpireAfterWriteThrows()
+        {
+            var builder = new ConcurrentLfuBuilder<int, int>()
+                .WithWeigher(new IntValueWeigher())
+                .WithExpireAfterWrite(TimeSpan.FromSeconds(1));
+
+            Action act = () => builder.Build();
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        private sealed class IntValueWeigher : IWeigher<int, int>
+        {
+            public int Weigh(int key, int value) => value;
+        }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuCoreTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuCoreTests.cs
@@ -219,9 +219,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
             weighted?.DoMaintenance();
         }
 
-        private sealed class UnitWeigher<K, V> : IWeigher<K, V>
+        private sealed class UnitWeigher<K, V> : IWeightCalculator<K, V>
         {
-            public int Weigh(K key, V value) => 1;
+            public int GetWeight(K key, V value) => 1;
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuCoreTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuCoreTests.cs
@@ -200,4 +200,28 @@ namespace BitFaster.Caching.UnitTests.Lfu
             tlfu?.DoMaintenance();
         }
     }
+
+    public class WeightedConcurrentLfuWrapperTests : ConcurrentLfuCoreTests
+    {
+        public override ICache<K, V> Create<K, V>()
+        {
+            return new ConcurrentLfuBuilder<K, V>()
+                .WithCapacity(capacity)
+                .WithConcurrencyLevel(1)
+                .WithWeigher(new UnitWeigher<K, V>())
+                .WithEvents()
+                .Build();
+        }
+
+        public override void DoMaintenance<K, V>(ICache<K, V> cache)
+        {
+            var weighted = cache as WeightedConcurrentLfu<K, V, WeightedAccessOrderNode<K, V>, WeightedAccessOrderPolicy<K, V, EventPolicy<K, V>>>;
+            weighted?.DoMaintenance();
+        }
+
+        private sealed class UnitWeigher<K, V> : IWeigher<K, V>
+        {
+            public int Weigh(K key, V value) => 1;
+        }
+    }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -256,6 +256,46 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
         [Theory]
         [Repeat(soakIterations)]
+        public async Task WhenConcurrentWeightedGetUpdateRemoveCacheEndsInConsistentState()
+        {
+            var cache = new ConcurrentLfuBuilder<int, string>()
+                .WithConcurrencyLevel(threads)
+                .WithCapacity(9)
+                .WithScheduler(new BackgroundThreadScheduler())
+                .WithWeigher(new StringLengthWeigher())
+                .WithEvents()
+                .Build();
+
+            await Threaded.Run(threads, () =>
+            {
+                for (int i = 0; i < loopIterations; i++)
+                {
+                    int k = i % 100;
+                    cache.GetOrAdd(k, x => x.ToString());
+                    cache.TryUpdate(k, "updated");
+
+                    if ((i & 7) == 0)
+                    {
+                        cache.TryRemove(k);
+                    }
+                }
+            });
+
+            var weighted = (WeightedConcurrentLfu<int, string, WeightedAccessOrderNode<int, string>, WeightedAccessOrderPolicy<int, string, EventPolicy<int, string>>>)cache;
+            new ConcurrentLfuIntegrityChecker<int, string, WeightedAccessOrderNode<int, string>, WeightedAccessOrderPolicy<int, string, EventPolicy<int, string>>, EventPolicy<int, string>>(weighted.Core).Validate(output);
+
+            // weighted invariant: total weight is non-negative and bounded by the weight capacity
+            weighted.Core.WeightedSize.Should().BeGreaterThanOrEqualTo(0);
+            weighted.Core.WeightedSize.Should().BeLessThanOrEqualTo(weighted.Capacity);
+        }
+
+        private sealed class StringLengthWeigher : IWeigher<int, string>
+        {
+            public int Weigh(int key, string value) => value.Length;
+        }
+
+        [Theory]
+        [Repeat(soakIterations)]
         public async Task WhenConcurrentGetAndRemoveKvpCacheEndsInConsistentState(int iteration)
         {
             var lfu = CreateWithBackgroundScheduler();

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -291,9 +291,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
             weighted.Core.WeightedSize.Should().BeLessThanOrEqualTo(weighted.Capacity);
         }
 
-        private sealed class StringLengthWeigher : IWeigher<int, string>
+        private sealed class StringLengthWeigher : IWeightCalculator<int, string>
         {
-            public int Weigh(int key, string value) => value.Length;
+            public int GetWeight(int key, string value) => value.Length;
         }
 
         [Theory]

--- a/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/ConcurrentLfuSoakTests.cs
@@ -256,8 +256,10 @@ namespace BitFaster.Caching.UnitTests.Lfu
 
         [Theory]
         [Repeat(soakIterations)]
-        public async Task WhenConcurrentWeightedGetUpdateRemoveCacheEndsInConsistentState()
+        public async Task WhenConcurrentWeightedGetUpdateRemoveCacheEndsInConsistentState(int iteration)
         {
+            this.output.WriteLine($"Weighted soak iteration {iteration}.");
+
             var cache = new ConcurrentLfuBuilder<int, string>()
                 .WithConcurrencyLevel(threads)
                 .WithCapacity(9)

--- a/BitFaster.Caching.UnitTests/Lfu/WeightedNodePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/WeightedNodePolicyTests.cs
@@ -18,7 +18,7 @@ namespace BitFaster.Caching.UnitTests.Lfu
             core = CreateWeighted(Capacity, new ValueWeigher());
         }
 
-        private static ConcurrentLfuCore<int, int, WeightedAccessOrderNode<int, int>, WeightedAccessOrderPolicy<int, int, NoEventPolicy<int, int>>, NoEventPolicy<int, int>> CreateWeighted(int capacity, IWeigher<int, int> weigher)
+        private static ConcurrentLfuCore<int, int, WeightedAccessOrderNode<int, int>, WeightedAccessOrderPolicy<int, int, NoEventPolicy<int, int>>, NoEventPolicy<int, int>> CreateWeighted(int capacity, IWeightCalculator<int, int> weigher)
         {
             var policy = new WeightedAccessOrderPolicy<int, int, NoEventPolicy<int, int>>(weigher);
             return new(1, capacity, new NullScheduler(), EqualityComparer<int>.Default, () => { }, policy, default);
@@ -207,9 +207,9 @@ namespace BitFaster.Caching.UnitTests.Lfu
             cache.Policy.ExpireAfterWrite.Value.TimeToLive.Should().Be(TimeSpan.FromMinutes(10));
         }
 
-        private sealed class ValueWeigher : IWeigher<int, int>
+        private sealed class ValueWeigher : IWeightCalculator<int, int>
         {
-            public int Weigh(int key, int value) => value;
+            public int GetWeight(int key, int value) => value;
         }
     }
 }

--- a/BitFaster.Caching.UnitTests/Lfu/WeightedNodePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/WeightedNodePolicyTests.cs
@@ -131,6 +131,41 @@ namespace BitFaster.Caching.UnitTests.Lfu
             core.MainProtectedWeightedSize.Should().Be(10);
         }
 
+        [Fact]
+        public void WhenRecencyWorkloadWindowMaximumIncreasesAndInvariantHolds()
+        {
+            var weighted = CreateWeighted(200, new ValueWeigher());
+
+            for (int i = 0; i < 10; i++)
+            {
+                weighted.AddOrUpdate(i, 10);
+            }
+            weighted.DoMaintenance();
+            long initialWindowMaximum = weighted.WindowMaximum;
+
+            // a steady stream of hits on resident items drives the hill climber to grow the window
+            for (int round = 0; round < 100; round++)
+            {
+                for (int r = 0; r < 15; r++)
+                {
+                    for (int i = 0; i < 10; i++)
+                    {
+                        weighted.TryGet(i, out _);
+                    }
+                }
+                weighted.DoMaintenance();
+            }
+
+            weighted.WindowMaximum.Should().BeGreaterThan(initialWindowMaximum);
+
+            // invariants must hold throughout adaptation
+            weighted.WeightedSize.Should().BeLessThanOrEqualTo(200);
+            weighted.WindowWeightedSize.Should().BeGreaterThanOrEqualTo(0);
+            weighted.MainProtectedWeightedSize.Should().BeGreaterThanOrEqualTo(0);
+            weighted.WindowMaximum.Should().BeGreaterThanOrEqualTo(1);
+            weighted.MainProtectedMaximum.Should().BeGreaterThanOrEqualTo(0);
+        }
+
         private sealed class ValueWeigher : IWeigher<int, int>
         {
             public int Weigh(int key, int value) => value;

--- a/BitFaster.Caching.UnitTests/Lfu/WeightedNodePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/WeightedNodePolicyTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using BitFaster.Caching.Lfu;
 using BitFaster.Caching.Scheduler;
 using FluentAssertions;
@@ -164,6 +165,46 @@ namespace BitFaster.Caching.UnitTests.Lfu
             weighted.MainProtectedWeightedSize.Should().BeGreaterThanOrEqualTo(0);
             weighted.WindowMaximum.Should().BeGreaterThanOrEqualTo(1);
             weighted.MainProtectedMaximum.Should().BeGreaterThanOrEqualTo(0);
+        }
+
+        [Fact]
+        public void WhenWeightedItemEvictedRemovedEventFires()
+        {
+            var removed = new List<ItemRemovedEventArgs<int, int>>();
+            var cache = new ConcurrentLfuBuilder<int, int>()
+                .WithCapacity(100)
+                .WithConcurrencyLevel(1)
+                .WithWeigher(new ValueWeigher())
+                .WithEvents()
+                .Build();
+            cache.Events.Value.ItemRemoved += (s, e) => removed.Add(e);
+
+            // weight 30 each, total 300 exceeds the weight capacity of 100
+            for (int i = 0; i < 10; i++)
+            {
+                cache.GetOrAdd(i, k => 30);
+            }
+
+            var weighted = cache as WeightedConcurrentLfu<int, int, WeightedAccessOrderNode<int, int>, WeightedAccessOrderPolicy<int, int, EventPolicy<int, int>>>;
+            weighted!.DoMaintenance();
+
+            removed.Should().NotBeEmpty();
+            removed.Should().OnlyContain(e => e.Reason == ItemRemovedReason.Evicted);
+        }
+
+        [Fact]
+        public void WhenWeightedWithExpiryTimeToExpireIsReturned()
+        {
+            var cache = new ConcurrentLfuBuilder<int, int>()
+                .WithCapacity(100)
+                .WithWeigher(new ValueWeigher())
+                .WithExpireAfterWrite(TimeSpan.FromMinutes(10))
+                .Build();
+
+            cache.GetOrAdd(1, k => 10);
+
+            cache.Policy.ExpireAfterWrite.HasValue.Should().BeTrue();
+            cache.Policy.ExpireAfterWrite.Value.TimeToLive.Should().Be(TimeSpan.FromMinutes(10));
         }
 
         private sealed class ValueWeigher : IWeigher<int, int>

--- a/BitFaster.Caching.UnitTests/Lfu/WeightedNodePolicyTests.cs
+++ b/BitFaster.Caching.UnitTests/Lfu/WeightedNodePolicyTests.cs
@@ -1,0 +1,139 @@
+﻿using System.Collections.Generic;
+using BitFaster.Caching.Lfu;
+using BitFaster.Caching.Scheduler;
+using FluentAssertions;
+using Xunit;
+
+namespace BitFaster.Caching.UnitTests.Lfu
+{
+    public class WeightedNodePolicyTests
+    {
+        private const int Capacity = 100;
+
+        private ConcurrentLfuCore<int, int, WeightedAccessOrderNode<int, int>, WeightedAccessOrderPolicy<int, int, NoEventPolicy<int, int>>, NoEventPolicy<int, int>> core;
+
+        public WeightedNodePolicyTests()
+        {
+            core = CreateWeighted(Capacity, new ValueWeigher());
+        }
+
+        private static ConcurrentLfuCore<int, int, WeightedAccessOrderNode<int, int>, WeightedAccessOrderPolicy<int, int, NoEventPolicy<int, int>>, NoEventPolicy<int, int>> CreateWeighted(int capacity, IWeigher<int, int> weigher)
+        {
+            var policy = new WeightedAccessOrderPolicy<int, int, NoEventPolicy<int, int>>(weigher);
+            return new(1, capacity, new NullScheduler(), EqualityComparer<int>.Default, () => { }, policy, default);
+        }
+
+        [Fact]
+        public void WhenItemsAddedWithinCapacityWeightedSizeEqualsTotalWeight()
+        {
+            core.AddOrUpdate(1, 10);
+            core.AddOrUpdate(2, 20);
+            core.AddOrUpdate(3, 30);
+            core.DoMaintenance();
+
+            core.Count.Should().Be(3);
+            core.WeightedSize.Should().Be(60);
+        }
+
+        [Fact]
+        public void WhenTotalWeightExceedsCapacityWeightedSizeStaysWithinMaximum()
+        {
+            for (int i = 0; i < 20; i++)
+            {
+                core.AddOrUpdate(i, 30);
+            }
+            core.DoMaintenance();
+
+            core.WeightedSize.Should().BeLessThanOrEqualTo(Capacity);
+        }
+
+        [Fact]
+        public void WhenItemWeightExceedsMaximumItemIsEvicted()
+        {
+            core.AddOrUpdate(1, 200);
+            core.DoMaintenance();
+
+            core.TryGet(1, out _).Should().BeFalse();
+            core.Count.Should().Be(0);
+            core.WeightedSize.Should().Be(0);
+        }
+
+        [Fact]
+        public void WhenItemHasZeroWeightItIsNotEvicted()
+        {
+            core.AddOrUpdate(1, 0);
+            core.AddOrUpdate(2, 60);
+            core.AddOrUpdate(3, 60);
+            core.DoMaintenance();
+
+            core.TryGet(1, out _).Should().BeTrue();
+            core.WeightedSize.Should().BeLessThanOrEqualTo(Capacity);
+        }
+
+        [Fact]
+        public void WhenItemWeightIncreasedWeightedSizeIncreases()
+        {
+            core.AddOrUpdate(1, 30);
+            core.DoMaintenance();
+            core.WeightedSize.Should().Be(30);
+
+            core.AddOrUpdate(1, 50);
+            core.DoMaintenance();
+
+            core.TryGet(1, out _).Should().BeTrue();
+            core.WeightedSize.Should().Be(50);
+        }
+
+        [Fact]
+        public void WhenItemWeightDecreasedWeightedSizeDecreases()
+        {
+            core.AddOrUpdate(1, 80);
+            core.DoMaintenance();
+            core.WeightedSize.Should().Be(80);
+
+            core.AddOrUpdate(1, 10);
+            core.DoMaintenance();
+
+            core.TryGet(1, out _).Should().BeTrue();
+            core.WeightedSize.Should().Be(10);
+        }
+
+        [Fact]
+        public void WhenItemRemovedWeightedSizeIsDiscounted()
+        {
+            core.AddOrUpdate(1, 30);
+            core.AddOrUpdate(2, 40);
+            core.DoMaintenance();
+            core.WeightedSize.Should().Be(70);
+
+            core.TryRemove(1);
+            core.DoMaintenance();
+
+            core.WeightedSize.Should().Be(40);
+            core.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void WhenProbationItemReadItIsPromotedAndProtectedWeightTracked()
+        {
+            core.AddOrUpdate(1, 10);
+            core.AddOrUpdate(2, 20);
+            core.AddOrUpdate(3, 30);
+            core.DoMaintenance();
+
+            // read item 1 so it is promoted from probation to protected during maintenance
+            core.TryGet(1, out _);
+            core.TryGet(1, out _);
+            core.DoMaintenance();
+
+            core.TryGet(1, out _).Should().BeTrue();
+            core.WeightedSize.Should().Be(60);
+            core.MainProtectedWeightedSize.Should().Be(10);
+        }
+
+        private sealed class ValueWeigher : IWeigher<int, int>
+        {
+            public int Weigh(int key, int value) => value;
+        }
+    }
+}

--- a/BitFaster.Caching/IWeigher.cs
+++ b/BitFaster.Caching/IWeigher.cs
@@ -1,0 +1,20 @@
+﻿namespace BitFaster.Caching
+{
+    /// <summary>
+    /// Calculates the weight of cache entries. The total weight is used to bound the cache size,
+    /// and to determine when an eviction is required. Entry weights are relative to each other and
+    /// have no unit.
+    /// </summary>
+    /// <typeparam name="K">The type of keys.</typeparam>
+    /// <typeparam name="V">The type of values.</typeparam>
+    public interface IWeigher<K, V>
+    {
+        /// <summary>
+        /// Returns the weight of a cache entry. The weight must be non-negative.
+        /// </summary>
+        /// <param name="key">The key to weigh.</param>
+        /// <param name="value">The value to weigh.</param>
+        /// <returns>The weight of the entry.</returns>
+        int Weigh(K key, V value);
+    }
+}

--- a/BitFaster.Caching/IWeightCalculator.cs
+++ b/BitFaster.Caching/IWeightCalculator.cs
@@ -7,7 +7,7 @@
     /// </summary>
     /// <typeparam name="K">The type of keys.</typeparam>
     /// <typeparam name="V">The type of values.</typeparam>
-    public interface IWeigher<K, V>
+    public interface IWeightCalculator<K, V>
     {
         /// <summary>
         /// Returns the weight of a cache entry. The weight must be non-negative.
@@ -15,6 +15,6 @@
         /// <param name="key">The key to weigh.</param>
         /// <param name="value">The value to weigh.</param>
         /// <returns>The weight of the entry.</returns>
-        int Weigh(K key, V value);
+        int GetWeight(K key, V value);
     }
 }

--- a/BitFaster.Caching/Lfu/Builder/LfuInfo.cs
+++ b/BitFaster.Caching/Lfu/Builder/LfuInfo.cs
@@ -11,6 +11,8 @@ namespace BitFaster.Caching.Lfu.Builder
     {
         private object? expiry = null;
 
+        private object? weigher = null;
+
         public int Capacity { get; set; } = 128;
 
         public int ConcurrencyLevel { get; set; } = Defaults.ConcurrencyLevel;
@@ -40,6 +42,23 @@ namespace BitFaster.Caching.Lfu.Builder
                 Throw.InvalidOp($"Incompatible IExpiryCalculator value generic type argument, expected {typeof(IExpiryCalculator<K, V>)} but found {this.expiry.GetType()}");
 
             return e;
+        }
+
+        public void SetWeigher<V>(IWeigher<K, V> weigher) => this.weigher = weigher;
+
+        public IWeigher<K, V>? GetWeigher<V>()
+        {
+            if (this.weigher == null)
+            {
+                return null;
+            }
+
+            var w = this.weigher as IWeigher<K, V>;
+
+            if (w == null)
+                Throw.InvalidOp($"Incompatible IWeigher value generic type argument, expected {typeof(IWeigher<K, V>)} but found {this.weigher.GetType()}");
+
+            return w;
         }
 
         internal void ThrowIfExpirySpecified(string extensionName)

--- a/BitFaster.Caching/Lfu/Builder/LfuInfo.cs
+++ b/BitFaster.Caching/Lfu/Builder/LfuInfo.cs
@@ -44,19 +44,19 @@ namespace BitFaster.Caching.Lfu.Builder
             return e;
         }
 
-        public void SetWeigher<V>(IWeigher<K, V> weigher) => this.weigher = weigher;
+        public void SetWeigher<V>(IWeightCalculator<K, V> weigher) => this.weigher = weigher;
 
-        public IWeigher<K, V>? GetWeigher<V>()
+        public IWeightCalculator<K, V>? GetWeigher<V>()
         {
             if (this.weigher == null)
             {
                 return null;
             }
 
-            var w = this.weigher as IWeigher<K, V>;
+            var w = this.weigher as IWeightCalculator<K, V>;
 
             if (w == null)
-                Throw.InvalidOp($"Incompatible IWeigher value generic type argument, expected {typeof(IWeigher<K, V>)} but found {this.weigher.GetType()}");
+                Throw.InvalidOp($"Incompatible IWeightCalculator value generic type argument, expected {typeof(IWeightCalculator<K, V>)} but found {this.weigher.GetType()}");
 
             return w;
         }

--- a/BitFaster.Caching/Lfu/ConcurrentLfuBuilder.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuBuilder.cs
@@ -46,6 +46,19 @@ namespace BitFaster.Caching.Lfu
             return this;
         }
 
+        /// <summary>
+        /// Evict using a weighted size, where the weight of each item is calculated using the specified
+        /// IWeigher. The cache is bounded by the total weight of all items, and the capacity is interpreted
+        /// as the maximum total weight.
+        /// </summary>
+        /// <param name="weigher">The weigher that determines the weight of each item.</param>
+        /// <returns>A ConcurrentLfuBuilder</returns>
+        public ConcurrentLfuBuilder<K, V> WithWeigher(IWeigher<K, V> weigher)
+        {
+            this.info.SetWeigher(weigher);
+            return this;
+        }
+
         ///<inheritdoc/>
         public override ICache<K, V> Build()
         {
@@ -69,6 +82,13 @@ namespace BitFaster.Caching.Lfu
             if (info.TimeToExpireAfterAccess.HasValue && expiry != null)
                 Throw.InvalidOp("Specifying both ExpireAfterAccess and ExpireAfter is not supported.");
 
+            var weigher = info.GetWeigher<V>();
+
+            if (weigher != null)
+            {
+                return CreateWeighted<K, V>(info, weigher, expiry);
+            }
+
             return (info.TimeToExpireAfterWrite.HasValue, info.TimeToExpireAfterAccess.HasValue, expiry != null, info.WithEvents) switch
             {
                 // time expiry, with events
@@ -87,6 +107,18 @@ namespace BitFaster.Caching.Lfu
                 // no time expiry, with events
                 _ => new ConcurrentLfu<K, V>(info.ConcurrencyLevel, info.Capacity, info.Scheduler, info.KeyComparer)
             };
+        }
+
+        private static ICache<K, V> CreateWeighted<K, V>(LfuInfo<K> info, IWeigher<K, V> weigher, IExpiryCalculator<K, V>? expiry)
+            where K : notnull
+        {
+            // Weighted eviction without expiry or events.
+            // Weighted eviction composed with expiry or events is wired up in a later phase.
+            if (info.TimeToExpireAfterWrite.HasValue || info.TimeToExpireAfterAccess.HasValue || expiry != null || info.WithEvents)
+                Throw.InvalidOp("Weighted eviction is not yet supported in combination with expiry or events.");
+
+            return new FastConcurrentLfu<K, V, WeightedAccessOrderNode<K, V>, WeightedAccessOrderPolicy<K, V, NoEventPolicy<K, V>>>(
+                info.ConcurrencyLevel, info.Capacity, info.Scheduler, info.KeyComparer, new WeightedAccessOrderPolicy<K, V, NoEventPolicy<K, V>>(weigher));
         }
     }
 }

--- a/BitFaster.Caching/Lfu/ConcurrentLfuBuilder.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuBuilder.cs
@@ -48,12 +48,12 @@ namespace BitFaster.Caching.Lfu
 
         /// <summary>
         /// Evict using a weighted size, where the weight of each item is calculated using the specified
-        /// IWeigher. The cache is bounded by the total weight of all items, and the capacity is interpreted
+        /// IWeightCalculator. The cache is bounded by the total weight of all items, and the capacity is interpreted
         /// as the maximum total weight.
         /// </summary>
         /// <param name="weigher">The weigher that determines the weight of each item.</param>
         /// <returns>A ConcurrentLfuBuilder</returns>
-        public ConcurrentLfuBuilder<K, V> WithWeigher(IWeigher<K, V> weigher)
+        public ConcurrentLfuBuilder<K, V> WithWeigher(IWeightCalculator<K, V> weigher)
         {
             this.info.SetWeigher(weigher);
             return this;
@@ -109,7 +109,7 @@ namespace BitFaster.Caching.Lfu
             };
         }
 
-        private static ICache<K, V> CreateWeighted<K, V>(LfuInfo<K> info, IWeigher<K, V> weigher, IExpiryCalculator<K, V>? expiry)
+        private static ICache<K, V> CreateWeighted<K, V>(LfuInfo<K> info, IWeightCalculator<K, V> weigher, IExpiryCalculator<K, V>? expiry)
             where K : notnull
         {
             IExpiryCalculator<K, V>? calculator =

--- a/BitFaster.Caching/Lfu/ConcurrentLfuBuilder.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuBuilder.cs
@@ -112,13 +112,29 @@ namespace BitFaster.Caching.Lfu
         private static ICache<K, V> CreateWeighted<K, V>(LfuInfo<K> info, IWeigher<K, V> weigher, IExpiryCalculator<K, V>? expiry)
             where K : notnull
         {
-            // Weighted eviction without expiry or events.
-            // Weighted eviction composed with expiry or events is wired up in a later phase.
-            if (info.TimeToExpireAfterWrite.HasValue || info.TimeToExpireAfterAccess.HasValue || expiry != null || info.WithEvents)
-                Throw.InvalidOp("Weighted eviction is not yet supported in combination with expiry or events.");
+            IExpiryCalculator<K, V>? calculator =
+                info.TimeToExpireAfterWrite.HasValue ? new ExpireAfterWrite<K, V>(info.TimeToExpireAfterWrite.Value)
+                : info.TimeToExpireAfterAccess.HasValue ? new ExpireAfterAccess<K, V>(info.TimeToExpireAfterAccess.Value)
+                : expiry;
 
-            return new FastConcurrentLfu<K, V, WeightedAccessOrderNode<K, V>, WeightedAccessOrderPolicy<K, V, NoEventPolicy<K, V>>>(
-                info.ConcurrencyLevel, info.Capacity, info.Scheduler, info.KeyComparer, new WeightedAccessOrderPolicy<K, V, NoEventPolicy<K, V>>(weigher));
+            return (calculator != null, info.WithEvents) switch
+            {
+                // weighted, no expiry, no events
+                (false, false) => new FastConcurrentLfu<K, V, WeightedAccessOrderNode<K, V>, WeightedAccessOrderPolicy<K, V, NoEventPolicy<K, V>>>(
+                    info.ConcurrencyLevel, info.Capacity, info.Scheduler, info.KeyComparer, new WeightedAccessOrderPolicy<K, V, NoEventPolicy<K, V>>(weigher)),
+
+                // weighted, time expiry, no events
+                (true, false) => new FastConcurrentLfu<K, V, WeightedTimeOrderNode<K, V>, WeightedExpireAfterPolicy<K, V, NoEventPolicy<K, V>>>(
+                    info.ConcurrencyLevel, info.Capacity, info.Scheduler, info.KeyComparer, new WeightedExpireAfterPolicy<K, V, NoEventPolicy<K, V>>(weigher, calculator!)),
+
+                // weighted, no expiry, with events
+                (false, true) => new WeightedConcurrentLfu<K, V, WeightedAccessOrderNode<K, V>, WeightedAccessOrderPolicy<K, V, EventPolicy<K, V>>>(
+                    info.ConcurrencyLevel, info.Capacity, info.Scheduler, info.KeyComparer, new WeightedAccessOrderPolicy<K, V, EventPolicy<K, V>>(weigher)),
+
+                // weighted, time expiry, with events
+                (true, true) => new WeightedConcurrentLfu<K, V, WeightedTimeOrderNode<K, V>, WeightedExpireAfterPolicy<K, V, EventPolicy<K, V>>>(
+                    info.ConcurrencyLevel, info.Capacity, info.Scheduler, info.KeyComparer, new WeightedExpireAfterPolicy<K, V, EventPolicy<K, V>>(weigher, calculator!)),
+            };
         }
     }
 }

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -55,6 +55,12 @@ namespace BitFaster.Caching.Lfu
         private const double MainPercentage = 0.99d;
         private const double MainProtectedPercentage = 0.8d;
         private const int AdmitHashDosThreshold = 6;
+        private const double HillClimberStepPercent = 0.0625d;
+        private const double HillClimberStepDecay = 0.98d;
+        private const double HillClimberRestartThreshold = 0.05d;
+        private const double HillClimberMinStep = 2.0d;
+        private const long SmallCacheThreshold = 512;
+        private const int QueueTransferThreshold = 1000;
 
         private readonly ConcurrentDictionary<K, N> dictionary;
 
@@ -80,6 +86,10 @@ namespace BitFaster.Caching.Lfu
         private long maximum;
         private long windowMaximum;
         private long mainProtectedMaximum;
+        private double stepSize;
+        private double previousHitRate;
+        private long previousHitCount;
+        private long previousMissCount;
         private readonly Random? random;
 
         internal readonly DrainStatus drainStatus = new();
@@ -143,6 +153,9 @@ namespace BitFaster.Caching.Lfu
                 this.maximum = capacity;
                 this.windowMaximum = this.maximum - (long)(MainPercentage * this.maximum);
                 this.mainProtectedMaximum = (long)(MainProtectedPercentage * (this.maximum - this.windowMaximum));
+                this.previousHitRate = 1.0d;
+                double initialStep = Math.Max(HillClimberStepPercent * this.maximum, HillClimberMinStep);
+                this.stepSize = (this.maximum <= SmallCacheThreshold) ? initialStep : -initialStep;
                 this.random = new Random();
             }
 
@@ -166,6 +179,8 @@ namespace BitFaster.Caching.Lfu
         internal long WeightedSize => this.weightedSize;
         internal long WindowWeightedSize => this.windowWeightedSize;
         internal long MainProtectedWeightedSize => this.mainProtectedWeightedSize;
+        internal long WindowMaximum => this.windowMaximum;
+        internal long MainProtectedMaximum => this.mainProtectedMaximum;
 
         public Optional<ICacheMetrics> Metrics => new(this.metrics);
 
@@ -675,6 +690,7 @@ namespace BitFaster.Caching.Lfu
 
             if (IsWeighted)
             {
+                OptimizeWeightedPartitioning();
                 ReFitProtectedWeighted();
             }
             else
@@ -1183,6 +1199,152 @@ namespace BitFaster.Caching.Lfu
                 demoted.Position = Position.Probation;
                 this.probationLru.AddLast(demoted);
             }
+        }
+
+        // Adapt the window and main space sizes (in weight units) using a hill climbing algorithm to
+        // iteratively improve hit rate. A larger window favors recency, a larger main favors frequency.
+        private void OptimizeWeightedPartitioning()
+        {
+            long adjustment = DetermineWeightedAdjustment();
+
+            if (adjustment > 0)
+            {
+                IncreaseWindow(adjustment);
+            }
+            else if (adjustment < 0)
+            {
+                DecreaseWindow(-adjustment);
+            }
+        }
+
+        private long DetermineWeightedAdjustment()
+        {
+            long newHits = this.metrics.Hits;
+            long newMisses = this.metrics.Misses;
+
+            long sampleHits = newHits - this.previousHitCount;
+            long sampleMisses = newMisses - this.previousMissCount;
+            long requestCount = sampleHits + sampleMisses;
+
+            if (requestCount < this.cmSketch.ResetSampleSize)
+            {
+                return 0;
+            }
+
+            double hitRate = (double)sampleHits / requestCount;
+            double hitRateChange = hitRate - this.previousHitRate;
+            double amount = (hitRateChange >= 0) ? this.stepSize : -this.stepSize;
+            double nextStepSize = (Math.Abs(hitRateChange) >= HillClimberRestartThreshold)
+                ? CopySign(Math.Max(HillClimberStepPercent * this.maximum, HillClimberMinStep), amount)
+                : HillClimberStepDecay * amount;
+
+            this.previousHitRate = hitRate;
+            this.previousHitCount = newHits;
+            this.previousMissCount = newMisses;
+            this.stepSize = nextStepSize;
+
+            return (long)amount;
+        }
+
+        private void IncreaseWindow(long adjustment)
+        {
+            if (this.mainProtectedMaximum == 0)
+            {
+                return;
+            }
+
+            long quota = Math.Min(adjustment, this.mainProtectedMaximum);
+            this.mainProtectedMaximum -= quota;
+            this.windowMaximum += quota;
+
+            ReFitProtectedWeighted();
+
+            for (int i = 0; i < QueueTransferThreshold; i++)
+            {
+                var candidate = this.probationLru.First;
+                bool probation = true;
+
+                if (candidate == null || quota < this.policy.GetPolicyWeight(candidate))
+                {
+                    candidate = this.protectedLru.First;
+                    probation = false;
+                }
+
+                if (candidate == null)
+                {
+                    break;
+                }
+
+                int weight = this.policy.GetPolicyWeight(candidate);
+                if (quota < weight)
+                {
+                    break;
+                }
+
+                quota -= weight;
+
+                if (probation)
+                {
+                    this.probationLru.Remove(candidate);
+                }
+                else
+                {
+                    this.mainProtectedWeightedSize -= weight;
+                    this.protectedLru.Remove(candidate);
+                }
+
+                this.windowWeightedSize += weight;
+                this.windowLru.AddLast(candidate);
+                candidate.Position = Position.Window;
+            }
+
+            // return unused quota
+            this.mainProtectedMaximum += quota;
+            this.windowMaximum -= quota;
+        }
+
+        private void DecreaseWindow(long adjustment)
+        {
+            if (this.windowMaximum <= 1)
+            {
+                return;
+            }
+
+            long quota = Math.Min(adjustment, Math.Max(0, this.windowMaximum - 1));
+            this.mainProtectedMaximum += quota;
+            this.windowMaximum -= quota;
+
+            for (int i = 0; i < QueueTransferThreshold; i++)
+            {
+                var candidate = this.windowLru.First;
+                if (candidate == null)
+                {
+                    break;
+                }
+
+                int weight = this.policy.GetPolicyWeight(candidate);
+                if (quota < weight)
+                {
+                    break;
+                }
+
+                quota -= weight;
+
+                this.windowWeightedSize -= weight;
+                this.windowLru.Remove(candidate);
+                this.probationLru.AddLast(candidate);
+                candidate.Position = Position.Probation;
+            }
+
+            // return unused quota
+            this.mainProtectedMaximum -= quota;
+            this.windowMaximum += quota;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static double CopySign(double magnitude, double sign)
+        {
+            return (sign < 0) ? -Math.Abs(magnitude) : Math.Abs(magnitude);
         }
 
         private LfuNode<K, V>? EvictFromWindow()

--- a/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
+++ b/BitFaster.Caching/Lfu/ConcurrentLfuCore.cs
@@ -51,6 +51,11 @@ namespace BitFaster.Caching.Lfu
 
         private const int DefaultBufferSize = 128;
 
+        // Weighted eviction tuning, matching Caffeine.
+        private const double MainPercentage = 0.99d;
+        private const double MainProtectedPercentage = 0.8d;
+        private const int AdmitHashDosThreshold = 6;
+
         private readonly ConcurrentDictionary<K, N> dictionary;
 
         internal readonly StripedMpscBuffer<N> readBuffer;
@@ -65,6 +70,17 @@ namespace BitFaster.Caching.Lfu
         private readonly LfuNodeList<K, V> protectedLru;
 
         private readonly LfuCapacityPartition capacity;
+
+        // Weighted eviction state. Used only when the node policy is weighted (IsWeighted == true);
+        // the JIT elides the weighted branches in the count case since IsWeighted folds to a constant.
+        private static readonly bool IsWeighted = default(P).IsWeighted;
+        private long weightedSize;
+        private long windowWeightedSize;
+        private long mainProtectedWeightedSize;
+        private long maximum;
+        private long windowMaximum;
+        private long mainProtectedMaximum;
+        private readonly Random? random;
 
         internal readonly DrainStatus drainStatus = new();
 
@@ -121,6 +137,15 @@ namespace BitFaster.Caching.Lfu
 
             this.capacity = new LfuCapacityPartition(capacity);
 
+            if (IsWeighted)
+            {
+                // Mirror Caffeine's initial split: window ~1% of total weight, protected ~80% of main.
+                this.maximum = capacity;
+                this.windowMaximum = this.maximum - (long)(MainPercentage * this.maximum);
+                this.mainProtectedMaximum = (long)(MainProtectedPercentage * (this.maximum - this.windowMaximum));
+                this.random = new Random();
+            }
+
             this.scheduler = scheduler;
 
             this.drainBuffer = new N[this.readBuffer.Capacity];
@@ -136,6 +161,11 @@ namespace BitFaster.Caching.Lfu
         public int Count => this.dictionary.Skip(0).Count();
 
         public int Capacity => this.capacity.Capacity;
+
+        // Weighted size accounting, exposed for tests. Valid only when the policy is weighted.
+        internal long WeightedSize => this.weightedSize;
+        internal long WindowWeightedSize => this.windowWeightedSize;
+        internal long MainProtectedWeightedSize => this.mainProtectedWeightedSize;
 
         public Optional<ICacheMetrics> Metrics => new(this.metrics);
 
@@ -642,8 +672,16 @@ namespace BitFaster.Caching.Lfu
 
             policy.ExpireEntries(ref this);
             EvictEntries(reason);
-            this.capacity.OptimizePartitioning(this.metrics, this.cmSketch.ResetSampleSize);
-            ReFitProtected();
+
+            if (IsWeighted)
+            {
+                ReFitProtectedWeighted();
+            }
+            else
+            {
+                this.capacity.OptimizePartitioning(this.metrics, this.cmSketch.ResetSampleSize);
+                ReFitProtected();
+            }
 
             // Reset to idle if either
             // 1. We drained both input buffers (all work done)
@@ -677,7 +715,14 @@ namespace BitFaster.Caching.Lfu
                     break;
                 case Position.Probation:
                     Debug.Assert(node.list == this.probationLru);
-                    PromoteProbation(node);
+                    if (IsWeighted)
+                    {
+                        PromoteProbationWeighted(node);
+                    }
+                    else
+                    {
+                        PromoteProbation(node);
+                    }
                     break;
                 case Position.Protected:
                     Debug.Assert(node.list == this.protectedLru);
@@ -694,12 +739,26 @@ namespace BitFaster.Caching.Lfu
             // not be added back into the LRU.
             if (node.WasRemoved)
             {
+                bool firstTime = !node.WasDeleted;
+
+                // discount the node's accounted weight exactly once, while it is still linked
+                if (IsWeighted && firstTime && node.list != null)
+                {
+                    DiscountWeighted(node);
+                }
+
                 node.list?.Remove(node);
 
-                if (!node.WasDeleted)
+                if (firstTime)
                 {
                     // if a write is in the buffer and is then removed in the buffer, it will enter OnWrite twice.
                     // we mark as deleted to avoid double counting/disposing it
+                    if (IsWeighted)
+                    {
+                        // deschedule from any timer wheel so a stale timer entry cannot re-evict the node
+                        policy.OnEvict(node);
+                    }
+
                     EventPolicyDispatch.OnRemovedEvent(this, node, ItemRemovedReason.Removed);
                     this.metrics.evictedCount++;
                     Disposer<V>.Dispose(node.Value);
@@ -711,35 +770,165 @@ namespace BitFaster.Caching.Lfu
 
             this.cmSketch.Increment(node.Key);
 
-            // node can already be in one of the queues due to update
+            if (IsWeighted)
+            {
+                OnWriteWeighted(node);
+
+                // OnWriteWeighted may have evicted an overweight entry; do not reschedule a dead node
+                if (node.WasRemoved)
+                {
+                    return;
+                }
+            }
+            else
+            {
+                // node can already be in one of the queues due to update
+                switch (node.Position)
+                {
+                    case Position.Window:
+                        if (node.list == null)
+                        {
+                            this.windowLru.AddLast(node);
+                        }
+                        else
+                        {
+                            Debug.Assert(node.list == this.windowLru);
+                            this.windowLru.MoveToEnd(node);
+                            this.metrics.updatedCount++;
+                        }
+                        break;
+                    case Position.Probation:
+                        Debug.Assert(node.list == this.probationLru);
+                        PromoteProbation(node);
+                        this.metrics.updatedCount++;
+                        break;
+                    case Position.Protected:
+                        Debug.Assert(node.list == this.protectedLru);
+                        this.protectedLru.MoveToEnd(node);
+                        this.metrics.updatedCount++;
+                        break;
+                }
+            }
+
+            policy.AfterWrite(node);
+        }
+
+        private void OnWriteWeighted(N node)
+        {
+            int weight = this.policy.GetWeight(node);
+
             switch (node.Position)
             {
                 case Position.Window:
                     if (node.list == null)
                     {
-                        this.windowLru.AddLast(node);
+                        // new entry: account its weight in the window, then place it
+                        this.policy.SetPolicyWeight(node, weight);
+                        this.weightedSize += weight;
+                        this.windowWeightedSize += weight;
+
+                        if (weight > this.maximum)
+                        {
+                            this.windowLru.AddLast(node);
+                            Evict(node, ItemRemovedReason.Evicted);
+                        }
+                        else if (weight > this.windowMaximum)
+                        {
+                            // too big for the window, place at the LRU position so it leaves next
+                            this.windowLru.AddFirst(node);
+                        }
+                        else
+                        {
+                            this.windowLru.AddLast(node);
+                        }
                     }
                     else
                     {
                         Debug.Assert(node.list == this.windowLru);
-                        this.windowLru.MoveToEnd(node);
+                        ApplyWeightDelta(node, weight, Position.Window);
                         this.metrics.updatedCount++;
+
+                        if (weight > this.maximum)
+                        {
+                            Evict(node, ItemRemovedReason.Evicted);
+                        }
+                        else if (weight <= this.windowMaximum)
+                        {
+                            this.windowLru.MoveToEnd(node);
+                        }
+                        else
+                        {
+                            this.windowLru.MoveToFront(node);
+                        }
                     }
                     break;
                 case Position.Probation:
                     Debug.Assert(node.list == this.probationLru);
-                    PromoteProbation(node);
+                    ApplyWeightDelta(node, weight, Position.Probation);
                     this.metrics.updatedCount++;
+
+                    if (weight <= this.maximum)
+                    {
+                        PromoteProbationWeighted(node);
+                    }
+                    else
+                    {
+                        Evict(node, ItemRemovedReason.Evicted);
+                    }
                     break;
                 case Position.Protected:
                     Debug.Assert(node.list == this.protectedLru);
-                    this.protectedLru.MoveToEnd(node);
+                    ApplyWeightDelta(node, weight, Position.Protected);
                     this.metrics.updatedCount++;
+
+                    if (weight <= this.maximum)
+                    {
+                        this.protectedLru.MoveToEnd(node);
+                    }
+                    else
+                    {
+                        Evict(node, ItemRemovedReason.Evicted);
+                    }
                     break;
             }
-
-            policy.AfterWrite(node);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ApplyWeightDelta(LfuNode<K, V> node, int newWeight, Position position)
+        {
+            int delta = newWeight - this.policy.GetPolicyWeight(node);
+            this.policy.SetPolicyWeight(node, newWeight);
+            this.weightedSize += delta;
+
+            if (position == Position.Window)
+            {
+                this.windowWeightedSize += delta;
+            }
+            else if (position == Position.Protected)
+            {
+                this.mainProtectedWeightedSize += delta;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void DiscountWeighted(LfuNode<K, V> node)
+        {
+            int pw = this.policy.GetPolicyWeight(node);
+            this.weightedSize -= pw;
+
+            if (node.Position == Position.Window)
+            {
+                this.windowWeightedSize -= pw;
+            }
+            else if (node.Position == Position.Protected)
+            {
+                this.mainProtectedWeightedSize -= pw;
+            }
+
+            // clear so a stale double eviction cannot discount the same weight twice
+            this.policy.SetPolicyWeight(node, 0);
+        }
+
 
         private void PromoteProbation(LfuNode<K, V> node)
         {
@@ -758,10 +947,242 @@ namespace BitFaster.Caching.Lfu
             }
         }
 
+        private void PromoteProbationWeighted(LfuNode<K, V> node)
+        {
+            int pw = this.policy.GetPolicyWeight(node);
+
+            // An entry that cannot fit in the protected space is kept in probation at the MRU position.
+            if (pw > this.mainProtectedMaximum)
+            {
+                this.probationLru.MoveToEnd(node);
+                return;
+            }
+
+            this.probationLru.Remove(node);
+            this.protectedLru.AddLast(node);
+            node.Position = Position.Protected;
+            this.mainProtectedWeightedSize += pw;
+
+            // If the protected space exceeds its maximum weight, demote LRU items to probation.
+            while (this.mainProtectedWeightedSize > this.mainProtectedMaximum)
+            {
+                var demoted = this.protectedLru.First;
+                if (demoted == null)
+                {
+                    break;
+                }
+
+                this.protectedLru.RemoveFirst();
+                this.mainProtectedWeightedSize -= this.policy.GetPolicyWeight(demoted);
+                demoted.Position = Position.Probation;
+                this.probationLru.AddLast(demoted);
+            }
+        }
+
         private void EvictEntries(ItemRemovedReason reason)
         {
+            if (IsWeighted)
+            {
+                var weightedCandidate = EvictFromWindowWeighted();
+                EvictFromMainWeighted(weightedCandidate, reason);
+                return;
+            }
+
             var candidate = EvictFromWindow();
             EvictFromMain(candidate, reason);
+        }
+
+        private LfuNode<K, V>? EvictFromWindowWeighted()
+        {
+            LfuNode<K, V>? first = null;
+            var node = this.windowLru.First;
+
+            while (this.windowWeightedSize > this.windowMaximum)
+            {
+                if (node == null)
+                {
+                    break;
+                }
+
+                var next = node.Next;
+                int pw = this.policy.GetPolicyWeight(node);
+
+                // zero weight entries are skipped, they do not count against the window size
+                if (pw != 0)
+                {
+                    first ??= node;
+
+                    this.windowLru.Remove(node);
+                    this.probationLru.AddLast(node);
+                    node.Position = Position.Probation;
+
+                    this.windowWeightedSize -= pw;
+                }
+
+                node = next;
+            }
+
+            return first;
+        }
+
+        // Queue identifiers used to walk victims/candidates across the three LRU lists.
+        private const int ProbationQueue = 0;
+        private const int ProtectedQueue = 1;
+        private const int WindowQueue = 2;
+
+        private void EvictFromMainWeighted(LfuNode<K, V>? candidateNode, ItemRemovedReason reason)
+        {
+            int victimQueue = ProbationQueue;
+            int candidateQueue = ProbationQueue;
+
+            var victim = this.probationLru.First; // victims are LRU position in probation
+            var candidate = candidateNode;
+
+            while (this.weightedSize > this.maximum)
+            {
+                // [A] search the admission window for additional candidates
+                if (candidate == null && candidateQueue == ProbationQueue)
+                {
+                    candidate = this.windowLru.First;
+                    candidateQueue = WindowQueue;
+                }
+
+                // [B] try evicting from the protected and window queues
+                if (candidate == null && victim == null)
+                {
+                    if (victimQueue == ProbationQueue)
+                    {
+                        victim = this.protectedLru.First;
+                        victimQueue = ProtectedQueue;
+                        continue;
+                    }
+                    else if (victimQueue == ProtectedQueue)
+                    {
+                        victim = this.windowLru.First;
+                        victimQueue = WindowQueue;
+                        continue;
+                    }
+
+                    // the pending operations will adjust the size to reflect the correct weight
+                    break;
+                }
+
+                // [C] skip over entries with zero weight
+                if (victim != null && this.policy.GetPolicyWeight(victim) == 0)
+                {
+                    victim = victim.Next;
+                    continue;
+                }
+                else if (candidate != null && this.policy.GetPolicyWeight(candidate) == 0)
+                {
+                    candidate = candidate.Next;
+                    continue;
+                }
+
+                // [D] evict immediately if only one of the entries is present
+                if (victim == null)
+                {
+                    var evict = candidate!;
+                    candidate = candidate!.Next;
+                    Evict(evict, reason);
+                    continue;
+                }
+                else if (candidate == null)
+                {
+                    var evict = victim;
+                    victim = victim.Next;
+                    Evict(evict, reason);
+                    continue;
+                }
+
+                // [E] evict immediately if both selected the same entry
+                if (candidate == victim)
+                {
+                    victim = victim.Next;
+                    Evict(candidate, reason);
+                    candidate = null;
+                    continue;
+                }
+
+                // [G] evict immediately if an entry was removed
+                if (victim.WasRemoved)
+                {
+                    var evict = victim;
+                    victim = victim.Next;
+                    Evict(evict, reason);
+                    continue;
+                }
+                else if (candidate.WasRemoved)
+                {
+                    var evict = candidate;
+                    candidate = candidate.Next;
+                    Evict(evict, reason);
+                    continue;
+                }
+
+                // [H] evict immediately if the candidate's weight exceeds the maximum
+                if (this.policy.GetPolicyWeight(candidate) > this.maximum)
+                {
+                    var evict = candidate;
+                    candidate = candidate.Next;
+                    Evict(evict, reason);
+                    continue;
+                }
+
+                // [I] evict the entry with the lowest frequency
+                if (AdmitCandidateWeighted(candidate.Key, victim.Key))
+                {
+                    var evict = victim;
+                    victim = victim.Next;
+                    Evict(evict, reason);
+                    candidate = candidate.Next;
+                }
+                else
+                {
+                    var evict = candidate;
+                    candidate = candidate.Next;
+                    Evict(evict, reason);
+                }
+            }
+        }
+
+        private bool AdmitCandidateWeighted(K candidateKey, K victimKey)
+        {
+            int victimFreq = this.cmSketch.EstimateFrequency(victimKey);
+            int candidateFreq = this.cmSketch.EstimateFrequency(candidateKey);
+
+            if (candidateFreq > victimFreq)
+            {
+                return true;
+            }
+
+            // The maximum frequency is 15 and halved to 7 on reset to age. A candidate with a moderate
+            // frequency is given a small chance to be admitted to defend against hash flooding.
+            if (candidateFreq >= AdmitHashDosThreshold)
+            {
+                return (this.random!.Next() & 127) == 0;
+            }
+
+            return false;
+        }
+
+        private void ReFitProtectedWeighted()
+        {
+            // If hill climbing decreased the protected maximum, demote overflow to probation.
+            while (this.mainProtectedWeightedSize > this.mainProtectedMaximum)
+            {
+                var demoted = this.protectedLru.First;
+                if (demoted == null)
+                {
+                    break;
+                }
+
+                this.protectedLru.RemoveFirst();
+                this.mainProtectedWeightedSize -= this.policy.GetPolicyWeight(demoted);
+
+                demoted.Position = Position.Probation;
+                this.probationLru.AddLast(demoted);
+            }
         }
 
         private LfuNode<K, V>? EvictFromWindow()
@@ -896,6 +1317,11 @@ namespace BitFaster.Caching.Lfu
         {
             evictee.WasRemoved = true;
             evictee.WasDeleted = true;
+
+            if (IsWeighted)
+            {
+                DiscountWeighted(evictee);
+            }
 
             // This handles the case where the same key exists in the write buffer both
             // as added and removed. Remove via KVP ensures we don't remove added nodes.

--- a/BitFaster.Caching/Lfu/FastConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/FastConcurrentLfu.cs
@@ -87,14 +87,12 @@ namespace BitFaster.Caching.Lfu
         ///<inheritdoc/>
         public CachePolicy Policy => CreatePolicy();
 
-        private static readonly bool IsExpireAfterPolicy = typeof(P) == typeof(ExpireAfterPolicy<K, V, NoEventPolicy<K, V>>);
-
         private CachePolicy CreatePolicy()
         {
-            if (IsExpireAfterPolicy)
-            {
-                var calc = Unsafe.As<P, ExpireAfterPolicy<K, V, NoEventPolicy<K, V>>>(ref core.policy).ExpiryCalculator;
+            var calc = core.policy.ExpiryCalculator;
 
+            if (calc != null)
+            {
                 var afterWrite = Optional<ITimePolicy>.None();
                 var afterAccess = Optional<ITimePolicy>.None();
                 var afterCustom = Optional<IDiscreteTimePolicy>.None();
@@ -122,17 +120,12 @@ namespace BitFaster.Caching.Lfu
         {
             get
             {
-                if (IsExpireAfterPolicy)
+                return core.policy.ExpiryCalculator switch
                 {
-                    return Unsafe.As<P, ExpireAfterPolicy<K, V, NoEventPolicy<K, V>>>(ref core.policy).ExpiryCalculator switch
-                    {
-                        ExpireAfterAccess<K, V> aa => aa.TimeToExpire,
-                        ExpireAfterWrite<K, V> aw => aw.TimeToExpire,
-                        _ => TimeSpan.Zero,
-                    };
-                }
-
-                return TimeSpan.Zero;
+                    ExpireAfterAccess<K, V> aa => aa.TimeToExpire,
+                    ExpireAfterWrite<K, V> aw => aw.TimeToExpire,
+                    _ => TimeSpan.Zero,
+                };
             }
         }
 
@@ -141,7 +134,7 @@ namespace BitFaster.Caching.Lfu
         ///<inheritdoc/>
         public bool TryGetTimeToExpire<K1>(K1 key, out TimeSpan timeToExpire)
         {
-            if (IsExpireAfterPolicy && key is K k && core.TryGetNode(k, out N? node) && node is TimeOrderNode<K, V> timeNode)
+            if (core.policy.ExpiryCalculator != null && key is K k && core.TryGetNode(k, out N? node) && node is TimeOrderNode<K, V> timeNode)
             {
                 var tte = new Duration(timeNode.GetTimestamp()) - Duration.SinceEpoch();
                 timeToExpire = tte.ToTimeSpan();

--- a/BitFaster.Caching/Lfu/LfuNode.cs
+++ b/BitFaster.Caching/Lfu/LfuNode.cs
@@ -142,7 +142,7 @@ namespace BitFaster.Caching.Lfu
         }
     }
 
-    internal sealed class TimeOrderNode<K, V> : LfuNode<K, V>
+    internal class TimeOrderNode<K, V> : LfuNode<K, V>
         where K : notnull
     {
         TimeOrderNode<K, V> prevTime;

--- a/BitFaster.Caching/Lfu/LfuNodeList.cs
+++ b/BitFaster.Caching/Lfu/LfuNodeList.cs
@@ -37,6 +37,12 @@ namespace BitFaster.Caching.Lfu
             this.AddLast(node);
         }
 
+        public void MoveToFront(LfuNode<K, V> node)
+        {
+            this.Remove(node);
+            this.AddFirst(node);
+        }
+
         public void AddLast(LfuNode<K, V> node)
         {
 #if DEBUG
@@ -50,6 +56,25 @@ namespace BitFaster.Caching.Lfu
             else
             {
                 InternalInsertNodeBefore(head, node);
+            }
+
+            node.list = this;
+        }
+
+        public void AddFirst(LfuNode<K, V> node)
+        {
+#if DEBUG
+            ValidateNewNode(node);
+#endif
+
+            if (head == null)
+            {
+                InternalInsertNodeToEmptyList(node);
+            }
+            else
+            {
+                InternalInsertNodeBefore(head, node);
+                head = node;
             }
 
             node.list = this;

--- a/BitFaster.Caching/Lfu/NodePolicy.cs
+++ b/BitFaster.Caching/Lfu/NodePolicy.cs
@@ -17,6 +17,13 @@ namespace BitFaster.Caching.Lfu
         void AfterWrite(N node);
         void OnEvict(N node);
         void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, N, P, E> cache) where P : struct, INodePolicy<K, V, N, E>;
+
+        // Sizing seam. The count policies implement these trivially (constant/no-op) so the JIT elides
+        // the weighted code paths in the core; the weighted policies implement them substantively.
+        bool IsWeighted { get; }
+        int GetWeight(LfuNode<K, V> node);
+        int GetPolicyWeight(LfuNode<K, V> node);
+        void SetPolicyWeight(LfuNode<K, V> node, int weight);
     }
 
     internal struct AccessOrderPolicy<K, V, E> : INodePolicy<K, V, AccessOrderNode<K, V>, E>
@@ -62,6 +69,19 @@ namespace BitFaster.Caching.Lfu
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, AccessOrderNode<K, V>, P, E> cache) where P : struct, INodePolicy<K, V, AccessOrderNode<K, V>, E>
+        {
+        }
+
+        public bool IsWeighted => false;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetWeight(LfuNode<K, V> node) => 1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetPolicyWeight(LfuNode<K, V> node) => 1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetPolicyWeight(LfuNode<K, V> node, int weight)
         {
         }
     }
@@ -143,6 +163,19 @@ namespace BitFaster.Caching.Lfu
         public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, TimeOrderNode<K, V>, P, E> cache) where P : struct, INodePolicy<K, V, TimeOrderNode<K, V>, E>
         {
             wheel.Advance<TimeOrderNode<K, V>, P, TimeOrderNode<K, V>, E>(ref cache, Duration.SinceEpoch());
+        }
+
+        public bool IsWeighted => false;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetWeight(LfuNode<K, V> node) => 1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetPolicyWeight(LfuNode<K, V> node) => 1;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetPolicyWeight(LfuNode<K, V> node, int weight)
+        {
         }
     }
 }

--- a/BitFaster.Caching/Lfu/NodePolicy.cs
+++ b/BitFaster.Caching/Lfu/NodePolicy.cs
@@ -24,6 +24,10 @@ namespace BitFaster.Caching.Lfu
         int GetWeight(LfuNode<K, V> node);
         int GetPolicyWeight(LfuNode<K, V> node);
         void SetPolicyWeight(LfuNode<K, V> node, int weight);
+
+        // The expiry calculator for time-based policies, else null. Enables wrappers to expose the
+        // time policy without depending on the concrete policy type.
+        IExpiryCalculator<K, V>? ExpiryCalculator { get; }
     }
 
     internal struct AccessOrderPolicy<K, V, E> : INodePolicy<K, V, AccessOrderNode<K, V>, E>
@@ -84,6 +88,8 @@ namespace BitFaster.Caching.Lfu
         public void SetPolicyWeight(LfuNode<K, V> node, int weight)
         {
         }
+
+        public IExpiryCalculator<K, V>? ExpiryCalculator => null;
     }
 
     internal struct ExpireAfterPolicy<K, V, E> : INodePolicy<K, V, TimeOrderNode<K, V>, E>

--- a/BitFaster.Caching/Lfu/WeightedConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/WeightedConcurrentLfu.cs
@@ -32,6 +32,8 @@ namespace BitFaster.Caching.Lfu
             this.core.DrainBuffers();
         }
 
+        internal ConcurrentLfuCore<K, V, N, P, EventPolicy<K, V>> Core => core;
+
         ///<inheritdoc/>
         public int Count => core.Count;
 

--- a/BitFaster.Caching/Lfu/WeightedConcurrentLfu.cs
+++ b/BitFaster.Caching/Lfu/WeightedConcurrentLfu.cs
@@ -1,0 +1,305 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using BitFaster.Caching.Lru;
+using BitFaster.Caching.Scheduler;
+
+namespace BitFaster.Caching.Lfu
+{
+    // Weighted LFU with events. Provided as a generic wrapper around ConcurrentLfuCore to support both
+    // weighted access-order and weighted time-order node policies while exposing the events API.
+    internal sealed class WeightedConcurrentLfu<K, V, N, P> : ICacheExt<K, V>, IAsyncCacheExt<K, V>, IBoundedPolicy, ITimePolicy, IDiscreteTimePolicy
+        where K : notnull
+        where N : LfuNode<K, V>
+        where P : struct, INodePolicy<K, V, N, EventPolicy<K, V>>
+    {
+        // Note: for performance reasons this is a mutable struct, it cannot be readonly.
+        private ConcurrentLfuCore<K, V, N, P, EventPolicy<K, V>> core;
+
+        public WeightedConcurrentLfu(int concurrencyLevel, int capacity, IScheduler scheduler, IEqualityComparer<K> comparer, P nodePolicy)
+        {
+            EventPolicy<K, V> eventPolicy = default;
+            eventPolicy.SetEventSource(this);
+            this.core = new(concurrencyLevel, capacity, scheduler, comparer, () => this.DrainBuffers(), nodePolicy, eventPolicy);
+        }
+
+        // structs cannot declare self referencing lambda functions, therefore pass this in from the ctor
+        private void DrainBuffers()
+        {
+            this.core.DrainBuffers();
+        }
+
+        ///<inheritdoc/>
+        public int Count => core.Count;
+
+        ///<inheritdoc/>
+        public Optional<ICacheMetrics> Metrics => core.Metrics;
+
+        ///<inheritdoc/>
+        public Optional<ICacheEvents<K, V>> Events => new(new Proxy(this));
+
+        internal ref EventPolicy<K, V> EventPolicyRef => ref this.core.eventPolicy;
+
+        ///<inheritdoc/>
+        public CachePolicy Policy => CreatePolicy();
+
+        ///<inheritdoc/>
+        public ICollection<K> Keys => core.Keys;
+
+#if NET9_0_OR_GREATER
+        /// <inheritdoc/>
+        public IEqualityComparer<K> Comparer => this.core.Comparer;
+#endif
+
+        ///<inheritdoc/>
+        public int Capacity => core.Capacity;
+
+        ///<inheritdoc/>
+        public IScheduler Scheduler => core.Scheduler;
+
+        public void DoMaintenance()
+        {
+            core.DoMaintenance();
+        }
+
+        ///<inheritdoc/>
+        public void AddOrUpdate(K key, V value)
+        {
+            core.AddOrUpdate(key, value);
+        }
+
+        ///<inheritdoc/>
+        public void Clear()
+        {
+            core.Clear();
+        }
+
+        ///<inheritdoc/>
+        public V GetOrAdd(K key, Func<K, V> valueFactory)
+        {
+            return core.GetOrAdd(key, valueFactory);
+        }
+
+        ///<inheritdoc/>
+        public V GetOrAdd<TArg>(K key, Func<K, TArg, V> valueFactory, TArg factoryArgument)
+#if NET9_0_OR_GREATER
+            where TArg : allows ref struct
+#endif
+        {
+            return core.GetOrAdd(key, valueFactory, factoryArgument);
+        }
+
+        ///<inheritdoc/>
+        public ValueTask<V> GetOrAddAsync(K key, Func<K, Task<V>> valueFactory)
+        {
+            return core.GetOrAddAsync(key, valueFactory);
+        }
+
+        ///<inheritdoc/>
+        public ValueTask<V> GetOrAddAsync<TArg>(K key, Func<K, TArg, Task<V>> valueFactory, TArg factoryArgument)
+        {
+            return core.GetOrAddAsync(key, valueFactory, factoryArgument);
+        }
+
+        ///<inheritdoc/>
+        public void Trim(int itemCount)
+        {
+            core.Trim(itemCount);
+        }
+
+        ///<inheritdoc/>
+        public bool TryGet(K key, [MaybeNullWhen(false)] out V value)
+        {
+            return core.TryGet(key, out value);
+        }
+
+        ///<inheritdoc/>
+        public bool TryRemove(K key)
+        {
+            return core.TryRemove(key);
+        }
+
+        /// <summary>
+        /// Attempts to remove the specified key value pair.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>true if the item was removed successfully; otherwise, false.</returns>
+        public bool TryRemove(KeyValuePair<K, V> item)
+        {
+            return core.TryRemove(item);
+        }
+
+        /// <summary>
+        /// Attempts to remove and return the value that has the specified key.
+        /// </summary>
+        /// <param name="key">The key of the element to remove.</param>
+        /// <param name="value">When this method returns, contains the object removed, or the default value of the value type if key does not exist.</param>
+        /// <returns>true if the object was removed successfully; otherwise, false.</returns>
+        public bool TryRemove(K key, [MaybeNullWhen(false)] out V value)
+        {
+            return core.TryRemove(key, out value);
+        }
+
+        ///<inheritdoc/>
+        public bool TryUpdate(K key, V value)
+        {
+            return core.TryUpdate(key, value);
+        }
+
+        ///<inheritdoc/>
+        public IEnumerator<KeyValuePair<K, V>> GetEnumerator()
+        {
+            return core.GetEnumerator();
+        }
+
+        ///<inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return core.GetEnumerator();
+        }
+
+#if NET9_0_OR_GREATER
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IAlternateLookup<TAlternateKey, K, V> GetAlternateLookup<TAlternateKey>()
+            where TAlternateKey : notnull, allows ref struct
+        {
+            return core.GetAlternateLookup<TAlternateKey>();
+        }
+
+        ///<inheritdoc/>
+        public bool TryGetAlternateLookup<TAlternateKey>([MaybeNullWhen(false)] out IAlternateLookup<TAlternateKey, K, V> lookup)
+            where TAlternateKey : notnull, allows ref struct
+        {
+            return core.TryGetAlternateLookup(out lookup);
+        }
+
+        ///<inheritdoc/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IAsyncAlternateLookup<TAlternateKey, K, V> GetAsyncAlternateLookup<TAlternateKey>()
+            where TAlternateKey : notnull, allows ref struct
+        {
+            return core.GetAsyncAlternateLookup<TAlternateKey>();
+        }
+
+        ///<inheritdoc/>
+        public bool TryGetAsyncAlternateLookup<TAlternateKey>([MaybeNullWhen(false)] out IAsyncAlternateLookup<TAlternateKey, K, V> lookup)
+            where TAlternateKey : notnull, allows ref struct
+        {
+            return core.TryGetAsyncAlternateLookup(out lookup);
+        }
+#endif
+
+        private CachePolicy CreatePolicy()
+        {
+            var calc = core.policy.ExpiryCalculator;
+
+            if (calc != null)
+            {
+                var afterWrite = Optional<ITimePolicy>.None();
+                var afterAccess = Optional<ITimePolicy>.None();
+                var afterCustom = Optional<IDiscreteTimePolicy>.None();
+
+                switch (calc)
+                {
+                    case ExpireAfterAccess<K, V>:
+                        afterAccess = new Optional<ITimePolicy>(this);
+                        break;
+                    case ExpireAfterWrite<K, V>:
+                        afterWrite = new Optional<ITimePolicy>(this);
+                        break;
+                    default:
+                        afterCustom = new Optional<IDiscreteTimePolicy>(this);
+                        break;
+                }
+
+                return new CachePolicy(new Optional<IBoundedPolicy>(this), afterWrite, afterAccess, afterCustom);
+            }
+
+            return core.Policy;
+        }
+
+        TimeSpan ITimePolicy.TimeToLive
+        {
+            get
+            {
+                return core.policy.ExpiryCalculator switch
+                {
+                    ExpireAfterAccess<K, V> aa => aa.TimeToExpire,
+                    ExpireAfterWrite<K, V> aw => aw.TimeToExpire,
+                    _ => TimeSpan.Zero,
+                };
+            }
+        }
+
+        void ITimePolicy.TrimExpired() => DoMaintenance();
+
+        void IDiscreteTimePolicy.TrimExpired() => DoMaintenance();
+
+        ///<inheritdoc/>
+        public bool TryGetTimeToExpire<K1>(K1 key, out TimeSpan timeToExpire)
+        {
+            if (core.policy.ExpiryCalculator != null && key is K k && core.TryGetNode(k, out N? node) && node is TimeOrderNode<K, V> timeNode)
+            {
+                var tte = new Duration(timeNode.GetTimestamp()) - Duration.SinceEpoch();
+                timeToExpire = tte.ToTimeSpan();
+                return true;
+            }
+
+            timeToExpire = default;
+            return false;
+        }
+
+        // To get JIT optimizations, policies must be structs.
+        // If the structs are returned directly via properties, they will be copied. Since
+        // eventPolicy is a mutable struct, copy is bad since changes are lost.
+        // Hence it is returned by ref and mutated via Proxy.
+        private class Proxy : ICacheEvents<K, V>
+        {
+            private readonly WeightedConcurrentLfu<K, V, N, P> lfu;
+
+            public Proxy(WeightedConcurrentLfu<K, V, N, P> lfu)
+            {
+                this.lfu = lfu;
+            }
+
+            public event EventHandler<ItemRemovedEventArgs<K, V>> ItemRemoved
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                add
+                {
+                    ref var policy = ref this.lfu.EventPolicyRef;
+                    policy.ItemRemoved += value;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                remove
+                {
+                    ref var policy = ref this.lfu.EventPolicyRef;
+                    policy.ItemRemoved -= value;
+                }
+            }
+
+            // backcompat: remove conditional compile
+#if NETCOREAPP3_0_OR_GREATER
+            public event EventHandler<ItemUpdatedEventArgs<K, V>> ItemUpdated
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                add
+                {
+                    ref var policy = ref this.lfu.EventPolicyRef;
+                    policy.ItemUpdated += value;
+                }
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                remove
+                {
+                    ref var policy = ref this.lfu.EventPolicyRef;
+                    policy.ItemUpdated -= value;
+                }
+            }
+#endif
+        }
+    }
+}

--- a/BitFaster.Caching/Lfu/WeightedLfuNode.cs
+++ b/BitFaster.Caching/Lfu/WeightedLfuNode.cs
@@ -1,0 +1,43 @@
+﻿#nullable disable
+namespace BitFaster.Caching.Lfu
+{
+    /// <summary>
+    /// A node used by the access order (no expiry) weighted eviction policy. Stores the entry weight
+    /// from the writer's perspective (<see cref="Weight"/>) and from the policy's perspective
+    /// (<see cref="PolicyWeight"/>).
+    /// </summary>
+    internal sealed class WeightedAccessOrderNode<K, V> : LfuNode<K, V>
+        where K : notnull
+    {
+        public WeightedAccessOrderNode(K k, V v)
+            : base(k, v)
+        {
+        }
+
+        // The weight from the writer's perspective. Set synchronously at write time, always up to date.
+        public int Weight;
+
+        // The weight from the policy's perspective. Set during maintenance, 0 until the write drains.
+        public int PolicyWeight;
+    }
+
+    /// <summary>
+    /// A node used by the time order (expiry) weighted eviction policy. Combines the time order links
+    /// with the entry weight from the writer's perspective (<see cref="Weight"/>) and from the policy's
+    /// perspective (<see cref="PolicyWeight"/>).
+    /// </summary>
+    internal sealed class WeightedTimeOrderNode<K, V> : TimeOrderNode<K, V>
+        where K : notnull
+    {
+        public WeightedTimeOrderNode(K k, V v)
+            : base(k, v)
+        {
+        }
+
+        // The weight from the writer's perspective. Set synchronously at write time, always up to date.
+        public int Weight;
+
+        // The weight from the policy's perspective. Set during maintenance, 0 until the write drains.
+        public int PolicyWeight;
+    }
+}

--- a/BitFaster.Caching/Lfu/WeightedNodePolicy.cs
+++ b/BitFaster.Caching/Lfu/WeightedNodePolicy.cs
@@ -1,0 +1,194 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace BitFaster.Caching.Lfu
+{
+    /// <summary>
+    /// A weighted node policy for caches without expiry. Each entry is weighed using the supplied
+    /// <see cref="IWeigher{K, V}"/>, and the cache is bounded by total weight.
+    /// </summary>
+    internal struct WeightedAccessOrderPolicy<K, V, E> : INodePolicy<K, V, WeightedAccessOrderNode<K, V>, E>
+        where K : notnull
+        where E : struct, IEventPolicy<K, V>
+    {
+        private readonly IWeigher<K, V> weigher;
+
+        public WeightedAccessOrderPolicy(IWeigher<K, V> weigher)
+        {
+            this.weigher = weigher;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public WeightedAccessOrderNode<K, V> Create(K key, V value)
+        {
+            return new WeightedAccessOrderNode<K, V>(key, value) { Weight = Weigh(key, value) };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsExpired(WeightedAccessOrderNode<K, V> node)
+        {
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnRead(WeightedAccessOrderNode<K, V> node)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnWrite(WeightedAccessOrderNode<K, V> node)
+        {
+            // the value may have changed, recompute the weight synchronously while the node is locked
+            node.Weight = Weigh(node.Key, node.Value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AfterRead(WeightedAccessOrderNode<K, V> node)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AfterWrite(WeightedAccessOrderNode<K, V> node)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnEvict(WeightedAccessOrderNode<K, V> node)
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, WeightedAccessOrderNode<K, V>, P, E> cache) where P : struct, INodePolicy<K, V, WeightedAccessOrderNode<K, V>, E>
+        {
+        }
+
+        public bool IsWeighted => true;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetWeight(LfuNode<K, V> node) => ((WeightedAccessOrderNode<K, V>)node).Weight;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetPolicyWeight(LfuNode<K, V> node) => ((WeightedAccessOrderNode<K, V>)node).PolicyWeight;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetPolicyWeight(LfuNode<K, V> node, int weight) => ((WeightedAccessOrderNode<K, V>)node).PolicyWeight = weight;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int Weigh(K key, V value)
+        {
+            int weight = weigher.Weigh(key, value);
+
+            if (weight < 0)
+                Throw.ArgOutOfRange(nameof(weight), "Weigher must return a non-negative weight.");
+
+            return weight;
+        }
+    }
+
+    /// <summary>
+    /// A weighted node policy for caches with expiry. Each entry is weighed using the supplied
+    /// <see cref="IWeigher{K, V}"/> and expires using the supplied <see cref="IExpiryCalculator{K, V}"/>.
+    /// </summary>
+    internal struct WeightedExpireAfterPolicy<K, V, E> : INodePolicy<K, V, WeightedTimeOrderNode<K, V>, E>
+        where K : notnull
+        where E : struct, IEventPolicy<K, V>
+    {
+        private readonly IWeigher<K, V> weigher;
+        private readonly IExpiryCalculator<K, V> expiryCalculator;
+        private readonly TimerWheel<K, V> wheel;
+        private Duration current;
+
+        public WeightedExpireAfterPolicy(IWeigher<K, V> weigher, IExpiryCalculator<K, V> expiryCalculator)
+        {
+            this.wheel = new TimerWheel<K, V>();
+            this.weigher = weigher;
+            this.expiryCalculator = expiryCalculator;
+            this.current = Duration.SinceEpoch();
+            this.wheel.time = current.raw;
+        }
+
+        public IExpiryCalculator<K, V> ExpiryCalculator => expiryCalculator;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public WeightedTimeOrderNode<K, V> Create(K key, V value)
+        {
+            var expiry = expiryCalculator.GetExpireAfterCreate(key, value);
+            return new WeightedTimeOrderNode<K, V>(key, value) { TimeToExpire = Duration.SinceEpoch() + expiry, Weight = Weigh(key, value) };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsExpired(WeightedTimeOrderNode<K, V> node)
+        {
+            current = Duration.SinceEpoch();
+            return node.TimeToExpire < current;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnRead(WeightedTimeOrderNode<K, V> node)
+        {
+            node.TimeToExpire = current + expiryCalculator.GetExpireAfterRead(node.Key, node.Value, node.TimeToExpire - current);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnWrite(WeightedTimeOrderNode<K, V> node)
+        {
+            var c = Duration.SinceEpoch();
+            node.TimeToExpire = c + expiryCalculator.GetExpireAfterUpdate(node.Key, node.Value, node.TimeToExpire - c);
+            node.Weight = Weigh(node.Key, node.Value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AfterRead(WeightedTimeOrderNode<K, V> node)
+        {
+            wheel.Reschedule(node);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AfterWrite(WeightedTimeOrderNode<K, V> node)
+        {
+            // if the node is not yet scheduled, it is being created
+            // the time is set on create in case it is read before the buffer is processed
+            if (node.GetNextInTimeOrder() == null)
+            {
+                wheel.Schedule(node);
+            }
+            else
+            {
+                wheel.Reschedule(node);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void OnEvict(WeightedTimeOrderNode<K, V> node)
+        {
+            TimerWheel<K, V>.Deschedule(node);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ExpireEntries<P>(ref ConcurrentLfuCore<K, V, WeightedTimeOrderNode<K, V>, P, E> cache) where P : struct, INodePolicy<K, V, WeightedTimeOrderNode<K, V>, E>
+        {
+            wheel.Advance<WeightedTimeOrderNode<K, V>, P, WeightedTimeOrderNode<K, V>, E>(ref cache, Duration.SinceEpoch());
+        }
+
+        public bool IsWeighted => true;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetWeight(LfuNode<K, V> node) => ((WeightedTimeOrderNode<K, V>)node).Weight;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetPolicyWeight(LfuNode<K, V> node) => ((WeightedTimeOrderNode<K, V>)node).PolicyWeight;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetPolicyWeight(LfuNode<K, V> node, int weight) => ((WeightedTimeOrderNode<K, V>)node).PolicyWeight = weight;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int Weigh(K key, V value)
+        {
+            int weight = weigher.Weigh(key, value);
+
+            if (weight < 0)
+                Throw.ArgOutOfRange(nameof(weight), "Weigher must return a non-negative weight.");
+
+            return weight;
+        }
+    }
+}

--- a/BitFaster.Caching/Lfu/WeightedNodePolicy.cs
+++ b/BitFaster.Caching/Lfu/WeightedNodePolicy.cs
@@ -4,15 +4,15 @@ namespace BitFaster.Caching.Lfu
 {
     /// <summary>
     /// A weighted node policy for caches without expiry. Each entry is weighed using the supplied
-    /// <see cref="IWeigher{K, V}"/>, and the cache is bounded by total weight.
+    /// <see cref="IWeightCalculator{K, V}"/>, and the cache is bounded by total weight.
     /// </summary>
     internal struct WeightedAccessOrderPolicy<K, V, E> : INodePolicy<K, V, WeightedAccessOrderNode<K, V>, E>
         where K : notnull
         where E : struct, IEventPolicy<K, V>
     {
-        private readonly IWeigher<K, V> weigher;
+        private readonly IWeightCalculator<K, V> weigher;
 
-        public WeightedAccessOrderPolicy(IWeigher<K, V> weigher)
+        public WeightedAccessOrderPolicy(IWeightCalculator<K, V> weigher)
         {
             this.weigher = weigher;
         }
@@ -77,7 +77,7 @@ namespace BitFaster.Caching.Lfu
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int Weigh(K key, V value)
         {
-            int weight = weigher.Weigh(key, value);
+            int weight = weigher.GetWeight(key, value);
 
             if (weight < 0)
                 Throw.ArgOutOfRange(nameof(weight), "Weigher must return a non-negative weight.");
@@ -88,18 +88,18 @@ namespace BitFaster.Caching.Lfu
 
     /// <summary>
     /// A weighted node policy for caches with expiry. Each entry is weighed using the supplied
-    /// <see cref="IWeigher{K, V}"/> and expires using the supplied <see cref="IExpiryCalculator{K, V}"/>.
+    /// <see cref="IWeightCalculator{K, V}"/> and expires using the supplied <see cref="IExpiryCalculator{K, V}"/>.
     /// </summary>
     internal struct WeightedExpireAfterPolicy<K, V, E> : INodePolicy<K, V, WeightedTimeOrderNode<K, V>, E>
         where K : notnull
         where E : struct, IEventPolicy<K, V>
     {
-        private readonly IWeigher<K, V> weigher;
+        private readonly IWeightCalculator<K, V> weigher;
         private readonly IExpiryCalculator<K, V> expiryCalculator;
         private readonly TimerWheel<K, V> wheel;
         private Duration current;
 
-        public WeightedExpireAfterPolicy(IWeigher<K, V> weigher, IExpiryCalculator<K, V> expiryCalculator)
+        public WeightedExpireAfterPolicy(IWeightCalculator<K, V> weigher, IExpiryCalculator<K, V> expiryCalculator)
         {
             this.wheel = new TimerWheel<K, V>();
             this.weigher = weigher;
@@ -185,7 +185,7 @@ namespace BitFaster.Caching.Lfu
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int Weigh(K key, V value)
         {
-            int weight = weigher.Weigh(key, value);
+            int weight = weigher.GetWeight(key, value);
 
             if (weight < 0)
                 Throw.ArgOutOfRange(nameof(weight), "Weigher must return a non-negative weight.");

--- a/BitFaster.Caching/Lfu/WeightedNodePolicy.cs
+++ b/BitFaster.Caching/Lfu/WeightedNodePolicy.cs
@@ -72,6 +72,8 @@ namespace BitFaster.Caching.Lfu
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetPolicyWeight(LfuNode<K, V> node, int weight) => ((WeightedAccessOrderNode<K, V>)node).PolicyWeight = weight;
 
+        public IExpiryCalculator<K, V>? ExpiryCalculator => null;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int Weigh(K key, V value)
         {

--- a/README.md
+++ b/README.md
@@ -49,3 +49,21 @@ var lfu = new ConcurrentLfu<string, SomeItem>(capacity);
 
 var value = lfu.GetOrAdd("key", (key) => new SomeItem(key));
 ```
+
+### Weighted eviction
+
+By default each entry counts as 1 towards the capacity. To bound the cache by a custom weight instead (for example total memory), configure a weigher using the builder. The capacity is then interpreted as the maximum total weight, and entries are evicted to keep the total weight within bounds. Weigher results must be non-negative; an entry with weight `0` does not count towards the bound, so `Count` may exceed `Capacity` when light entries are present.
+
+```csharp
+var lfu = new ConcurrentLfuBuilder<string, byte[]>()
+    .WithCapacity(1_000_000) // maximum total weight
+    .WithWeigher(new ByteArrayWeigher())
+    .Build();
+
+class ByteArrayWeigher : IWeigher<string, byte[]>
+{
+    public int Weigh(string key, byte[] value) => value.Length;
+}
+```
+
+`WithWeigher` composes with `WithExpireAfterWrite`/`WithExpireAfterAccess`/`WithExpireAfter` and `WithEvents`.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ var lfu = new ConcurrentLfuBuilder<string, byte[]>()
     .WithWeigher(new ByteArrayWeigher())
     .Build();
 
-class ByteArrayWeigher : IWeigher<string, byte[]>
+class ByteArrayWeigher : IWeightCalculator<string, byte[]>
 {
-    public int Weigh(string key, byte[] value) => value.Length;
+    public int GetWeight(string key, byte[] value) => value.Length;
 }
 ```
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,275 @@
+# Plan: Weight-based eviction for ConcurrentLfu (Caffeine parity)
+
+## 1. Goal
+Add an **opt-in, weight-based** eviction policy to `ConcurrentLfu`, faithfully matching
+Caffeine's weighted W-TinyLFU. A user supplies a weigher `weigh(key, value) -> int (>= 0)`;
+the cache bounds the **total weight** (not item count). The default/unweighted path must
+remain **behaviorally and memory identical** to today.
+
+Reference: `ben-manes/caffeine` `BoundedLocalCache.java` (commit `30f867a`), `Weigher.java`,
+node/cache code generators (`AddMaximum.java`).
+
+## 2. How the current (unweighted) LFU works  (baseline to preserve)
+- `ConcurrentLfuCore<K,V,N,P,E>` holds `windowLru`/`probationLru`/`protectedLru`
+  (`LfuNodeList<K,V>`), a `CmSketch`, and an `LfuCapacityPartition` (integer
+  Window/Protected/Probation counts).
+- Reads/writes are buffered (`readBuffer`/`writeBuffer`) then applied under
+  `maintenanceLock` in `Maintenance()` -> `OnAccess`/`OnWrite`, then `EvictEntries()`,
+  then `capacity.OptimizePartitioning(...)`, then `ReFitProtected()`.
+- All sizing is **count-based**: `EvictFromWindow` runs `while windowLru.Count >
+  capacity.Window`; `EvictFromMain` runs `while window+probation+protected.Count > Capacity`.
+- Hill-climb is **ratio-based**: `OptimizePartitioning` nudges a `mainRatio` double from
+  hit-rate change and recomputes integer (window, protected, probation). It does **not**
+  touch the LRU lists; the count loops + `ReFitProtected`/`PromoteProbation` lazily enforce
+  the new target counts.
+- `OnWrite` handles add **and** update in one path keyed off `node.Position` + `node.list ==
+  null`, and **always** promotes a probation entry on update (`PromoteProbation`).
+- `AdmitCandidate` currently only does `candidateFreq > victimFreq` (has a `// TODO: random
+  factor` at `ConcurrentLfuCore.cs:891`).
+- Exact eviction order and partition behavior are locked by tests
+  (`LfuCapacityPartitionTests`, the commented W/P/Probation assertions in `ConcurrentLfuTests`).
+
+## 3. Caffeine weighted algorithm (the target) — confirmed from source
+- **Per-node**: `weight` (user value, set synchronously at write) and `policyWeight`
+  (policy's view, set during maintenance; **0 until the add drains**). Eviction reads
+  `policyWeight`. `makeDead` (our `Evict`) subtracts **`weight`**, not `policyWeight`.
+- **Cache sizes** (`long`): `weightedSize`, `windowWeightedSize`,
+  `mainProtectedWeightedSize`. Probation weight is implicit
+  (`weightedSize - window - protected`).
+- **Maximums** (`long`): `maximum`, `windowMaximum` (~1%), `mainProtectedMaximum`
+  (~79.2% of total = 80% of main). Climb adjusts **absolute weight quotas**.
+- **evictFromWindow**: `while windowWeightedSize > windowMaximum`, move LRU window node to
+  **probation tail**; **skip `policyWeight == 0`** nodes; decrement `windowWeightedSize` by
+  `policyWeight`; return first moved node as the starting candidate.
+- **evictFromMain(candidate)**: `while weightedSize > maximum`. `victim` = probation LRU,
+  advancing toward MRU; `candidate` = window-promoted nodes, then window LRU. Skip
+  zero-weight; if only one present evict it; if same node evict; **if
+  `candidate.policyWeight > maximum` evict candidate**; else `admit()` decides. When both
+  exhausted, fall back to protected LRU, then window LRU, then break.
+- **admit(cand, victim)**: `candFreq > victimFreq` -> admit; else if `candFreq >= 6` ->
+  `1/128` random admit (anti hash-flood); else keep victim (ties favor the main-space victim).
+- **Oversize on add** (after map insert, sketch incremented): `weight > maximum` -> evict
+  immediately; `weight > windowMaximum` -> insert at window **LRU front** (`offerFirst`);
+  else MRU tail.
+- **Update changing weight** (`delta = newWeight - oldWeight`): apply delta to sizes; window
+  grow `> maximum` -> evict, grow `> windowMaximum` -> **move to LRU front**; probation/
+  protected grow `> maximum` -> evict; shrink -> `onAccess` (may promote). A probation entry
+  whose `policyWeight > mainProtectedMaximum` is **not** promoted (kept in probation).
+- **Zero weight**: legal; a size-eviction targeting a `weight == 0` node **resurrects** it;
+  zero-weight nodes are skipped by the evict loops and never size-evicted.
+- **Hill climb** (weighted): `determineAdjustment()` produces a signed weight `adjustment`
+  from hit-rate change; `increaseWindow()`/`decreaseWindow()` transfer budget between
+  `windowMaximum` and `mainProtectedMaximum` **and physically move whole nodes** between the
+  deques within that quota (cap `QUEUE_TRANSFER_THRESHOLD = 1000` moves/step), returning
+  unused quota. Protected enforcement is `mainProtectedWeightedSize > mainProtectedMaximum`.
+- **Sketch sizing**: weighted caches size the frequency sketch by **entry count**, not by the
+  weight maximum.
+
+## 4. Design principles
+1. **Unweighted path untouched** — no behavior change, no node-layout change, no extra hot-path
+   work. Existing tests must pass unmodified.
+2. **Compile-time selection** of weighted vs count via BitFaster's established patterns
+   (generic struct policies + `static readonly bool` JIT elision, e.g.
+   `EventPolicyDispatch.IsEnabled`, `FastConcurrentLfu.IsExpireAfterPolicy`).
+3. **Additive public API only** (`IBoundedPolicy.Capacity` stays `int`).
+4. **Faithful port** of the weighted accounting, eviction, admission, oversize, update, and
+   hill-climb behavior.
+
+## 5. Architecture — weight via `INodePolicy`  (DECIDED: no new generic)
+Per maintainer decision (D1), weighting is carried by the existing node policy `P`;
+`ConcurrentLfuCore` keeps its `<K,V,N,P,E>` arity. **No 6th generic, no `ISizePolicy`.**
+
+Two new `INodePolicy` structs are added alongside the existing `AccessOrderPolicy` /
+`ExpireAfterPolicy`:
+- `WeightedAccessOrderPolicy<K,V,E>` — weighted, no expiry.
+- `WeightedExpireAfterPolicy<K,V,E>` — weighted + time expiry; **composes** the existing
+  `ExpireAfterPolicy` for the expiry hooks (TimerWheel scheduling) and layers weight on top, to
+  avoid duplicating expiry logic.
+
+**Selection & elision:** add `bool IsWeighted { get; }` to `INodePolicy` (a literal
+`true`/`false`), and in the core use `static readonly bool IsWeighted = default(P).IsWeighted;`
+(safe — the getter is a pure literal). The eviction/climb code branches on this static bool;
+for the unweighted policies the JIT elides the weighted branches so the current path is
+untouched (same idiom as `FastConcurrentLfu.IsExpireAfterPolicy`,
+`EventPolicyDispatch.IsEnabled`).
+
+**Sizing seam added to `INodePolicy`** — implemented trivially by the two unweighted policies
+(constants / no-ops, elided) and substantively by the two weighted policies:
+- `int Weigh(K, V)` — unweighted returns 1.
+- `bool IsWeighted { get; }`.
+- per-node weight access on `N`: `int GetPolicyWeight(N)`, `void SetPolicyWeight(N, int)`,
+  `int GetWeight(N)`, `void SetWeight(N, int)`. Unweighted = `return 1` / no-op; weighted reads
+  the node's fields **directly** (for a weighted cache `N` *is* the weighted node type — matched
+  pair, see §6 — so no cast, no virtual dispatch).
+- **Weighted cache-wide state** (the `long` `weightedSize` / `windowWeightedSize` /
+  `mainProtectedWeightedSize`, the weighted maximums, and the climb) lives **inside the weighted
+  policy struct** (mutable struct field, like `eventPolicy`). The core reads/updates it via
+  `policy.` members and drives the node-moving climb by passing itself back in
+  (e.g. `policy.Optimize(ref this, ...)`), mirroring the existing `ExpireEntries(ref this)`
+  reach-back pattern. For the unweighted policies these members are empty/no-ops.
+
+**Benefit of D1 vs the rejected 6th-generic option:** `INodePolicy.ExpireEntries`,
+`TimerWheel.Advance`/`Expire`, and the wrapper core field arities **do not change** (no `S`
+churn). **Cost:** the `INodePolicy` interface grows (all four policy structs implement the new
+members) and there are two new weighted `P` structs (only +2 — expiry's afterWrite/afterAccess/
+custom modes are already collapsed into the single `ExpireAfterPolicy` via its
+`IExpiryCalculator`, so there is no real combinatorial explosion).
+
+## 6. Node weight storage  (DECIDED: weighted node subclasses)  — see §12 D2
+**Weighted node subclasses** `WeightedAccessOrderNode<K,V>` and `WeightedTimeOrderNode<K,V>`
+`WeightedTimeOrderNode<K,V>` adding `int weight` + `int policyWeight`. The unweighted nodes and
+their memory layout are **untouched** (no +8 bytes tax). The factory wires **matched (N, P)
+pairs** — `(WeightedAccessOrderNode, WeightedAccessOrderPolicy)` and
+`(WeightedTimeOrderNode, WeightedExpireAfterPolicy)` — so the weighted policy's weight accessors
+read the node fields directly with no cast/virtual.
+
+**Alternative:** put `Weight`/`PolicyWeight` on base `LfuNode<K,V>` (+8 bytes/node always,
+simpler code). Rejected by default because BitFaster is memory-first and the unweighted path
+should pay nothing (per critique).
+
+## 7. Public API & builder
+- New `IWeigher<K, V>` interface (mirrors `IExpiryCalculator<K,V>`): `int Weigh(K key, V value)`.
+  Document the non-negative contract; throw `ArgumentOutOfRangeException` on negative (mirrors
+  Caffeine's `BoundedWeigher`). Provide a `Weigher` helper with a singleton (weight 1) and a
+  `Func<K,V,int>` adapter for ergonomics.
+- `ConcurrentLfuBuilder<K,V>.WithWeigher(IWeigher<K,V> weigher)` -> stores on `LfuInfo<K>`.
+  (Consider `LfuInfo<K>` becoming weigher-aware similar to its `expiry` handling.)
+- `ConcurrentLfuFactory.Create` switch gains a `weigher != null` dimension and selects the
+  weighted `N`/`P` pair. Weight composes with events and with time expiry.
+- **Wrapper wiring:** the public `ConcurrentLfu<K,V>` hard-codes an unweighted core type, so
+  weighted+events needs its own wrapper that exposes `Events` — mirror the existing internal
+  `ConcurrentTLfu<K,V>` pattern (a new internal weighted wrapper, and/or generalize
+  `ConcurrentTLfu` to the weighted+time+events combo). Weighted **without** events maps cleanly
+  onto the already-generic `FastConcurrentLfu<K,V,N,P>` with the weighted `N`/`P` args.
+- `WithCapacity` doc updated: "maximum total **weight** when a weigher is configured."
+- `IBoundedPolicy.Capacity` stays `int` (weight budget, capped at `int.MaxValue`); internal
+  accounting uses `long` to avoid overflow. Document that with a weigher `Count` may exceed
+  `Capacity` (zero/low-weight entries).
+
+## 8. File-by-file changes
+**New files**
+- `Lfu/IWeigher.cs` — `IWeigher<K,V>` + `Weigher` helpers (singleton, `Func` adapter).
+- `Lfu/WeightedNodePolicy.cs` — `WeightedAccessOrderPolicy` and `WeightedExpireAfterPolicy`
+  (each holds the `IWeigher` + the weighted `long` state/maximums + accounting hooks +
+  admission + climb; the expiry one composes `ExpireAfterPolicy`).
+- `Lfu/WeightedLfuNode.cs` — `WeightedAccessOrderNode`, `WeightedTimeOrderNode` (if §12 D2 =
+  subclasses).
+- (Maybe) `Lfu/WeightedCapacityPartition.cs` — `long` maximum/windowMaximum/
+  mainProtectedMaximum + `determineAdjustment`, owned by the weighted policy struct; the
+  node-moving increase/decrease runs in the core via a `policy.Optimize(ref this, …)` reach-back.
+- (Maybe) internal weighted cache wrapper for the weighted+events (and weighted+time+events)
+  combos — see §7.
+
+**Modified**
+- `Lfu/NodePolicy.cs` — `INodePolicy` interface grows the sizing seam (`IsWeighted`, `Weigh`,
+  `GetPolicyWeight`/`SetPolicyWeight`/`GetWeight`/`SetWeight`, and the size/climb reach-back
+  members); `AccessOrderPolicy` + `ExpireAfterPolicy` implement them trivially (constants/
+  no-ops). **`ExpireEntries` keeps its current generic arity** (no `S`).
+- `Lfu/ConcurrentLfuCore.cs` — `static readonly bool IsWeighted`; weighted branches in
+  `OnWrite` (split add/update/remove delta logic), `Evict`, `EvictEntries`, `EvictFromWindow`,
+  `EvictFromMain`, `AdmitCandidate`, `Trim`; weighted protected enforcement replacing
+  `ReFitProtected` for weighted; route size reads/writes through `policy.`; sketch sized by
+  count when weighted; `Capacity` clamp. **No new generic param.**
+- `Lfu/TimerWheel.cs` — **unchanged** (arity stays the same; this is a benefit of D1).
+- `Lfu/LfuNodeList.cs` — add `AddFirst(node)` / `MoveToFront(node)` primitives (needed for
+  oversize-add `offerFirst` and update `moveToFront`).
+- `Lfu/LfuNode.cs` — only if §12 D2 = base fields.
+- `Lfu/ConcurrentTLfu.cs` (+ any new weighted wrapper), `Lfu/FastConcurrentLfu.cs` — accept the
+  weighted `N`/`P` type args; `ConcurrentLfu.cs` is unchanged unless a weighted+events wrapper
+  reuses it.
+- `Lfu/Builder/LfuInfo.cs`, `Lfu/ConcurrentLfuBuilder.cs` (+ `LfuBuilderBase` if exposed
+  broadly), `ConcurrentLfuBuilderExtensions.cs` — `WithWeigher` + factory wiring.
+- README / API docs — document weighted eviction + capacity semantics.
+
+## 9. Algorithm port details (the crux)
+**Accounting is `PolicyWeight`-authoritative (avoids buffer double-count):**
+- New add (in `OnWrite`, `node.list == null && !WasRemoved`): `delta = Weight`;
+  `weightedSize += delta`; `windowWeightedSize += delta`; set `PolicyWeight = Weight`.
+- Existing update: `delta = Weight - PolicyWeight`; apply delta to `weightedSize` and the
+  node's current-queue size; set `PolicyWeight = Weight`. **Do not** auto-`PromoteProbation`;
+  instead follow Caffeine's conditional grow/shrink/evict/move-to-front logic.
+- Remove/evict path (`WasRemoved`, and `Evict`): subtract the **accounted** amount
+  (`PolicyWeight`/queue-specific) — never blindly subtract `Weight` for a node whose add never
+  drained (guards negative accounting). On real eviction, subtract `Weight` (finalized) per
+  Caffeine `makeDead`.
+- Duplicate buffered writes for one node must net to a single correct delta because each apply
+  recomputes `Weight - PolicyWeight` and then syncs `PolicyWeight`.
+- Oversize-on-add: implement the `> maximum` evict / `> windowMaximum` `AddFirst` / else
+  `AddLast` placement.
+- Zero-weight: skip in evict loops; **resurrect** on size-eviction of a `weight == 0` node.
+- `EvictFromWindow`/`EvictFromMain`/`AdmitCandidate`: weighted variants per §3 (skip-zero,
+  candidate-oversize evict, freq compare + `>= 6` `1/128` random). The random admission is
+  implemented in the **weighted** path only; the existing unweighted admission is left unchanged
+  (D4 deferred).
+- **Weighted hill-climb**: the weighted policy's `DetermineAdjustment(metrics, sampleSize)`
+  returns a signed weight adjustment; the core applies `IncreaseWindow`/`DecreaseWindow` (via a
+  `policy.Optimize(ref this, …)` reach-back) that move whole nodes between deques within quota
+  (cap 1000), updating window/protected sizes & maximums, then a weighted `DemoteFromProtected`.
+  The count path keeps `OptimizePartitioning` + `ReFitProtected` unchanged.
+
+## 10. Test strategy  (`BitFaster.Caching.UnitTests/Lfu/`, one test file per class)
+- **Builder**: `WithWeigher` builds a weighted cache; negative weight throws; composes with
+  events; capacity is weight budget.
+- **Accounting/eviction parity** (drive with `DoMaintenance()` + a `LogLru`-style weighted
+  dump): basic weighted eviction by total weight; window/probation/protected weighted splits;
+  admission (freq compare) chooses correctly.
+- **Caffeine edge cases**: entry `weight > maximum` evicted on add; `weight > windowMaximum`
+  placed at window front and leaves next; update grows weight -> evict/move-to-front; update
+  shrinks -> promote; zero-weight entries never size-evicted and allow `Count > Capacity`;
+  probation entry with `policyWeight > mainProtectedMaximum` stays in probation.
+- **Buffer-model edge cases** (where BitFaster differs from Caffeine's task model): add then
+  remove before maintenance; add then multiple weight updates before first drain; remove a node
+  with `policyWeight == 0`; zero-weight node at an LRU head during eviction; expired weighted
+  node subtracts size exactly once; duplicate write-buffer entries don't double-count.
+- **Weighted climb**: window grows/shrinks in weight units; converges; respects the
+  window>=1 / protected>=0 bounds; transfer cap honored.
+- **Soak**: extend `ConcurrentLfuSoakTests` with a weighted variant asserting weighted-size
+  invariants (`weightedSize == sum(node.weight)`, `window+protected+probation` consistency)
+  hold under concurrency.
+- **Hit-rate parity (optional)**: a weighted scenario in `HitRateAnalysis` cross-checked
+  against Caffeine numbers.
+
+## 11. Phased delivery
+1. **Foundations** — `IWeigher`, `WithWeigher`, factory wiring, the `INodePolicy` sizing seam +
+   the two new weighted policy structs as no-op-until-wired stubs (no behavior change), weighted
+   node type(s), `LfuNodeList.AddFirst`. Gate: full build (all TFMs) + **all existing tests
+   green**, weighted cache builds and behaves like count.
+2. **Weighted accounting** — `long` sizes/maximums (in the weighted policy), `OnWrite`
+   add/update/remove delta, `Evict` subtract, oversize-on-add, zero-weight resurrect.
+3. **Weighted eviction** — `EvictFromWindow`/`EvictFromMain`/`AdmitCandidate` weighted +
+   randomness; weighted protected enforcement.
+4. **Weighted climb** — `DetermineAdjustment` + node-moving increase/decrease via the
+   `policy.Optimize(ref this, …)` reach-back.
+5. **Variants (v1 scope)** — `ConcurrentTLfu` (+ any new weighted+events wrapper) so weight
+   composes with time expiry (`WeightedTimeOrderNode` + `WeightedExpireAfterPolicy` together;
+   factory handles weigher × {none, afterWrite, afterAccess, custom expiry}), and weighted `Trim`
+   semantics. **Deferred to a later milestone:** `FastConcurrentLfu` standalone exposure and the
+   scoped/atomic/async builder wrappers.
+6. **Tests + validation + docs** — full matrix above; `dotnet format`; soak; README.
+
+**Verified commands**: build `dotnet build BitFaster.Caching\BitFaster.Caching.csproj -c
+Release` (multi-TFM: netstandard2.0, netcoreapp3.1, net6.0, net10.0). Run `dotnet format`
+after changes (repo convention). Tests via the `BitFaster.Caching.UnitTests` project.
+
+## 12. Open decisions for the maintainer
+- **D1 Seam** *(DECIDED: weight is carried by the existing `INodePolicy` slot — two new weighted
+  policy structs, no new generic. `ConcurrentLfuCore` arity and `TimerWheel`/`ExpireEntries`
+  signatures are unchanged; the `INodePolicy` interface grows a sizing seam. See §5.)*
+- **D2 Node memory** *(DECIDED: weighted node subclasses `WeightedAccessOrderNode` /
+  `WeightedTimeOrderNode`; unweighted nodes and their layout are untouched — zero memory tax on
+  the default path.)*
+- **D3 Scope** *(DECIDED: Core `ConcurrentLfu` + `ConcurrentTLfu` so weight composes with time
+  expiry — matches Caffeine. `FastConcurrentLfu` and scoped/atomic/async wrappers deferred.)*
+- **D4 Unweighted admission TODO** *(DEFERRED: leave the existing unweighted admission as-is for
+  now; implement the `>=6` / `1/128` random admission only in the weighted path. Finishing the
+  unweighted TODO — which would shift unweighted eviction order/tests — is a separate later
+  task.)*
+
+## 13. Risks
+- Buffered duplicate writes/removes -> double/under-count (mitigated by `PolicyWeight`-based
+  deltas).
+- `INodePolicy` interface growth: all four policy structs must implement the new sizing-seam
+  members (unweighted ones trivially); mechanical and compiler-enforced.
+- Accidental behavior change to the unweighted path (mitigated by compile-time elision +
+  existing tests as a guard).
+- `int` capacity vs `long` internal accounting overflow (clamp + `long` math).


### PR DESCRIPTION
## Summary

Adds opt-in **weight-based eviction** to `ConcurrentLfu`, faithfully matching Caffeine's weighted W-TinyLFU. A user supplies an `IWeigher<K, V>`; the cache is then bounded by **total weight** instead of item count.

```csharp
var lfu = new ConcurrentLfuBuilder<string, byte[]>()
    .WithCapacity(1_000_000)              // maximum total weight
    .WithWeigher(new ByteArrayWeigher())  // IWeigher<K,V>.Weigh => value.Length
    .Build();
```

`WithWeigher` composes with `WithEvents` and `WithExpireAfterWrite`/`WithExpireAfterAccess`/`WithExpireAfter`.

## Design

- **No new generic.** Weighting is carried by the existing `INodePolicy` slot via two new policy structs (`WeightedAccessOrderPolicy`, `WeightedExpireAfterPolicy`). `ConcurrentLfuCore`/`TimerWheel` arities are unchanged.
- **Zero cost to the default (unweighted) path.** Weighted branches are selected by `static readonly bool IsWeighted = default(P).IsWeighted` and JIT-elided in the count case. Weight is stored on weighted node subclasses, so unweighted node layout is untouched.
- **`policyWeight`-authoritative accounting** maintains the invariant `weightedSize == Σ policyWeight`, which is robust to BitFaster's buffered/duplicated writes.
- Ports Caffeine's weighted `evictFromWindow`/`evictFromMain` (zero-weight skips, oversize-candidate eviction, frequency admission with the `>=6`/`1-in-128` anti-hashflood jitter), oversize-on-add, conditional weight-change handling, zero-weight survival, and the absolute-weight hill-climb (`increase`/`decreaseWindow` moving whole nodes within quota).
- `IBoundedPolicy.Capacity` stays `int` (the weight budget); internal accounting is `long`. With a weigher, zero/low-weight entries mean `Count` can exceed `Capacity` (by design).

## Scope

In: `ConcurrentLfu` (with/without events) and `ConcurrentTLfu` (weight composed with time expiry). Deferred: `FastConcurrentLfu` standalone exposure and the scoped/atomic/async builder wrappers.

## Testing

- Full suite: **1563 pass**, no regressions; builds on all TFMs (netstandard2.0, netcoreapp3.1, net6.0, net10.0, net48).
- New coverage: weighted accounting/eviction/oversize/zero-weight/weight-change/promotion invariants, the hill-climb adaptation, all builder combinations, the shared cache suite run against the weighted+events wrapper, and a 4-thread concurrency soak that reuses the integrity checker and asserts the weighted-size invariant under load.
- A rubber-duck review caught a critical bug (probation→protected read promotion was using the unweighted path, corrupting `mainProtectedWeightedSize`) — fixed and regression-tested — plus three weighted+expiry hazards (deschedule-on-remove, skip `AfterWrite` on evict, idempotent discount).

## Note

`TimerWheelTests.WhenRescheduledLaterNodeIsMoved` is a pre-existing, date/wall-clock-dependent test (uses real `Duration.SinceEpoch()`); it fails on a clean `main` independent of this change.

## Draft

Opened as a draft for review of the approach and API shape before finalizing.
