### PR TITLE
Use Thread.GetCurrentProcessorId as Counter bucket index

### DIFF
--- a/BitFaster.Caching/Counters/Striped64.cs
+++ b/BitFaster.Caching/Counters/Striped64.cs
@@ -81,8 +81,11 @@ namespace BitFaster.Caching.Counters
     public abstract class Striped64
     {
         // Number of CPUS, to place bound on table size
+#if NETCOREAPP2_1_OR_GREATER
+        private static readonly int MaxBuckets = Environment.ProcessorCount;
+#else
         private static readonly int MaxBuckets = Environment.ProcessorCount * 4;
-
+#endif
         /// <summary>
         /// The base value used mainly when there is no contention, but also as a fallback 
         /// during table initialization races. Updated via CAS.
@@ -135,7 +138,11 @@ namespace BitFaster.Caching.Counters
         protected static int GetProbe()
         {
             // Note: this results in higher throughput than introducing a random.
+#if NETCOREAPP2_1_OR_GREATER
+            return Thread.GetCurrentProcessorId();
+#else
             return Environment.CurrentManagedThreadId;
+#endif
         }
 
         /**

--- a/BitFaster.Caching/Counters/Striped64.cs
+++ b/BitFaster.Caching/Counters/Striped64.cs
@@ -82,7 +82,7 @@ namespace BitFaster.Caching.Counters
     {
         // Number of CPUS, to place bound on table size
 #if NETCOREAPP2_1_OR_GREATER
-        private static readonly int MaxBuckets = Environment.ProcessorCount;
+        private static readonly int MaxBuckets = BitOps.CeilingPowerOfTwo(Environment.ProcessorCount);
 #else
         private static readonly int MaxBuckets = Environment.ProcessorCount * 4;
 #endif


### PR DESCRIPTION

```
BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.9106/25H2/2025Update/HudsonValley2)
Intel Xeon W-2133 CPU 3.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK 10.0.400
  [Host] : .NET 10.0.11 (10.0.11, 10.0.1126.37416), X64 RyuJIT x86-64-v4
  net9.0 : .NET 9.0.19 (9.0.19, 9.0.1926.36724), X64 RyuJIT x86-64-v4

Job=net9.0  Runtime=.NET 9.0
```

| Method                   | Mean      | Error     | StdDev    |
|------------------------- |----------:|----------:|----------:|
| ThreadIdSerial            | 19.973 ms | 0.0555 ms | 0.0492 ms |
| ThreadIdParallel          |  2.190 ms | 0.0231 ms | 0.0205 ms |
| ProcIdSerial   | 19.986 ms | 0.0655 ms | 0.0612 ms |
| ProcIdParallel |  4.786 ms | 0.0789 ms | 0.0699 ms |

Via benchmark from PR #819