### PR TITLE
Alternative concurrent counter

### DIFF
--- a/BitFaster.Caching.Benchmarks/CounterBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/CounterBenchmark.cs
@@ -1,0 +1,111 @@
+﻿
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace BitFaster.Caching.Benchmarks
+{
+#if Windows
+    [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
+#endif
+    [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
+    public class CounterBenchmark
+    {
+        const int Iters = 1_000_000;
+
+        private Counters.Counter counter = new Counters.Counter();
+
+        private Meter meter;
+        private Counter<long> metricsCounter;
+        private UpDownCounter<long> upDownCounter;
+        private MetricsEventListener listener;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            meter = new Meter("Example");
+            upDownCounter = meter.CreateUpDownCounter<long>("upDownCounter");
+            metricsCounter = meter.CreateCounter<long>("counter");
+            listener = new MetricsEventListener();
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            meter.Dispose();
+        }
+
+        [Benchmark]
+        public void CounterSerial()
+        {
+            for (int i = 0; i < Iters; i++)
+            {
+                counter.Add(1);
+                counter.Add(1);
+            }
+        }
+
+        [Benchmark]
+        public void CounterParallel()
+        {
+            Parallel.For(0, Iters, i =>
+            {
+                counter.Add(1);
+                counter.Add(1);
+            });
+        }
+
+        [Benchmark]
+        public void MetricsCounterSerial()
+        {
+            for (int i = 0; i < Iters; i++)
+            {
+                metricsCounter.Add(1);
+                metricsCounter.Add(1);
+            }
+        }
+
+        [Benchmark]
+        public void MetricsCounterParallel()
+        {
+            Parallel.For(0, Iters, i =>
+            {
+                metricsCounter.Add(1);
+                metricsCounter.Add(1);
+            });
+        }
+
+        [Benchmark]
+        public void UpDownCounterSerial()
+        {
+            for (int i = 0; i < Iters; i++)
+            {
+                upDownCounter.Add(1);
+                upDownCounter.Add(-1);
+            }
+        }
+
+        [Benchmark]
+        public void UpDownCounterParallel()
+        {
+            Parallel.For(0, Iters, i =>
+            {
+                upDownCounter.Add(1);
+                upDownCounter.Add(-1);
+            });
+        }
+
+        private sealed class MetricsEventListener : EventListener
+        {
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource.Name == "System.Diagnostics.Metrics")
+                {
+                    EnableEvents(eventSource, EventLevel.LogAlways, EventKeywords.All, new Dictionary<string, string>() { { "Metrics", "Example\\upDownCounter;Example\\counter" } });
+                }
+            }
+        }
+    }
+}

--- a/BitFaster.Caching.Benchmarks/CounterBenchmark.cs
+++ b/BitFaster.Caching.Benchmarks/CounterBenchmark.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
+using Benchly;
 using BenchmarkDotNet.Attributes;
 
 namespace BitFaster.Caching.Benchmarks
@@ -11,11 +12,14 @@ namespace BitFaster.Caching.Benchmarks
     [DisassemblyDiagnoser(printSource: true, maxDepth: 5)]
 #endif
     [HideColumns("Job", "Median", "RatioSD", "Alloc Ratio")]
+    [ColumnChart(Title = "Counter Latency ({JOB})", Output = OutputMode.PerJob, Colors = "seagreen,darkgreen,thistle,plum,lightcoral,indianred,lightpink,hotpink")]
     public class CounterBenchmark
     {
         const int Iters = 1_000_000;
 
         private Counters.Counter counter = new Counters.Counter();
+
+        private Striped64Counter striped64Counter = new Striped64Counter();
 
         private Meter meter;
         private Counter<long> metricsCounter;
@@ -54,6 +58,26 @@ namespace BitFaster.Caching.Benchmarks
             {
                 counter.Add(1);
                 counter.Add(1);
+            });
+        }
+
+        [Benchmark]
+        public void Striped64CounterSerial()
+        {
+            for (int i = 0; i < Iters; i++)
+            {
+                striped64Counter.Add(1);
+                striped64Counter.Add(1);
+            }
+        }
+
+        [Benchmark]
+        public void Striped64CounterParallel()
+        {
+            Parallel.For(0, Iters, i =>
+            {
+                striped64Counter.Add(1);
+                striped64Counter.Add(1);
             });
         }
 

--- a/BitFaster.Caching.Benchmarks/Striped64Counter.cs
+++ b/BitFaster.Caching.Benchmarks/Striped64Counter.cs
@@ -112,7 +112,7 @@ namespace BitFaster.Caching.Benchmarks
         /// <param name="value">The value to add.</param>
         public void Add(long value)
         {
-            Cell[]? @as;
+            Cell[] @as;
             long b, v;
             int m;
             Cell a;
@@ -158,7 +158,7 @@ namespace BitFaster.Caching.Benchmarks
         /// <summary>
         /// When non-null, size is a power of 2.
         /// </summary>
-        protected Cell[]? Cells;
+        protected Cell[] Cells;
 
         /**
          * Returns the probe value for the current thread.
@@ -218,7 +218,7 @@ namespace BitFaster.Caching.Benchmarks
             var collide = false;                    // True if last slot nonempty
             for (; ; )
             {
-                Cell[]? @as; Cell a; int n; long v;
+                Cell[] @as; Cell a; int n; long v;
                 if ((@as = this.Cells) != null && (n = @as.Length) > 0)
                 {
                     if ((a = @as[(n - 1) & h]) == null)
@@ -230,7 +230,7 @@ namespace BitFaster.Caching.Benchmarks
                             {
                                 try
                                 {                   // Recheck under lock
-                                    Cell[]? rs; int m, j;
+                                    Cell[] rs; int m, j;
                                     if ((rs = this.Cells) != null &&
                                         (m = rs.Length) > 0 &&
                                         rs[j = (m - 1) & h] == null)

--- a/BitFaster.Caching.Benchmarks/Striped64Counter.cs
+++ b/BitFaster.Caching.Benchmarks/Striped64Counter.cs
@@ -1,0 +1,304 @@
+﻿/*
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+using System;
+using System.Threading;
+using BitFaster.Caching.Counters;
+
+namespace BitFaster.Caching.Benchmarks
+{
+    /*
+     * This class maintains a lazily-initialized table of atomically
+     * updated variables, plus an extra "base" field. The table size
+     * is a power of two. Indexing uses masked per-thread hash codes.
+     * Nearly all declarations in this class are package-private,
+     * accessed directly by subclasses.
+     *
+     * Table entries are of class Cell; a variant of AtomicLong padded
+     * to reduce cache contention on most processors. Padding is
+     * overkill for most Atomics because they are usually irregularly
+     * scattered in memory and thus don't interfere much with each
+     * other. But Atomic objects residing in arrays will tend to be
+     * placed adjacent to each other, and so will most often share
+     * cache lines (with a huge negative performance impact) without
+     * this precaution.
+     *
+     * In part because Cells are relatively large, we avoid creating
+     * them until they are needed.  When there is no contention, all
+     * updates are made to the base field.  Upon first contention (a
+     * failed CAS on base update), the table is initialized to size 2.
+     * The table size is doubled upon further contention until
+     * reaching the nearest power of two greater than or equal to the
+     * number of CPUS. Table slots remain empty (null) until they are
+     * needed.
+     *
+     * A single spinlock ("busy") is used for initializing and
+     * resizing the table, as well as populating slots with new Cells.
+     * There is no need for a blocking lock; when the lock is not
+     * available, threads try other slots (or the base).  During these
+     * retries, there is increased contention and reduced locality,
+     * which is still better than alternatives.
+     *
+     * Per-thread hash codes are initialized to random values.
+     * Contention and/or table collisions are indicated by failed
+     * CASes when performing an update operation (see method
+     * retryUpdate). Upon a collision, if the table size is less than
+     * the capacity, it is doubled in size unless some other thread
+     * holds the lock. If a hashed slot is empty, and lock is
+     * available, a new Cell is created. Otherwise, if the slot
+     * exists, a CAS is tried.  Retries proceed by "double hashing",
+     * using a secondary hash (Marsaglia XorShift) to try to find a
+     * free slot.
+     *
+     * The table size is capped because, when there are more threads
+     * than CPUs, supposing that each thread were bound to a CPU,
+     * there would exist a perfect hash function mapping threads to
+     * slots that eliminates collisions. When we reach capacity, we
+     * search for this mapping by randomly varying the hash codes of
+     * colliding threads.  Because search is random, and collisions
+     * only become known via CAS failures, convergence can be slow,
+     * and because threads are typically not bound to CPUS forever,
+     * may not occur at all. However, despite these limitations,
+     * observed contention rates are typically low in these cases.
+     *
+     * It is possible for a Cell to become unused when threads that
+     * once hashed to it terminate, as well as in the case where
+     * doubling the table causes no thread to hash to it under
+     * expanded mask.  We do not try to detect or remove such cells,
+     * under the assumption that for long-running instances, observed
+     * contention levels will recur, so the cells will eventually be
+     * needed again; and for short-lived ones, it does not matter.
+     */
+    public class Striped64Counter : Striped64Internal
+    {
+        /// <summary>
+        /// Creates a new Counter with an intial sum of zero.
+        /// </summary>
+        public Striped64Counter() { }
+
+        /// <summary>
+        /// Computes the current count.
+        /// </summary>
+        /// <returns>The current count.</returns>
+        public long Count()
+        {
+            var @as = this.Cells; Cell a;
+            var sum = @base.VolatileRead();
+            if (@as != null)
+            {
+                for (var i = 0; i < @as.Length; ++i)
+                {
+                    if ((a = @as[i]) != null)
+                        sum += a.value.VolatileRead();
+                }
+            }
+            return sum;
+        }
+
+        /// <summary>
+        /// Increment by 1.
+        /// </summary>
+        public void Increment()
+        {
+            Add(1L);
+        }
+
+        /// <summary>
+        /// Adds the specified value.
+        /// </summary>
+        /// <param name="value">The value to add.</param>
+        public void Add(long value)
+        {
+            Cell[]? @as;
+            long b, v;
+            int m;
+            Cell a;
+            if ((@as = this.Cells) != null || !@base.CompareAndSwap(b = @base.VolatileRead(), b + value))
+            {
+                var uncontended = true;
+                if (@as == null || (m = @as.Length - 1) < 0 || (a = @as[GetProbe() & m]) == null || !(uncontended = a.value.CompareAndSwap(v = a.value.VolatileRead(), v + value)))
+                {
+                    LongAccumulate(value, uncontended);
+                }
+            }
+        }
+    }
+
+    public abstract class Striped64Internal
+    {
+        /// <summary>
+        /// The base value used mainly when there is no contention, but also as a fallback 
+        /// during table initialization races. Updated via CAS.
+        /// </summary>
+        protected PaddedLong @base = new();
+
+        /// <summary>
+        /// A wrapper for PaddedLong.
+        /// </summary>
+        protected sealed class Cell
+        {
+            /// <summary>
+            /// The value of the cell.
+            /// </summary>
+            public PaddedLong value;
+
+            /// <summary>
+            /// Initializes a new cell with the specified value.
+            /// </summary>
+            /// <param name="x">The value.</param>
+            public Cell(long x)
+            {
+                this.value = new PaddedLong() { value = x };
+            }
+        }
+
+        /// <summary>
+        /// When non-null, size is a power of 2.
+        /// </summary>
+        protected Cell[]? Cells;
+
+        /**
+         * Returns the probe value for the current thread.
+         * Duplicated from ThreadLocalRandom because of packaging restrictions.
+         */
+        protected static int GetProbe()
+        {
+            // Note: this results in higher throughput than introducing a random.
+            return Environment.CurrentManagedThreadId;
+        }
+
+        // Number of CPUS, to place bound on table size
+        private static readonly int MaxBuckets = Environment.ProcessorCount * 4;
+
+        private int cellsBusy;
+
+        /**
+         * CASes the cellsBusy field from 0 to 1 to acquire lock.
+         */
+        private bool CasCellsBusy()
+        {
+            return Interlocked.CompareExchange(ref this.cellsBusy, 1, 0) == 0;
+        }
+
+        private void VolatileWriteNotBusy()
+        {
+            Volatile.Write(ref this.cellsBusy, 0);
+        }
+
+        /**
+        * Pseudo-randomly advances and records the given probe value for the
+        * given thread.
+        * Duplicated from ThreadLocalRandom because of packaging restrictions.
+        */
+        private static int AdvanceProbe(int probe)
+        {
+            probe ^= probe << 13;   // xorshift
+            probe ^= (int)((uint)probe >> 17);
+            probe ^= probe << 5;
+            return probe;
+        }
+
+        /**
+         * Handles cases of updates involving initialization, resizing,
+         * creating new Cells, and/or contention. See above for
+         * explanation. This method suffers the usual non-modularity
+         * problems of optimistic retry code, relying on rechecked sets of
+         * reads.
+         *
+         * @param x the value
+         * @param wasUncontended false if CAS failed before call
+         */
+        protected void LongAccumulate(long x, bool wasUncontended)
+        {
+            var h = GetProbe();
+
+            var collide = false;                    // True if last slot nonempty
+            for (; ; )
+            {
+                Cell[]? @as; Cell a; int n; long v;
+                if ((@as = this.Cells) != null && (n = @as.Length) > 0)
+                {
+                    if ((a = @as[(n - 1) & h]) == null)
+                    {
+                        if (this.cellsBusy == 0)
+                        {       // Try to attach new Cell
+                            var r = new Cell(x);    // Optimistically create
+                            if (this.cellsBusy == 0 && CasCellsBusy())
+                            {
+                                try
+                                {                   // Recheck under lock
+                                    Cell[]? rs; int m, j;
+                                    if ((rs = this.Cells) != null &&
+                                        (m = rs.Length) > 0 &&
+                                        rs[j = (m - 1) & h] == null)
+                                    {
+                                        rs[j] = r;
+                                        break;
+                                    }
+                                }
+                                finally
+                                {
+                                    VolatileWriteNotBusy();
+                                }
+
+                                continue;           // Slot is now non-empty
+                            }
+                        }
+                        collide = false;
+                    }
+                    else if (!wasUncontended)       // CAS already known to fail
+                        wasUncontended = true;      // Continue after rehash
+                    else if (a.value.CompareAndSwap(v = a.value.VolatileRead(), v + x))
+                        break;
+                    else if (n >= MaxBuckets || this.Cells != @as)
+                        collide = false;            // At max size or stale
+                    else if (!collide)
+                        collide = true;
+                    else if (this.cellsBusy == 0 && CasCellsBusy())
+                    {
+                        try
+                        {
+                            if (this.Cells == @as)
+                            {                       // Expand table unless stale
+                                var rs = new Cell[n << 1];
+                                for (var i = 0; i < n; ++i)
+                                    rs[i] = @as[i];
+                                this.Cells = rs;
+                            }
+                        }
+                        finally
+                        {
+                            VolatileWriteNotBusy();
+                        }
+                        collide = false;
+                        continue;                   // Retry with expanded table
+                    }
+                    h = AdvanceProbe(h);            // Rehash
+                }
+                else if (this.cellsBusy == 0 && this.Cells == @as && CasCellsBusy())
+                {
+                    try
+                    {                               // Initialize table
+                        if (this.Cells == @as)
+                        {
+                            var rs = new Cell[2];
+                            rs[h & 1] = new Cell(x);
+                            this.Cells = rs;
+                            break;
+                        }
+                    }
+                    finally
+                    {
+                        VolatileWriteNotBusy();
+                    }
+                }
+                // Fall back on using base
+                else if (this.@base.CompareAndSwap(v = this.@base.VolatileRead(), v + x))
+                    break;
+            }
+        }
+    }
+}

--- a/BitFaster.Caching/Counters/Counter.cs
+++ b/BitFaster.Caching/Counters/Counter.cs
@@ -1,15 +1,58 @@
-﻿/*
- * Written by Doug Lea with assistance from members of JCP JSR-166
- * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/publicdomain/zero/1.0/
- */
+﻿#if NET9_0_OR_GREATER
+using System;
+using System.Threading;
+#endif
 
 namespace BitFaster.Caching.Counters
 {
     /// <summary>
     /// A thread-safe counter suitable for high throuhgput counting across many concurrent threads.
     /// </summary>
-    /// Based on the LongAdder class by Doug Lea.
+#if NET9_0_OR_GREATER
+
+    public sealed class Counter : Striped64
+    {
+        private PaddedLong[] Deltas = new PaddedLong[Environment.ProcessorCount];
+
+        /// <summary>
+        /// Increment by 1.
+        /// </summary>
+        public void Increment()
+        {
+            Add(1L);
+        }
+
+        /// <summary>
+        /// Adds the specified value.
+        /// </summary>
+        /// <param name="value">The value to add.</param>
+        public void Add(long value)
+        {
+            ref PaddedLong delta = ref Deltas[(uint)Thread.GetCurrentProcessorId() % (uint)Deltas.Length];
+            Interlocked.Add(ref delta.value, value);
+        }
+
+        /// <summary>
+        /// Computes the current count.
+        /// </summary>
+        /// <returns>The current count.</returns>
+        public long Count()
+        {
+            long delta = 0;
+            foreach (ref PaddedLong i in Deltas.AsSpan())
+            { 
+                delta += Interlocked.Exchange(ref i.value, 0);
+            }
+            return delta;
+        }
+    }
+
+#else
+    /*
+     * Written by Doug Lea with assistance from members of JCP JSR-166
+     * Expert Group and released to the public domain, as explained at
+     * http://creativecommons.org/publicdomain/zero/1.0/
+     */
     public sealed class Counter : Striped64
     {
         /// <summary>
@@ -20,7 +63,7 @@ namespace BitFaster.Caching.Counters
         /// <summary>
         /// Computes the current count.
         /// </summary>
-        /// <returns>The current sum.</returns>
+        /// <returns>The current count.</returns>
         public long Count()
         {
             var @as = this.Cells; Cell a;
@@ -64,4 +107,5 @@ namespace BitFaster.Caching.Counters
             }
         }
     }
+#endif
 }

--- a/BitFaster.Caching/Counters/Counter.cs
+++ b/BitFaster.Caching/Counters/Counter.cs
@@ -12,7 +12,7 @@ namespace BitFaster.Caching.Counters
 
     public sealed class Counter : Striped64
     {
-        private PaddedLong[] Deltas = new PaddedLong[Environment.ProcessorCount];
+        private readonly PaddedLong[] Deltas = new PaddedLong[Environment.ProcessorCount];
 
         /// <summary>
         /// Increment by 1.

--- a/BitFaster.Caching/Counters/Counter.cs
+++ b/BitFaster.Caching/Counters/Counter.cs
@@ -41,7 +41,7 @@ namespace BitFaster.Caching.Counters
             long delta = 0;
             foreach (ref PaddedLong i in Deltas.AsSpan())
             { 
-                delta += Interlocked.Exchange(ref i.value, 0);
+                delta += Interlocked.Read(ref i.value);
             }
             return delta;
         }

--- a/BitFaster.Caching/Counters/Counter.cs
+++ b/BitFaster.Caching/Counters/Counter.cs
@@ -41,7 +41,7 @@ namespace BitFaster.Caching.Counters
             long delta = 0;
             foreach (ref PaddedLong i in Deltas.AsSpan())
             { 
-                delta += Interlocked.Read(ref i.value);
+                delta += i.VolatileRead();
             }
             return delta;
         }

--- a/BitFaster.Caching/Counters/Counter.cs
+++ b/BitFaster.Caching/Counters/Counter.cs
@@ -12,7 +12,17 @@ namespace BitFaster.Caching.Counters
 
     public sealed class Counter : Striped64
     {
-        private readonly PaddedLong[] Deltas = new PaddedLong[Environment.ProcessorCount];
+        private readonly PaddedLong[] Deltas;
+        private readonly uint mask;
+
+        /// <summary>
+        /// Creates a new Counter with an intial sum of zero.
+        /// </summary>
+        public Counter()
+        {
+            this.Deltas = new PaddedLong[BitOps.CeilingPowerOfTwo(Environment.ProcessorCount)];
+            this.mask = (uint)Deltas.Length - 1;
+        }
 
         /// <summary>
         /// Increment by 1.
@@ -28,7 +38,7 @@ namespace BitFaster.Caching.Counters
         /// <param name="value">The value to add.</param>
         public void Add(long value)
         {
-            ref PaddedLong delta = ref Deltas[(uint)Thread.GetCurrentProcessorId() % (uint)Deltas.Length];
+            ref PaddedLong delta = ref Deltas[(uint)Thread.GetCurrentProcessorId() & mask];
             Interlocked.Add(ref delta.value, value);
         }
 

--- a/BitFaster.Caching/Counters/Striped64.cs
+++ b/BitFaster.Caching/Counters/Striped64.cs
@@ -80,20 +80,11 @@ namespace BitFaster.Caching.Counters
     [ExcludeFromCodeCoverage]
     public abstract class Striped64
     {
-        // Number of CPUS, to place bound on table size
-        private static readonly int MaxBuckets = Environment.ProcessorCount * 4;
-
         /// <summary>
         /// The base value used mainly when there is no contention, but also as a fallback 
         /// during table initialization races. Updated via CAS.
         /// </summary>
         protected PaddedLong @base = new();
-
-        /// <summary>
-        /// When non-null, size is a power of 2.
-        /// </summary>
-        protected Cell[]? Cells;
-        private int cellsBusy;
 
         /// <summary>
         /// A wrapper for PaddedLong.
@@ -115,6 +106,36 @@ namespace BitFaster.Caching.Counters
             }
         }
 
+        /// <summary>
+        /// When non-null, size is a power of 2.
+        /// </summary>
+        protected Cell[]? Cells;
+
+        /**
+         * Returns the probe value for the current thread.
+         * Duplicated from ThreadLocalRandom because of packaging restrictions.
+         */
+        protected static int GetProbe()
+        {
+            // Note: this results in higher throughput than introducing a random.
+            return Environment.CurrentManagedThreadId;
+        }
+
+#if NET9_0_OR_GREATER
+#pragma warning disable CA1822 // Mark members as static
+        /// <summary>
+        /// Not used on .NET 9.0
+        /// </summary>
+        protected void LongAccumulate(long x, bool wasUncontended)
+        {
+        }
+#pragma warning restore CA1822 // Mark members as static
+#else
+        // Number of CPUS, to place bound on table size
+        private static readonly int MaxBuckets = Environment.ProcessorCount * 4;
+
+        private int cellsBusy;
+
         /**
          * CASes the cellsBusy field from 0 to 1 to acquire lock.
          */
@@ -126,16 +147,6 @@ namespace BitFaster.Caching.Counters
         private void VolatileWriteNotBusy()
         {
             Volatile.Write(ref this.cellsBusy, 0);
-        }
-
-        /**
-         * Returns the probe value for the current thread.
-         * Duplicated from ThreadLocalRandom because of packaging restrictions.
-         */
-        protected static int GetProbe()
-        {
-            // Note: this results in higher throughput than introducing a random.
-            return Environment.CurrentManagedThreadId;
         }
 
         /**
@@ -250,5 +261,6 @@ namespace BitFaster.Caching.Counters
                     break;
             }
         }
+#endif
     }
 }


### PR DESCRIPTION
Address feedback from .NET team.

Benchmark taken from [https://github.com/dotnet/runtime/pull/91566](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fdotnet%2Fruntime%2Fpull%2F91566&data=05%7C02%7Calexpeck%40microsoft.com%7Cac2ea0735c14435d8fe708df031a028c%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639233082380131411%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=5xbpQX2K%2F6vnmPoGvvnEQydPV2oRVDSJxJOqNqG3GxQ%3D&reserved=0)

New counter vs striped is marginally slower in these tests, although likely noise:

<img width="1000" height="600" alt="BitFaster Caching Benchmarks CounterBenchmark-net9 0-columnchart" src="https://github.com/user-attachments/assets/2d49e94c-c851-4299-897b-c224c0a55799" />

```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2)
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v4
  net9.0 : .NET 9.0.19 (9.0.19, 9.0.1926.36724), X64 RyuJIT x86-64-v4

Job=net9.0  Runtime=.NET 9.0

| Method                   | Mean      | Error     | StdDev    |
|------------------------- |----------:|----------:|----------:|
| CounterSerial            | 20.179 ms | 0.2076 ms | 0.1942 ms |
| CounterParallel          |  2.189 ms | 0.0335 ms | 0.0297 ms |
| Striped64CounterSerial   | 19.944 ms | 0.0514 ms | 0.0481 ms |
| Striped64CounterParallel |  2.195 ms | 0.0278 ms | 0.0247 ms |
| MetricsCounterSerial     | 65.934 ms | 0.8149 ms | 0.6805 ms |
| MetricsCounterParallel   | 52.809 ms | 0.4452 ms | 0.4164 ms |
| UpDownCounterSerial      | 67.020 ms | 1.0584 ms | 0.9383 ms |
| UpDownCounterParallel    | 42.196 ms | 0.8298 ms | 1.0191 ms |
```